### PR TITLE
Summary table, ruler undo, JSON import, icon toolbar

### DIFF
--- a/PDF-Parser/docs/PDF-Parser.md
+++ b/PDF-Parser/docs/PDF-Parser.md
@@ -647,18 +647,47 @@ A2.1,NET TOTAL,,,,,42.53,,457.87,
 - [x] `loadPolygons` in polygon-tool, `restoreCalibration` in scale-manager
 - [x] Status message: "Imported: X areas, Y windows, Z rulers from project.json"
 
-### Step 10 — Schedule Extraction & Cross-Validation
+### Step 10 — Volumetric Calculation (Priority — BEAM Integration)
+
+**Purpose:** Compute concrete and material volumes from plan-view cross-sectional areas for embodied carbon analysis in BEAM. This is the critical path feature — BEAM needs volume data to calculate EC for foundations, walls, and slabs.
+
+**Approach:** The auto-detect system (Step 6) already identifies filled quads (wall faces, foundation outlines) from CAD-exported PDFs. The volume workflow extends this by allowing the user to select or group detected face quads as a cross-sectional area, then multiply by a height to produce a volume.
+
+#### 10.1 Cross-Section Area from Detected Quads
+- [ ] **Select detected quads** — user clicks or lasso-selects multiple auto-detected filled quads on a plan sheet
+- [ ] **Group as cross-section** — selected quads combine into a single cross-sectional area (union of faces)
+- [ ] **Label as material type** — user assigns a label (e.g., "Foundation Wall", "Slab on Grade", "Bearing Wall")
+- [ ] **Display combined area** in measurement panel with distinct styling (e.g., concrete grey)
+
+#### 10.2 Height Input & Volume Calculation
+- [ ] **Manual height entry** — user enters height/depth per cross-section (e.g., "1200 mm" for a foundation wall, "150 mm" for a slab)
+- [ ] **Section sheet reference** — optionally pull height from a section sheet annotation (floor-to-floor, footing depth, wall height)
+- [ ] **Volume = cross-section area × height** — computed and displayed in m³ and ft³
+- [ ] **Volume summary** — per-element and total, grouped by material type
+
+#### 10.3 Export for BEAM
+- [ ] Volume data included in CSV and JSON export
+- [ ] Format compatible with BEAM's material input (element type, volume m³, material)
+- [ ] Summary: total concrete volume, total wood framing volume, etc.
+
+#### 10.4 Implementation Notes
+- Reuse `buildAssociationMap` pattern for grouping quads with parent cross-sections
+- Reuse existing auto-detect candidates (`closedPaths` from vector-snap.mjs) as selectable elements
+- Height could be stored as a new field on polygon objects: `height` (mm), `volumeM3` (computed)
+- Consider a "Volume" tool mode (V key? — conflicts with Navigate, use Shift+V or new key)
+
+### Step 11 — Schedule Extraction & Cross-Validation
 - [ ] Text clustering into table rows/columns
 - [ ] Room schedule parser
 - [ ] Cross-validation: "Schedule says Office = 27.80 m²; your polygon = 28.1 m² (1.1% variance)"
 
-### Step 11 — Section Analysis & Volume (Phase 2)
+### Step 12 — Section Analysis & Automated Heights
 - [ ] Level detection on section sheets
 - [ ] Floor-to-floor height extraction
-- [ ] Volume = area × height per storey
+- [ ] Auto-populate heights for volumetric calculations from section annotations
 - [ ] Cross-validation against energy model data (A0.10)
 
-### Step 12 — Polish & Testing
+### Step 13 — Polish & Testing
 - [ ] Print-friendly summary view
 - [ ] Error handling and edge cases
 - [ ] Testing against multiple CD sets (different firms, scales, formats)

--- a/PDF-Parser/docs/PDF-Parser.md
+++ b/PDF-Parser/docs/PDF-Parser.md
@@ -515,6 +515,9 @@ var project = {
 - [x] Shared drawing code between ruler and calibrate (`_drawRulerLine`)
 - [x] Escape cancels in-progress ruler, Delete removes last ruler
 - [x] Multiple rulers per page, snap-to-vertex works during placement
+- [x] **Ruler undo/redo** — unified undo stack tracks interleaved polygon + ruler operations (added Step 9)
+- [x] **Clear Rulers** — Shift+Delete clears all rulers on current page, undoable (added Step 9)
+- [x] **Ruler persistence** — rulers saved to JSON export and restored on import (added Step 9)
 
 ### Step 7.5 — Design System Refactor & UX Polish ✅ (2026-03-28)
 
@@ -614,20 +617,49 @@ A2.1,NET TOTAL,,,,,42.53,,457.87,
 | `pdfparser.css` | Window-mode dropdown, `.wall-toggle`, `.detail-row`, `.net-label` styles |
 | `js/project-store.mjs` | Persist type/mode, hierarchical CSV with Gross/Net columns |
 
-### Step 9 — Schedule Extraction & Cross-Validation
+### Step 9 — Summary Table & Project Management ✅ (2026-03-28)
+
+#### 9.1 Summary Table Modal
+- [x] **Summary** button in toolbar opens full-viewport modal overlay
+- [x] Shows all pages with measurements, grouped by sheet name/ID
+- [x] Columns: Sheet, Label, Gross m², Net m², Gross ft², Net ft², Perimeter m
+- [x] Hierarchical wall→window structure with expandable chevrons
+- [x] Per-page subtotals + grand total row
+- [x] Inline **delete** and **rename** from summary (syncs mini-table + canvas)
+- [x] Download CSV button in footer
+- [x] Close via × button, Close button, or Escape key
+
+#### 9.2 Ruler Undo/Redo & Clear Rulers
+- [x] **Unified undo stack** — Cmd+Z / Cmd+Shift+Z dispatches to correct stack (polygon or ruler) based on action order
+- [x] Polygon tool fires `onUndoPush` callback for unified tracking
+- [x] **Shift+Delete** clears all rulers on current page (undoable)
+- [x] Fix: rulers now reset when loading a new PDF (previously persisted across loads)
+
+#### 9.3 Ruler Persistence
+- [x] Rulers saved to project JSON alongside polygons and calibrations
+- [x] `saveRulers`/`getRulers` in project-store
+- [x] Auto-saved after create, delete, undo, redo, and clear
+
+#### 9.4 JSON Import
+- [x] **Import** button in toolbar opens file picker for `.json` project files
+- [x] Validates project structure, warns on page count mismatch with loaded PDF
+- [x] Restores per page: polygons (with type/mode), calibrations, and rulers
+- [x] `loadPolygons` in polygon-tool, `restoreCalibration` in scale-manager
+- [x] Status message: "Imported: X areas, Y windows, Z rulers from project.json"
+
+### Step 10 — Schedule Extraction & Cross-Validation
 - [ ] Text clustering into table rows/columns
 - [ ] Room schedule parser
 - [ ] Cross-validation: "Schedule says Office = 27.80 m²; your polygon = 28.1 m² (1.1% variance)"
 
-### Step 10 — Section Analysis & Volume (Phase 2)
+### Step 11 — Section Analysis & Volume (Phase 2)
 - [ ] Level detection on section sheets
 - [ ] Floor-to-floor height extraction
 - [ ] Volume = area × height per storey
 - [ ] Cross-validation against energy model data (A0.10)
 
-### Step 11 — Polish & Export
+### Step 12 — Polish & Testing
 - [ ] Print-friendly summary view
-- [ ] Improved project save/load (restore polygons + calibrations from JSON)
 - [ ] Error handling and edge cases
 - [ ] Testing against multiple CD sets (different firms, scales, formats)
 
@@ -650,8 +682,9 @@ A2.1,NET TOTAL,,,,,42.53,,457.87,
 | 11 | **Known** | Auto-detect finds wall fills, not building outlines | Most CAD PDFs draw walls as individual quads. Edge-tracing needed for outline assembly. |
 | 12 | **FIXED** | `var s` redeclared in vector-snap.mjs | Renamed to `si` — caught by ESLint `no-redeclare`. |
 | 13 | **FIXED** | Detail rows not visible when expanding wall chevron | CSS `.detail-row { display: none }` overrode empty inline style. Fixed: set `display: table-row` explicitly. |
-| 14 | **Cosmetic** | `favicon.ico` 404 on every page load | Harmless; browser auto-requests. |
-| 15 | **Cosmetic** | `TT: undefined function: 32` warning from PDF.js | CAD font hinting opcode; no impact on rendering. |
+| 14 | **FIXED** | Rulers not reset when loading a new PDF | Added `_rulers = {}` reset in `loadPdf()`. |
+| 15 | **Cosmetic** | `favicon.ico` 404 on every page load | Harmless; browser auto-requests. |
+| 16 | **Cosmetic** | `TT: undefined function: 32` warning from PDF.js | CAD font hinting opcode; no impact on rendering. |
 
 ---
 

--- a/PDF-Parser/eslint.config.mjs
+++ b/PDF-Parser/eslint.config.mjs
@@ -42,6 +42,7 @@ export default [
         Event: "readonly",
         prompt: "readonly",
         alert: "readonly",
+        confirm: "readonly",
         // App globals
         PP: "writable"
       }

--- a/PDF-Parser/index.html
+++ b/PDF-Parser/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PDF-Parser — Construction Document Area Extraction</title>
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="bfcastyles.css" />
     <link rel="stylesheet" href="pdfparser.css" />
   </head>
@@ -14,49 +15,76 @@
       <!-- ── Toolbar ──────────────────────────────────── -->
       <div id="toolbar">
         <img src="graphics/BFCA-LOGO-sm.png" alt="BfCA" class="header-logo" />
-        <button class="tool-btn active" data-tool="navigate" title="Navigate / Pan (V)">
-          Navigate <span class="key-hint">V</span>
+
+        <!-- Tools -->
+        <button class="tool-btn active" data-tool="navigate" data-tip="Navigate / Pan [V]">
+          <i class="bi bi-hand-index"></i>
         </button>
-        <button class="tool-btn" data-tool="measure" title="Measure Area (M)">
-          Measure <span class="key-hint">M</span>
+        <button class="tool-btn" data-tool="measure" data-tip="Measure Area [M] — draw rectangle or polygon">
+          <i class="bi bi-bounding-box"></i>
         </button>
         <select id="measure-method" title="Measurement method" onchange="PP.setMeasureMethod(this.value)">
           <option value="rectangle">Rectangle</option>
           <option value="polygon">Polygon</option>
         </select>
-        <button class="tool-btn" data-tool="window" title="Measure Window (W)">
-          Window <span class="key-hint">W</span>
+        <button class="tool-btn" data-tool="window" data-tip="Measure Window [W] — subtract from wall area">
+          <i class="bi bi-window"></i>
         </button>
         <select id="window-mode" title="Window mode" onchange="PP.setWindowMode(this.value)">
           <option value="net">Net (subtract)</option>
           <option value="add">Add</option>
         </select>
-        <button class="tool-btn" data-tool="ruler" title="Ruler (L)">Ruler <span class="key-hint">L</span></button>
-        <button class="tool-btn" data-tool="checkscale" title="Check Scale (S)">
-          Scale <span class="key-hint">S</span>
+        <button class="tool-btn" data-tool="ruler" data-tip="Ruler [L] — measure a linear distance">
+          <i class="bi bi-rulers"></i>
         </button>
-        <button class="tool-btn" data-tool="calibrate" title="Manual Calibrate (C)">
-          Calibrate <span class="key-hint">C</span>
+        <button class="tool-btn" data-tool="checkscale" data-tip="Check Scale [S] — set or verify page scale">
+          <i class="bi bi-aspect-ratio"></i>
         </button>
-        <button class="export-btn" onclick="PP.autoDetect()" title="Auto-detect building outline (D)">
-          Detect <span class="key-hint">D</span>
+        <button class="tool-btn" data-tool="calibrate" data-tip="Calibrate [C] — two-point scale verification">
+          <i class="bi bi-crosshair2"></i>
         </button>
+        <button class="tool-btn" onclick="PP.autoDetect()" data-tip="Auto-Detect [D] — detect building outline">
+          <i class="bi bi-magic"></i>
+        </button>
+
         <div class="toolbar-sep"></div>
-        <button class="tool-btn" onclick="PP.zoomIn()" title="Zoom In (+)">+</button>
-        <button class="tool-btn" onclick="PP.zoomOut()" title="Zoom Out (-)">&#8722;</button>
-        <button class="tool-btn" onclick="PP.zoomFit()" title="Zoom Fit">Fit</button>
+
+        <!-- Zoom -->
+        <button class="tool-btn" onclick="PP.zoomIn()" data-tip="Zoom In [+]"><i class="bi bi-zoom-in"></i></button>
+        <button class="tool-btn" onclick="PP.zoomOut()" data-tip="Zoom Out [-]"><i class="bi bi-zoom-out"></i></button>
+        <button class="tool-btn" onclick="PP.zoomFit()" data-tip="Fit to View [F]">
+          <i class="bi bi-fullscreen"></i>
+        </button>
+
         <div class="toolbar-sep"></div>
-        <button class="tool-btn" onclick="PP.prevPage()" title="Previous Page">&larr;</button>
-        <button class="tool-btn" onclick="PP.nextPage()" title="Next Page">&rarr;</button>
+
+        <!-- Page nav -->
+        <button class="tool-btn" onclick="PP.prevPage()" data-tip="Previous Page [&larr;]">
+          <i class="bi bi-chevron-left"></i>
+        </button>
+        <button class="tool-btn" onclick="PP.nextPage()" data-tip="Next Page [&rarr;]">
+          <i class="bi bi-chevron-right"></i>
+        </button>
         <span class="toolbar-label" id="page-label"></span>
 
         <div class="toolbar-spacer"></div>
 
-        <button class="export-btn" onclick="PP.openSummaryTable()" title="View summary table">Summary</button>
-        <button class="export-btn" onclick="PP.exportCSV()" title="Export measurements as CSV">CSV</button>
-        <button class="export-btn" onclick="PP.exportJSON()" title="Save project as JSON">JSON</button>
-        <button class="export-btn" onclick="document.getElementById('json-input').click()" title="Import saved project">
-          Import
+        <!-- Export / Import -->
+        <button class="export-btn" onclick="PP.openSummaryTable()" data-tip="View measurement summary table">
+          <i class="bi bi-table"></i>
+        </button>
+        <button class="export-btn" onclick="PP.exportCSV()" data-tip="Export measurements as CSV">
+          <i class="bi bi-filetype-csv"></i>
+        </button>
+        <button class="export-btn" onclick="PP.exportJSON()" data-tip="Save project as JSON">
+          <i class="bi bi-filetype-json"></i>
+        </button>
+        <button
+          class="export-btn"
+          onclick="document.getElementById('json-input').click()"
+          data-tip="Import saved project JSON"
+        >
+          <i class="bi bi-upload"></i>
         </button>
         <input type="file" id="json-input" accept=".json" style="display: none" />
         <div class="toolbar-sep"></div>

--- a/PDF-Parser/index.html
+++ b/PDF-Parser/index.html
@@ -52,6 +52,7 @@
 
         <div class="toolbar-spacer"></div>
 
+        <button class="export-btn" onclick="PP.openSummaryTable()" title="View summary table">Summary</button>
         <button class="export-btn" onclick="PP.exportCSV()" title="Export measurements as CSV">CSV</button>
         <button class="export-btn" onclick="PP.exportJSON()" title="Save project as JSON">JSON</button>
         <div class="toolbar-sep"></div>
@@ -149,6 +150,20 @@
             <input type="checkbox" id="scale-feedback-remember" /> Don't show this again
           </label>
           <button id="scale-feedback-ok" onclick="PP.closeScaleFeedback()">OK</button>
+        </div>
+      </div>
+
+      <!-- ── Summary Table Modal ──────────────────────── -->
+      <div id="summary-backdrop"></div>
+      <div id="summary-panel">
+        <div class="summary-header">
+          <span class="summary-title">Measurement Summary</span>
+          <button class="summary-close" onclick="PP.closeSummaryTable()">&times;</button>
+        </div>
+        <div id="summary-content"></div>
+        <div class="summary-footer">
+          <button class="export-btn" onclick="PP.exportCSV()">Download CSV</button>
+          <button class="export-btn" onclick="PP.closeSummaryTable()">Close</button>
         </div>
       </div>
 

--- a/PDF-Parser/index.html
+++ b/PDF-Parser/index.html
@@ -21,14 +21,14 @@
           <i class="bi bi-hand-index"></i>
         </button>
         <button class="tool-btn" data-tool="measure" data-tip="Measure Area [M] — draw rectangle or polygon">
-          <i class="bi bi-bounding-box"></i>
+          <i class="bi bi-building-add"></i>
         </button>
         <select id="measure-method" title="Measurement method" onchange="PP.setMeasureMethod(this.value)">
           <option value="rectangle">Rectangle</option>
           <option value="polygon">Polygon</option>
         </select>
         <button class="tool-btn" data-tool="window" data-tip="Measure Window [W] — subtract from wall area">
-          <i class="bi bi-house-door"></i>
+          <i class="bi bi-border-all"></i>
         </button>
         <select id="window-mode" title="Window mode" onchange="PP.setWindowMode(this.value)">
           <option value="net">Net (subtract)</option>

--- a/PDF-Parser/index.html
+++ b/PDF-Parser/index.html
@@ -55,6 +55,10 @@
         <button class="export-btn" onclick="PP.openSummaryTable()" title="View summary table">Summary</button>
         <button class="export-btn" onclick="PP.exportCSV()" title="Export measurements as CSV">CSV</button>
         <button class="export-btn" onclick="PP.exportJSON()" title="Save project as JSON">JSON</button>
+        <button class="export-btn" onclick="document.getElementById('json-input').click()" title="Import saved project">
+          Import
+        </button>
+        <input type="file" id="json-input" accept=".json" style="display: none" />
         <div class="toolbar-sep"></div>
         <a href="matrix.html" class="nav-btn" title="EC Compliance Matrix">Matrix</a>
       </div>

--- a/PDF-Parser/index.html
+++ b/PDF-Parser/index.html
@@ -28,7 +28,7 @@
           <option value="polygon">Polygon</option>
         </select>
         <button class="tool-btn" data-tool="window" data-tip="Measure Window [W] — subtract from wall area">
-          <i class="bi bi-window"></i>
+          <i class="bi bi-house-door"></i>
         </button>
         <select id="window-mode" title="Window mode" onchange="PP.setWindowMode(this.value)">
           <option value="net">Net (subtract)</option>

--- a/PDF-Parser/js/app.mjs
+++ b/PDF-Parser/js/app.mjs
@@ -36,9 +36,40 @@ var _snapTarget = null; // current snap indicator {x, y, type}
 var _rulerStart = null; // first point for ruler/calibrate rubber-band
 var _rulerCurrent = null; // live cursor position for ruler preview
 
-// Persistent ruler lines per page: _rulers[pageNum] = [{p1, p2, label, lengthM}, ...]
+// Persistent ruler lines per page: _rulers[pageNum] = [{p1, p2, pdfLength, lengthM}, ...]
 var _rulers = {};
 var _nextRulerId = 1;
+
+// Ruler undo/redo
+var _rulerUndoStack = [];
+var _rulerRedoStack = [];
+
+function _pushRulerUndo(pageNum) {
+  var rulers = _rulers[pageNum] || [];
+  _rulerUndoStack.push({ pageNum: pageNum, snapshot: JSON.parse(JSON.stringify(rulers)) });
+  _rulerRedoStack = [];
+  if (_rulerUndoStack.length > 50) _rulerUndoStack.shift();
+}
+
+function _undoRuler() {
+  if (_rulerUndoStack.length === 0) return false;
+  var entry = _rulerUndoStack.pop();
+  _rulerRedoStack.push({ pageNum: entry.pageNum, snapshot: JSON.parse(JSON.stringify(_rulers[entry.pageNum] || [])) });
+  _rulers[entry.pageNum] = entry.snapshot;
+  return entry.pageNum;
+}
+
+function _redoRuler() {
+  if (_rulerRedoStack.length === 0) return false;
+  var entry = _rulerRedoStack.pop();
+  _rulerUndoStack.push({ pageNum: entry.pageNum, snapshot: JSON.parse(JSON.stringify(_rulers[entry.pageNum] || [])) });
+  _rulers[entry.pageNum] = entry.snapshot;
+  return entry.pageNum;
+}
+
+// Unified undo history — tracks order of polygon vs ruler actions
+var _undoOrder = []; // "polygon" | "ruler"
+var _redoOrder = [];
 
 /* ── Boot ─────────────────────────────────────────────── */
 
@@ -68,7 +99,14 @@ function init() {
   Viewer.onOverlayClick(_handleOverlayClick);
   Viewer.onOverlayMouseMove(_handleOverlayMouseMove);
 
+  // Track polygon undo pushes in the unified undo order
+  PolygonTool.onUndoPush(function () {
+    _undoOrder.push("polygon");
+    _redoOrder = [];
+  });
+
   _bindFileInput();
+  _bindJsonImport();
   _bindToolbar();
   _bindKeyboard();
 
@@ -132,6 +170,12 @@ function loadPdf(buffer, fileName) {
   ScaleManager.reset();
   VectorSnap.reset();
   ProjectStore.reset();
+  _rulers = {};
+  _rulerUndoStack = [];
+  _rulerRedoStack = [];
+  _undoOrder = [];
+  _redoOrder = [];
+  _nextRulerId = 1;
 
   var loadingOverlay = document.getElementById("loading-overlay");
   var loadingBar = document.getElementById("loading-bar-fill");
@@ -708,6 +752,9 @@ function _handleRulerClick(pt) {
     var lengthM = ScaleManager.pdfToMetres(_currentPage, pdfLen);
 
     if (!_rulers[_currentPage]) _rulers[_currentPage] = [];
+    _pushRulerUndo(_currentPage);
+    _undoOrder.push("ruler");
+    _redoOrder = [];
     _rulers[_currentPage].push({
       id: "ruler_" + _nextRulerId++,
       p1: p1,
@@ -718,6 +765,8 @@ function _handleRulerClick(pt) {
 
     _rulerStart = null;
     _rulerCurrent = null;
+
+    ProjectStore.saveRulers(_currentPage, _rulers[_currentPage]);
 
     var lenStr =
       lengthM !== null
@@ -1076,25 +1125,43 @@ function setTool(tool) {
 function _bindKeyboard() {
   document.addEventListener("keydown", function (e) {
     if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
-    // Undo: Cmd+Z / Ctrl+Z
+    // Undo: Cmd+Z / Ctrl+Z — unified polygon + ruler undo
     if ((e.metaKey || e.ctrlKey) && e.key === "z" && !e.shiftKey) {
       e.preventDefault();
-      var pg = PolygonTool.undo();
-      if (pg !== false) {
-        _refreshMeasurements();
-        Viewer.requestRedraw();
-        setStatus("Undo", "ready");
+      if (_undoOrder.length > 0) {
+        var lastType = _undoOrder.pop();
+        _redoOrder.push(lastType);
+        if (lastType === "ruler") {
+          var rulerPg = _undoRuler();
+          if (rulerPg !== false) ProjectStore.saveRulers(rulerPg, _rulers[rulerPg] || []);
+          Viewer.requestRedraw();
+          setStatus("Undo ruler", "ready");
+        } else {
+          PolygonTool.undo();
+          _refreshMeasurements();
+          Viewer.requestRedraw();
+          setStatus("Undo", "ready");
+        }
       }
       return;
     }
-    // Redo: Cmd+Shift+Z / Ctrl+Shift+Z
+    // Redo: Cmd+Shift+Z / Ctrl+Shift+Z — unified
     if ((e.metaKey || e.ctrlKey) && e.key === "z" && e.shiftKey) {
       e.preventDefault();
-      var pg2 = PolygonTool.redo();
-      if (pg2 !== false) {
-        _refreshMeasurements();
-        Viewer.requestRedraw();
-        setStatus("Redo", "ready");
+      if (_redoOrder.length > 0) {
+        var lastType2 = _redoOrder.pop();
+        _undoOrder.push(lastType2);
+        if (lastType2 === "ruler") {
+          var redoPg = _redoRuler();
+          if (redoPg !== false) ProjectStore.saveRulers(redoPg, _rulers[redoPg] || []);
+          Viewer.requestRedraw();
+          setStatus("Redo ruler", "ready");
+        } else {
+          PolygonTool.redo();
+          _refreshMeasurements();
+          Viewer.requestRedraw();
+          setStatus("Redo", "ready");
+        }
       }
       return;
     }
@@ -1158,9 +1225,25 @@ function _bindKeyboard() {
         break;
       case "Delete":
       case "Backspace":
+        // Shift+Delete: clear all rulers on current page
+        if (e.shiftKey && _rulers[_currentPage] && _rulers[_currentPage].length > 0) {
+          _pushRulerUndo(_currentPage);
+          _undoOrder.push("ruler");
+          _redoOrder = [];
+          var count = _rulers[_currentPage].length;
+          _rulers[_currentPage] = [];
+          ProjectStore.saveRulers(_currentPage, []);
+          Viewer.requestRedraw();
+          setStatus(count + " ruler" + (count > 1 ? "s" : "") + " cleared", "ready");
+          break;
+        }
         // Delete last ruler if in ruler mode, otherwise last polygon
         if (_currentTool === "ruler" && _rulers[_currentPage] && _rulers[_currentPage].length > 0) {
+          _pushRulerUndo(_currentPage);
+          _undoOrder.push("ruler");
+          _redoOrder = [];
           _rulers[_currentPage].pop();
+          ProjectStore.saveRulers(_currentPage, _rulers[_currentPage]);
           Viewer.requestRedraw();
           setStatus("Ruler deleted", "ready");
           break;
@@ -1997,6 +2080,112 @@ function exportCSV() {
 
 function exportJSON() {
   ProjectStore.download(ProjectStore.toJSON(), "pdf-parser-project.json", "application/json");
+}
+
+/* ── JSON Import ──────────────────────────────────────── */
+
+function _bindJsonImport() {
+  var jsonInput = document.getElementById("json-input");
+  if (jsonInput) {
+    jsonInput.addEventListener("change", function (e) {
+      if (e.target.files.length > 0) _importJsonFile(e.target.files[0]);
+      e.target.value = ""; // reset so same file can be re-imported
+    });
+  }
+}
+
+function _importJsonFile(file) {
+  var reader = new FileReader();
+  reader.onload = function (e) {
+    try {
+      var data = JSON.parse(e.target.result);
+    } catch (err) {
+      setStatus("Import failed: invalid JSON file", "error");
+      return;
+    }
+
+    if (!data.pages || !data.pageCount) {
+      setStatus("Import failed: not a PDF-Parser project file", "error");
+      return;
+    }
+
+    if (!Loader.isLoaded()) {
+      setStatus("Load the PDF first, then import measurements", "error");
+      return;
+    }
+
+    var pdfPageCount = Loader.getPageCount();
+    if (data.pageCount !== pdfPageCount) {
+      var proceed = confirm(
+        "Project has " +
+          data.pageCount +
+          " pages but the loaded PDF has " +
+          pdfPageCount +
+          " pages.\n\nImport anyway? (measurements will be applied to matching page numbers)"
+      );
+      if (!proceed) return;
+    }
+
+    // Restore project data into ProjectStore
+    ProjectStore.fromJSON(JSON.stringify(data));
+
+    // Restore per-page data into live modules
+    var areaCount = 0,
+      winCount = 0,
+      rulerCount = 0;
+    var maxPage = Math.min(data.pageCount, pdfPageCount);
+
+    for (var i = 0; i < maxPage; i++) {
+      var page = data.pages[i];
+      var pageNum = page.pageNum || i + 1;
+
+      // Restore polygons
+      if (page.polygons && page.polygons.length > 0) {
+        PolygonTool.loadPolygons(pageNum, page.polygons);
+        for (var pi = 0; pi < page.polygons.length; pi++) {
+          if (page.polygons[pi].type === "window") winCount++;
+          else areaCount++;
+        }
+      }
+
+      // Restore calibration
+      if (page.calibration) {
+        ScaleManager.restoreCalibration(pageNum, page.calibration);
+      }
+
+      // Restore rulers
+      if (page.rulers && page.rulers.length > 0) {
+        _rulers[pageNum] = page.rulers.slice();
+        rulerCount += page.rulers.length;
+      }
+    }
+
+    // Reset undo stacks (import is a fresh starting point)
+    _rulerUndoStack = [];
+    _rulerRedoStack = [];
+    _undoOrder = [];
+    _redoOrder = [];
+
+    // Refresh current page display
+    var pageData = ProjectStore.getPage(_currentPage);
+    _updateSheetInfo(pageData);
+    _updateScaleLabel();
+    _refreshMeasurements();
+    Viewer.requestRedraw();
+
+    setStatus(
+      "Imported: " +
+        areaCount +
+        " areas, " +
+        winCount +
+        " windows, " +
+        rulerCount +
+        " rulers from " +
+        (data.fileName || "project"),
+      "ready"
+    );
+  };
+  reader.readAsText(file);
 }
 
 /* ── Public API (exposed to HTML onclick handlers) ────── */

--- a/PDF-Parser/js/app.mjs
+++ b/PDF-Parser/js/app.mjs
@@ -1102,7 +1102,12 @@ function _bindKeyboard() {
     switch (e.key) {
       case "Escape":
         // Cascade: cancel the most immediate in-progress action
-        // 0. Scale feedback dialogue open? Close it.
+        // 0a. Summary table open? Close it.
+        if (document.getElementById("summary-panel").classList.contains("visible")) {
+          closeSummaryTable();
+          break;
+        }
+        // 0b. Scale feedback dialogue open? Close it.
         if (document.getElementById("scale-feedback-panel").classList.contains("visible")) {
           closeScaleFeedback();
           break;
@@ -1680,6 +1685,310 @@ function _placeDetectedOutline(candidate, idx, total) {
   setStatus("Outline: " + areaStr + ", " + verts.length + " vertices." + hint, "ready");
 }
 
+/* ── Summary Table Modal ──────────────────────────────── */
+
+function openSummaryTable() {
+  if (!Loader.isLoaded()) return;
+  _renderSummaryTable();
+  document.getElementById("summary-backdrop").classList.add("visible");
+  document.getElementById("summary-panel").classList.add("visible");
+}
+
+function closeSummaryTable() {
+  document.getElementById("summary-backdrop").classList.remove("visible");
+  document.getElementById("summary-panel").classList.remove("visible");
+}
+
+function _renderSummaryTable() {
+  var project = ProjectStore.getProject();
+  var html = "<table><thead><tr>";
+  html += "<th>Sheet</th><th>Label</th>";
+  html += "<th>Gross m\u00B2</th><th>Net m\u00B2</th>";
+  html += "<th>Gross ft\u00B2</th><th>Net ft\u00B2</th>";
+  html += "<th>Perimeter m</th><th></th>";
+  html += "</tr></thead><tbody>";
+
+  var grandGrossM2 = 0,
+    grandNetM2 = 0,
+    grandGrossFt2 = 0,
+    grandNetFt2 = 0;
+  var hasAnyData = false;
+  var toggleIdx = 0;
+
+  for (var p = 0; p < project.pages.length; p++) {
+    var page = project.pages[p];
+    var pageNum = page.pageNum;
+    var assoc = PolygonTool.buildAssociationMap(pageNum);
+    if (assoc.walls.length === 0 && assoc.orphanWindows.length === 0) continue;
+
+    var sheetLabel = page.sheetId || "Page " + pageNum;
+    var sheetTitle = page.sheetTitle ? " \u2014 " + page.sheetTitle : "";
+    hasAnyData = true;
+
+    // Sheet header row
+    html += "<tr class='summary-sheet-row'><td colspan='8'>" + sheetLabel + sheetTitle + "</td></tr>";
+
+    var pageGrossM2 = 0,
+      pageNetM2 = 0,
+      pageGrossFt2 = 0,
+      pageNetFt2 = 0;
+
+    // Wall rows
+    for (var w = 0; w < assoc.walls.length; w++) {
+      var wall = assoc.walls[w];
+      var wm = wall.measurement;
+      var hasChildren = wall.children.length > 0;
+
+      // Compute net
+      var wallNetM2 = wm.areaM2;
+      var wallNetFt2 = wm.areaFt2;
+      if (hasChildren && wm.areaM2 !== null) {
+        for (var ci = 0; ci < wall.children.length; ci++) {
+          var ch = wall.children[ci].measurement;
+          if (ch.areaM2 !== null) {
+            if (ch.mode !== "add") {
+              wallNetM2 -= ch.areaM2;
+              wallNetFt2 -= ch.areaFt2;
+            } else {
+              wallNetM2 += ch.areaM2;
+              wallNetFt2 += ch.areaFt2;
+            }
+          }
+        }
+      }
+
+      if (wm.areaM2 !== null) {
+        pageGrossM2 += wm.areaM2;
+        pageGrossFt2 += wm.areaFt2;
+        pageNetM2 += wallNetM2;
+        pageNetFt2 += wallNetFt2;
+      }
+
+      // Wall row
+      var chevron = hasChildren
+        ? "<span class='wall-toggle' data-wall-idx='st" + toggleIdx + "' data-expanded='0'>\u25B6</span> "
+        : "";
+      var netSuffix = hasChildren ? " <span class='net-label'>net</span>" : "";
+      html += "<tr>";
+      html += "<td></td>";
+      html +=
+        "<td class='label-cell' data-poly-idx='" +
+        wall.polyIdx +
+        "' data-page-num='" +
+        pageNum +
+        "' title='Click to rename'>" +
+        chevron +
+        wm.label +
+        netSuffix +
+        "</td>";
+      if (wm.areaM2 !== null) {
+        html += "<td class='num'>" + wm.areaM2.toFixed(2) + "</td>";
+        html += "<td class='num'>" + wallNetM2.toFixed(2) + "</td>";
+        html += "<td class='num'>" + wm.areaFt2.toFixed(2) + "</td>";
+        html += "<td class='num'>" + wallNetFt2.toFixed(2) + "</td>";
+      } else {
+        html += "<td class='num' colspan='4'>\u2014</td>";
+      }
+      html += "<td class='num'>" + (wm.perimeterM !== null ? wm.perimeterM.toFixed(2) : "") + "</td>";
+      html +=
+        "<td class='del-cell' data-poly-idx='" +
+        wall.polyIdx +
+        "' data-page-num='" +
+        pageNum +
+        "' title='Delete'>\u00D7</td>";
+      html += "</tr>";
+
+      // Detail rows (children)
+      if (hasChildren) {
+        for (var cj = 0; cj < wall.children.length; cj++) {
+          var child = wall.children[cj];
+          var cm = child.measurement;
+          var cPrefix = cm.mode !== "add" ? "\u2212" : "+";
+          html += "<tr class='detail-row' data-parent='st" + toggleIdx + "' style='color:" + WIN_EDGE + ";'>";
+          html += "<td></td>";
+          html +=
+            "<td class='label-cell' data-poly-idx='" +
+            child.polyIdx +
+            "' data-page-num='" +
+            pageNum +
+            "' style='padding-left:24px;font-size:10px;' title='Click to rename'>" +
+            cPrefix +
+            " " +
+            cm.label +
+            "</td>";
+          if (cm.areaM2 !== null) {
+            html += "<td class='num' style='font-size:10px;'>" + cPrefix + cm.areaM2.toFixed(2) + "</td>";
+            html += "<td class='num' style='font-size:10px;'></td>";
+            html += "<td class='num' style='font-size:10px;'>" + cPrefix + cm.areaFt2.toFixed(2) + "</td>";
+            html += "<td class='num' style='font-size:10px;'></td>";
+          } else {
+            html += "<td colspan='4'></td>";
+          }
+          html +=
+            "<td class='num' style='font-size:10px;'>" +
+            (cm.perimeterM !== null ? cm.perimeterM.toFixed(2) : "") +
+            "</td>";
+          html +=
+            "<td class='del-cell' data-poly-idx='" +
+            child.polyIdx +
+            "' data-page-num='" +
+            pageNum +
+            "' title='Delete' style='font-size:10px;'>\u00D7</td>";
+          html += "</tr>";
+        }
+        toggleIdx++;
+      }
+    }
+
+    // Orphan windows
+    for (var o = 0; o < assoc.orphanWindows.length; o++) {
+      var om = assoc.orphanWindows[o].measurement;
+      var oPrefix = om.mode !== "add" ? "\u2212" : "+";
+      html += "<tr style='color:" + WIN_EDGE + ";'>";
+      html += "<td></td>";
+      html +=
+        "<td class='label-cell' data-poly-idx='" +
+        assoc.orphanWindows[o].polyIdx +
+        "' data-page-num='" +
+        pageNum +
+        "' title='Click to rename'>" +
+        om.label +
+        " (unassociated)</td>";
+      if (om.areaM2 !== null) {
+        html += "<td class='num'>" + oPrefix + om.areaM2.toFixed(2) + "</td><td class='num'></td>";
+        html += "<td class='num'>" + oPrefix + om.areaFt2.toFixed(2) + "</td><td class='num'></td>";
+      } else {
+        html += "<td colspan='4'>\u2014</td>";
+      }
+      html += "<td class='num'>" + (om.perimeterM !== null ? om.perimeterM.toFixed(2) : "") + "</td>";
+      html +=
+        "<td class='del-cell' data-poly-idx='" +
+        assoc.orphanWindows[o].polyIdx +
+        "' data-page-num='" +
+        pageNum +
+        "' title='Delete'>\u00D7</td>";
+      html += "</tr>";
+    }
+
+    // Page subtotal
+    if (assoc.walls.length > 1 || assoc.orphanWindows.length > 0) {
+      html += "<tr class='summary-total-row'><td></td><td>" + sheetLabel + " Total</td>";
+      html += "<td class='num'>" + pageGrossM2.toFixed(2) + "</td>";
+      html += "<td class='num'>" + pageNetM2.toFixed(2) + "</td>";
+      html += "<td class='num'>" + pageGrossFt2.toFixed(2) + "</td>";
+      html += "<td class='num'>" + pageNetFt2.toFixed(2) + "</td>";
+      html += "<td colspan='2'></td></tr>";
+    }
+
+    grandGrossM2 += pageGrossM2;
+    grandNetM2 += pageNetM2;
+    grandGrossFt2 += pageGrossFt2;
+    grandNetFt2 += pageNetFt2;
+  }
+
+  // Grand total
+  if (hasAnyData) {
+    html += "<tr class='summary-grand-total'><td></td><td>Grand Total</td>";
+    html += "<td class='num'>" + grandGrossM2.toFixed(2) + "</td>";
+    html += "<td class='num'>" + grandNetM2.toFixed(2) + "</td>";
+    html += "<td class='num'>" + grandGrossFt2.toFixed(2) + "</td>";
+    html += "<td class='num'>" + grandNetFt2.toFixed(2) + "</td>";
+    html += "<td colspan='2'></td></tr>";
+  }
+
+  html += "</tbody></table>";
+
+  if (!hasAnyData) {
+    html =
+      "<p class='empty' style='padding:2rem;text-align:center;'>No measurements yet. Press <b>M</b> to measure areas.</p>";
+  }
+
+  document.getElementById("summary-content").innerHTML = html;
+
+  // Bind chevron toggles
+  var panel = document.getElementById("summary-content");
+  var toggles = panel.querySelectorAll(".wall-toggle");
+  for (var t = 0; t < toggles.length; t++) {
+    toggles[t].addEventListener("click", function (e) {
+      e.stopPropagation();
+      var wallIdx = this.dataset.wallIdx;
+      var expanded = this.dataset.expanded === "1";
+      this.dataset.expanded = expanded ? "0" : "1";
+      this.textContent = expanded ? "\u25B6" : "\u25BC";
+      var details = panel.querySelectorAll(".detail-row[data-parent='" + wallIdx + "']");
+      for (var d = 0; d < details.length; d++) {
+        details[d].style.display = expanded ? "none" : "table-row";
+      }
+    });
+  }
+
+  // Bind label rename
+  var labelCells = panel.querySelectorAll(".label-cell");
+  for (var lc = 0; lc < labelCells.length; lc++) {
+    labelCells[lc].addEventListener("click", function (e) {
+      var polyIdx = parseInt(this.dataset.polyIdx, 10);
+      var pageNum = parseInt(this.dataset.pageNum, 10);
+      _startSummaryLabelEdit(this, pageNum, polyIdx);
+    });
+  }
+
+  // Bind delete buttons
+  var delCells = panel.querySelectorAll(".del-cell");
+  for (var dc = 0; dc < delCells.length; dc++) {
+    delCells[dc].addEventListener("click", function (e) {
+      var idx = parseInt(this.dataset.polyIdx, 10);
+      var pg = parseInt(this.dataset.pageNum, 10);
+      PolygonTool.deletePolygon(pg, idx);
+      ProjectStore.savePolygons(pg, PolygonTool.getPolygons(pg));
+      _renderSummaryTable();
+      if (pg === _currentPage) {
+        _refreshMeasurements();
+        Viewer.requestRedraw();
+      }
+      setStatus("Measurement deleted", "ready");
+    });
+  }
+}
+
+function _startSummaryLabelEdit(cell, pageNum, polyIdx) {
+  var currentLabel = cell.textContent
+    .replace(/^[\u25B6\u25BC]\s*/, "")
+    .replace(/\s*net$/, "")
+    .trim();
+  var input = document.createElement("input");
+  input.type = "text";
+  input.value = currentLabel;
+  input.className = "label-edit-input";
+  input.style.width = "100%";
+  cell.textContent = "";
+  cell.appendChild(input);
+  input.focus();
+  input.select();
+
+  function commit() {
+    var newLabel = input.value.trim() || currentLabel;
+    PolygonTool.renamePolygon(pageNum, polyIdx, newLabel);
+    ProjectStore.savePolygons(pageNum, PolygonTool.getPolygons(pageNum));
+    if (pageNum === _currentPage) {
+      Viewer.requestRedraw();
+      _refreshMeasurements();
+    }
+    _renderSummaryTable();
+  }
+
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit();
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      _renderSummaryTable();
+    }
+  });
+  input.addEventListener("blur", commit);
+}
+
 /* ── Export ────────────────────────────────────────────── */
 
 function exportCSV() {
@@ -1719,6 +2028,9 @@ window.PP = {
   setWindowMode: setWindowMode,
   // Auto-detect
   autoDetect: autoDetect,
+  // Summary table
+  openSummaryTable: openSummaryTable,
+  closeSummaryTable: closeSummaryTable,
   // Sample
   loadSample: loadSample
 };

--- a/PDF-Parser/js/polygon-tool.mjs
+++ b/PDF-Parser/js/polygon-tool.mjs
@@ -14,6 +14,12 @@ var _colorIdx = 0,
   _nextWinId = 1;
 var _undoStack = []; // snapshots for undo
 var _redoStack = [];
+var _onUndoPushCallback = null;
+
+/** Register a callback invoked whenever polygon undo state is pushed. */
+export function onUndoPush(fn) {
+  _onUndoPushCallback = fn;
+}
 
 function _pushUndo(pageNum) {
   var polys = _polygons[pageNum] || [];
@@ -23,6 +29,7 @@ function _pushUndo(pageNum) {
   });
   _redoStack = []; // clear redo on new action
   if (_undoStack.length > 50) _undoStack.shift();
+  if (_onUndoPushCallback) _onUndoPushCallback();
 }
 
 export function undo() {
@@ -576,6 +583,35 @@ export function reset() {
   _activePolyId = null;
   _colorIdx = 0;
   _nextId = 1;
+  _nextWinId = 1;
   _undoStack = [];
   _redoStack = [];
+}
+
+/**
+ * Load polygons from a saved project (import).
+ * Replaces current polygons for the given page and resets counters.
+ */
+export function loadPolygons(pageNum, polygons) {
+  _polygons[pageNum] = (polygons || []).map(function (p) {
+    return {
+      id: p.id || "poly_" + Date.now(),
+      label: p.label || "Area",
+      vertices: p.vertices || [],
+      closed: p.closed !== false,
+      type: p.type || "area",
+      mode: p.mode || "net",
+      color: POLY_COLORS[_colorIdx++ % POLY_COLORS.length],
+      _pageNum: pageNum
+    };
+  });
+  // Update counters to avoid ID collisions
+  var areaCount = 0,
+    winCount = 0;
+  for (var i = 0; i < _polygons[pageNum].length; i++) {
+    if (_polygons[pageNum][i].type === "window") winCount++;
+    else areaCount++;
+  }
+  if (areaCount >= _nextId) _nextId = areaCount + 1;
+  if (winCount >= _nextWinId) _nextWinId = winCount + 1;
 }

--- a/PDF-Parser/js/project-store.mjs
+++ b/PDF-Parser/js/project-store.mjs
@@ -33,7 +33,8 @@ export function initFromPdf(fileName, pageCount) {
       sheetTitle: null,
       classification: null,
       scale: null,
-      polygons: []
+      polygons: [],
+      rulers: []
     });
   }
 }
@@ -67,6 +68,21 @@ export function savePolygons(pageNum, polygons) {
     });
     _touch();
   }
+}
+
+export function saveRulers(pageNum, rulers) {
+  var page = _project.pages[pageNum - 1];
+  if (page) {
+    page.rulers = (rulers || []).map(function (r) {
+      return { id: r.id, p1: r.p1, p2: r.p2, pdfLength: r.pdfLength, lengthM: r.lengthM };
+    });
+    _touch();
+  }
+}
+
+export function getRulers(pageNum) {
+  var page = _project.pages[pageNum - 1];
+  return page && page.rulers ? page.rulers : [];
 }
 
 /**

--- a/PDF-Parser/js/scale-manager.mjs
+++ b/PDF-Parser/js/scale-manager.mjs
@@ -156,3 +156,21 @@ export function getCalibration(pageNum) {
 export function reset() {
   _calibrations = {};
 }
+
+/**
+ * Restore a calibration from a saved project (import).
+ * Accepts the calibration object as saved by ProjectStore.
+ */
+export function restoreCalibration(pageNum, calData) {
+  if (!calData || !calData.pdfUnitsPerMetre) return;
+  _calibrations[pageNum] = {
+    state: calData.source === "verified" ? STATE.VERIFIED : STATE.ACCEPTED,
+    ratio: calData.ratio,
+    ratioLabel: calData.ratioLabel || "1:" + calData.ratio,
+    pdfUnitsPerMetre: calData.pdfUnitsPerMetre,
+    source: calData.source || "accepted",
+    refPoints: calData.refPoints || null,
+    refDistance: calData.refDistance || null,
+    refUnit: calData.refUnit || null
+  };
+}

--- a/PDF-Parser/pdfparser.css
+++ b/PDF-Parser/pdfparser.css
@@ -718,3 +718,128 @@ body {
 .status-error {
   color: var(--red);
 }
+
+/* ── Summary Table Modal ─────────────────────────────── */
+#summary-backdrop {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 103;
+}
+#summary-backdrop.visible {
+  display: block;
+}
+
+#summary-panel {
+  display: none;
+  position: absolute;
+  top: 5%;
+  left: 5%;
+  right: 5%;
+  bottom: 5%;
+  background: var(--bg-panel);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  z-index: 104;
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+}
+#summary-panel.visible {
+  display: flex;
+}
+
+.summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.summary-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--accent-lit);
+}
+.summary-close {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.summary-close:hover {
+  color: var(--text);
+}
+
+#summary-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+
+.summary-footer {
+  display: flex;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* Summary table styling */
+#summary-content table {
+  width: 100%;
+  border-collapse: collapse;
+}
+#summary-content th {
+  text-align: right;
+  color: var(--text-dim);
+  font-weight: 500;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  position: sticky;
+  top: 0;
+  background: var(--bg-panel);
+}
+#summary-content th:first-child,
+#summary-content th:nth-child(2) {
+  text-align: left;
+}
+#summary-content td {
+  padding: 4px 8px;
+  font-size: 11px;
+}
+#summary-content td.num {
+  font-family: var(--font-mono);
+  text-align: right;
+}
+
+.summary-sheet-row td {
+  padding-top: 12px !important;
+  font-size: 12px !important;
+  font-weight: 700;
+  color: var(--accent-lit);
+  border-bottom: 1px solid var(--border);
+}
+.summary-total-row td {
+  border-top: 1px solid var(--accent);
+  font-weight: 700;
+  padding-top: 6px !important;
+}
+.summary-grand-total td {
+  border-top: 2px solid var(--accent);
+  font-weight: 700;
+  font-size: 12px !important;
+  padding-top: 8px !important;
+}

--- a/PDF-Parser/pdfparser.css
+++ b/PDF-Parser/pdfparser.css
@@ -100,6 +100,41 @@ body {
   color: #fff;
 }
 
+/* Icon sizing in toolbar buttons */
+.tool-btn i,
+.export-btn i {
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* ── Toolbar Tooltips (data-tip attribute) ────────────── */
+[data-tip] {
+  position: relative;
+}
+[data-tip]::after {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-family: var(--font);
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+  z-index: 200;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+[data-tip]:hover::after {
+  opacity: 1;
+}
+
 #measure-method,
 #window-mode {
   background: var(--bg-panel);

--- a/README.md
+++ b/README.md
@@ -1,28 +1,85 @@
-# BfCA Labs — BEAM R&D
+# BfCA CAF — Embodied Carbon Assessment Framework
 
-Private collaboration repo for research and development supporting [BEAM](https://www.buildersforclimateaction.org/beam.html), Builders for Climate Action's embodied carbon assessment tool for Canadian residential buildings.
+Research, prototyping, and tooling for embodied carbon (EC) assessment in Canadian construction, developed under the NRCan Codes Accelerator Fund (CAF) in collaboration with [Builders for Climate Action](https://www.buildersforclimateaction.org/) (BfCA).
 
-This repo serves as a staging area for exploratory research, reference models, and prototype tools that will inform future versions of BEAM. It is organized into three workstreams, each focused on a distinct domain of BEAM's development roadmap.
+## Live Tools
+
+Both tools are deployed via GitHub Pages and share a unified dark-chrome design system with cross-navigation.
+
+### PDF-Parser — Construction Document Area Extraction
+
+Client-side tool for extracting area and volume data from construction document PDFs. Loads a PDF, identifies architectural plans, and lets users measure areas with polygon or rectangle tools — purpose-built for the area/volume inputs needed by BEAM, MCE2, and wbLCA tools.
+
+**Key features:**
+- PDF.js 4.x viewer with CAD-style controls (scroll-zoom at cursor, middle-click pan)
+- Three-state scale workflow: auto-detect → accept → verify (empirical two-point calibration)
+- Polygon + rectangle area measurement with vertex snap to PDF vector geometry
+- **Window/opening measurement** — gold-styled window polygons auto-associate with parent walls via ray-casting centroid containment; wall rows show net area
+- Expandable measurement panel with gross/net breakdown per wall
+- Full-screen summary table across all pages
+- Ruler tool with tick marks and dual-unit labels
+- Unified undo/redo (polygons + rulers), JSON project save/load/import, CSV export
+
+### EC Matrix — Canadian Embodied Carbon Compliance Matrix
+
+Interactive reference mapping roles, responsibilities, tools, standards, and compliance requirements for EC assessments across Canadian building types, sizes, jurisdictions, and project phases. Aligned to NBC/NECB 2025 Draft.
+
+**Key features:**
+- Card view with 6-phase status strip (None → Voluntary → Conditional → Emerging → Mandatory)
+- Flow model view (horizontal phase-to-phase with statutory/EC/voluntary tracks)
+- Actor lens mode (dims irrelevant phases, highlights selected role's involvement)
+- 2025 code updates panel, PT equivalents, standards tooltips, BEM glossary
+- Persona quick-filter chips for common role scenarios
 
 ## Repository Structure
 
 ```
 at/
-├── regulatory/   Research and tooling for Canadian Part 9 building code compliance
-├── ifc/          IFC building model import exploration for BEAM integration
-└── cost/         Cost data integration research for co-evaluating cost and carbon
+├── PDF-Parser/          Construction document area extraction tool
+│   ├── index.html       PDF-Parser app (dark theme)
+│   ├── matrix.html      EC Matrix app (light theme)
+│   ├── bfcastyles.css   Shared design system
+│   ├── pdfparser.css    PDF-Parser styles
+│   ├── matrix.css       EC Matrix styles
+│   ├── js/              10 ESM modules (vanilla JS)
+│   ├── lib/             PDF.js 4.9.155 (local ESM build)
+│   └── docs/            Workplan and technical documentation
+├── Matrix App/          EC Matrix standalone (step-numbered HTML files)
+├── BfCA Resources/      Reference documents (Vancouver EC guides, NRC reports)
+├── regulatory/          Canadian Part 9 building code compliance research
+├── ifc/                 IFC building model import exploration
+├── cost/                Cost data integration research
+├── CCI-tables/          CCI construction classification taxonomy
+└── CLAUDE.md            Project instructions for AI-assisted development
 ```
 
-See the README in each subdirectory for workstream-specific documentation.
+## Development
+
+PDF-Parser requires a local server for ESM module imports:
+
+```bash
+cd PDF-Parser
+npm install          # ESLint + Prettier (one-time)
+npm run serve        # python3 -m http.server 8000
+npm run lint         # ESLint check
+npm run lint:fix     # ESLint auto-fix (includes Prettier)
+npm run format       # Prettier on CSS/HTML/JS
+```
+
+Matrix App (`ec_matrix_step15.html`) opens directly in a browser — no server needed.
 
 ## Context
 
-BEAM is currently in active development under the NRCan Codes Accelerator Fund (CAF), with a near-term MVP focused on combined operational and embodied carbon analysis for Part 9 residential buildings. The work in this repo is **post-MVP R&D** — research and prototyping that will feed into future iterations of BEAM beyond the current CAF deliverables.
+This work is part of the NRCan Codes Accelerator Fund (CAF), with a near-term focus on combined operational and embodied carbon analysis for Part 9 and Part 3 buildings. The PDF-Parser and EC Matrix are complementary tools: the Matrix maps *what* EC requirements apply; the Parser extracts the *area and volume data* needed to run the assessment.
+
+## Scope
+
+**Canada only.** No US codes, ICC, or ASHRAE references unless explicitly referenced by a Canadian standard.
 
 ## Collaborators
 
-This repo is primarily maintained by **Andy Thomson** in collaboration with BfCA. Other collaborators may be granted access for reference.
+Maintained by **Andy Thomson** (Thomson Architecture Inc.) in collaboration with BfCA.
 
 ## About BfCA
 
-[Builders for Climate Action](https://www.buildersforclimateaction.org/) (BfCA) is a Canadian organization working to reduce carbon emissions in the built environment through research, tools, and education.
+[Builders for Climate Action](https://www.buildersforclimateaction.org/) (BfCA) is a Canadian organization working to reduce carbon emissions in the built environment through research, tools, and education. BfCA develops [BEAM](https://www.buildersforclimateaction.org/beam.html) — an embodied carbon assessment tool for Canadian residential buildings.


### PR DESCRIPTION
## Summary

- **Summary Table** — full-screen modal showing all pages with hierarchical wall→window measurements, gross/net columns, expandable detail rows, inline delete/rename
- **Ruler undo/redo** — unified undo stack (Cmd+Z works for both polygons and rulers), Shift+Delete clears all rulers, rulers persist to JSON
- **JSON Import** — Import button restores polygons, calibrations, and rulers from a saved project file onto a re-loaded PDF
- **Bootstrap Icons toolbar** — all text buttons replaced with icons (building-add, border-all, rulers, aspect-ratio, crosshair2, magic, etc.) with descriptive hover tooltips showing shortcuts
- **README rewrite** — comprehensive project overview with both tools, repo structure, dev setup
- **PDF-Parser docs** — Step 9 added (summary, ruler undo, import), future steps renumbered

## Test plan

- [ ] Click Summary → modal shows all pages with gross/net areas
- [ ] Draw ruler → Cmd+Z undoes it → Cmd+Shift+Z redoes
- [ ] Shift+Delete clears all rulers (undoable)
- [ ] Export JSON → reload PDF → Import JSON → all measurements restored
- [ ] Hover toolbar icons → tooltips show tool name + shortcut
- [ ] All icon buttons trigger correct tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)