### PR TITLE
PDF-Parser: Auto-Detect auto-tag + C7a/b edge-scrub (MAGIC AT + C7 partial)

### DIFF
--- a/docs/workplans/MAGIC.md
+++ b/docs/workplans/MAGIC.md
@@ -6,6 +6,83 @@
 
 ## 0. Cold-start handoff
 
+### Status as of 2026-04-23 (session 2 PM EOD — AT-1/2/3 shipped; paused before C7)
+
+**Successor agent: read this block first.** Andy paused the session after AT-1/2/3 landed. Context window was maxed — this block is the complete handoff; §0 sub-sections below are historical detail.
+
+- **Active branch**: `Magic-Wand-Polish-2`, tip **`81d3358`**. Two commits since `main` at `85fa550` (merged PR #12):
+  - `a0c81b4` — MAGIC.md: AT-1/2/3 prerequisites documented
+  - `81d3358` — AT-1/2/3 shipped (auto-tag on successful Auto-Detect)
+- **`main`** is at `85fa550` — PR #12 merged. `origin/main` mirrored.
+- **Dev server** is expected to be running on port 8000 (Andy asked to leave it up for the session). If not: `npm run serve` in the repo root.
+
+#### AT-1 / AT-2 / AT-3 — shipped 2026-04-23 PM at `81d3358`
+
+One cohesive commit to [`js/app.mjs`](../../js/app.mjs). Behavior changes to `_placeDetectedOutline()`:
+
+- **AT-1**: After polygon placement, `setTool("measure")` switches the active tool from navigate → polygon-edit mode so the user lands in the right context to refine.
+- **AT-2**: New `_autoTagFromPage(pageNum, textItems)` helper maps classification + title + page-text to `{component, scope, preset}`:
+  - `plan` + foundation title → `slab_foundation`
+  - `plan` + roof title → `roof_plan`
+  - `plan` + main/upper/lower/basement/ground/floor title → `slab_above_grade`
+  - `elevation` → `wall_exterior` + AT-3 preset
+  - `/\bgarage\b/i` in title OR anywhere in page-text → `scope = "garage"`
+- **AT-3**: `wall_exterior` polygons get `assembly_preset = "wood_2x6"` by default.
+- Status bar now appends the applied tag: `"Outline: 108.2 m², 4 vertices. tagged wall_exterior · wood_2x6."`
+
+**Signature change**: `_placeDetectedOutline(candidate, idx, total, textItems)` — the `textItems` arg is threaded through from `autoDetect()`'s `Promise.all` results. Two call sites (shrink-wrap success path + closed-polygon fallback) both pass it.
+
+**Verified via Playwright** on both fixtures. All classifications below work as expected unless noted:
+
+| Sheet | Classification | Component | Scope | Preset |
+|---|---|---|---|---|
+| Calgary p9 FOUNDATION | plan | slab_foundation | building | — |
+| Calgary p10 MAIN FLOOR | plan | slab_above_grade | building | — |
+| Calgary p12 ROOF | plan | roof_plan | building | — |
+| Calgary p5 EAST ELEV | elevation | wall_exterior | building | wood_2x6 |
+| Calgary p25 garage elev | elevation | wall_exterior | **building** ← LIMITATION | wood_2x6 |
+| Calgary p26 garage plan+section | section | — (C4 gate blocks) | — | — |
+| ArchiCad p4 A2.43 | plan | slab_foundation | building | — |
+| ArchiCad p5 A2.44 CD Main | plan | **— (title noise)** | building | — |
+| ArchiCad p6 A2.45 | plan | slab_above_grade | building | — |
+| ArchiCad p8 Elevation | elevation | wall_exterior | building | wood_2x6 |
+
+#### Known limitations (not bugs — design)
+
+1. **Calgary p25 garage-elevation sheet.** Blank title block + zero "garage" text anywhere on the page. Auto-tag outputs `wall_exterior` but scope stays `building`. User manually sets scope=garage via Summary Table scope dropdown. Confirmed by Andy 2026-04-23 PM — no realistic text signal to detect this.
+2. **ArchiCad A2.44 CD Main Level** has noisy title text (regex captures "Site Ad" from unrelated title-block labels). Component stays null — user picks from dropdown. Correct behavior; better than guessing wrong.
+3. **Attached-garage PDFs** where the main-floor plan has a "GARAGE" room label would trigger scope=garage via page-text scan. Acceptable false-positive: user overrides via Summary Table. pdfjs v4's per-glyph fragmentation coincidentally masks this on ArchiCad so the false-positive isn't observed today — but a word-level-text-emitting attached-garage PDF would see it.
+
+#### C7 is next — edge-scrub drag handles + oculus (decisions pending)
+
+C7 is redesigned per Andy 2026-04-22 — the original "inner/middle/outer buttons" spec in §3e is abandoned. Replace with:
+
+- **Per-edge drag handles** on the detected polygon that snap through `wallVertPositions` / `wallHorizPositions` (arrays of candidate x/y values computed inside `shrinkWrapBuilding` in [`js/shrink-wrap.mjs`](../../js/shrink-wrap.mjs) — need to expose on the returned polygon record).
+- **ArchiCad-style popup** distinguishing edge-click from vertex-click: on edge → "Drag edge" (default) + "Insert vertex"; on vertex → "Drag point" (default) + "Delete vertex". Andy showed screenshots 2026-04-23 AM.
+- **Oculus control** — single "tighten inward one step" button that closes all 4 edges to next inner candidate.
+
+**Proposed slicing** (my last message to Andy before pause):
+- **C7a** hit-test distinguishes vertex vs edge + cursor feedback (~30 min)
+- **C7b** expose wall-candidate arrays + edge-drag snap (~1 hr)
+- **C7c** ArchiCad-style popup toolbar (~1.5 hr)
+- **C7d** oculus "tighten one step" button (~30 min)
+
+**Three outstanding decisions from Andy** before C7 starts (I said "my defaults if you just say go":
+- **Snap cluster radius** — cluster candidates within 5pt, or every candidate individually? *Default: cluster within 5pt.*
+- **Oculus shape** — button ("tighten one step", discrete) or slider (0–100%, continuous)? *Default: button.*
+- **Handle glyph** — small circle with arrow, OSX `<|>` chevron, or colored tick? *Default: small circle with directional arrow hint.*
+
+Ask Andy on resume; if he says "just go", ship C7a+b as one commit with defaults above.
+
+#### Post-merge branch state reference
+
+```
+main                                   85fa550   PR #12 merged
+└── Magic-Wand-Polish-2  (active)
+    ├── a0c81b4  MAGIC.md AT prereq notes
+    └── 81d3358  AT-1/2/3 auto-tag (← tip)
+```
+
 ### Status as of 2026-04-23 (session 2 PM — PR #12 merged; on Magic-Wand-Polish-2)
 
 - **[PR #12 merged](https://github.com/arossti/OpenBuilding/pull/12)** as commit `85fa550` on `main`. 21 commits from `3360f42` ancestor. Branch `Magic-Wand-Polish` deleted on both remotes + locally.
@@ -325,8 +402,10 @@ Same layer-peel + shrink-wrap on elevation sheets, but always return the outermo
 | — | Classifier: sheetId row-scan + ANSI A-series prefix mapping | ✅ shipped 2026-04-23 | `5621a85` |
 | — | Pre-merge cleanup: eslint globals + prettier sweep | ✅ shipped 2026-04-23 | `fab1974` |
 | — | Matrix: stray `</body>` tag fix (prettier parse error) | ✅ shipped 2026-04-23 | `e0b5ae9` |
+| — | **PR #12 merged to `main`** | ✅ 2026-04-23 PM | `85fa550` |
+| AT-1/2/3 | Auto-tag polygon: tool-mode switch + classification → tag/scope + wood_2x6 default | ✅ shipped 2026-04-23 PM | `81d3358` |
 | C6 | non-orthogonal refinement | 🅿️ on hold — see §0 C7 redesign (edge-scrub likely covers gables) |
-| C7 | ~~inner/middle/outer snap buttons~~ → **edge-scrub drag handles + oculus** | 🔜 next session (post-PR-#12 merge) | — |
+| C7 | ~~inner/middle/outer snap buttons~~ → **edge-scrub drag handles + oculus** | 🔜 next session (decisions pending; see §0 EOD block) | — |
 | C8 | elevation outermost + eave-crop | ⏳ deferred until C7 lands; p5 shrink-wrap already performs well without outermost-only tweak |
 
 Each commit: end-to-end assertion before push, per the "tests before commits" rule. Push to both remotes (`openbuilding`, `origin`) after every commit.

--- a/docs/workplans/MAGIC.md
+++ b/docs/workplans/MAGIC.md
@@ -1,10 +1,53 @@
 # PDF-Parser Magic-Wand Polish — workplan (MAGIC.md)
 
-> Polish pass on the PDF-Parser magic-wand (auto-detect) path. Adds dimension-string calibration with declared-vs-detected scale cross-check and a shrink-wrap building-outline detector that replaces the current "closed-polygon only" heuristic. Branch: `Magic-Wand-Polish`. Started 2026-04-22.
+> Polish pass on the PDF-Parser magic-wand (auto-detect) path. Adds dimension-string calibration with declared-vs-detected scale cross-check and a shrink-wrap building-outline detector that replaces the current "closed-polygon only" heuristic. Branch: `Magic-Wand-Polish-2` (successor to merged `Magic-Wand-Polish` → PR #12). Started 2026-04-22.
 
 ---
 
 ## 0. Cold-start handoff
+
+### Status as of 2026-04-23 (session 2 PM — PR #12 merged; on Magic-Wand-Polish-2)
+
+- **[PR #12 merged](https://github.com/arossti/OpenBuilding/pull/12)** as commit `85fa550` on `main`. 21 commits from `3360f42` ancestor. Branch `Magic-Wand-Polish` deleted on both remotes + locally.
+- **Active branch**: `Magic-Wand-Polish-2`, off `main` at `85fa550`. No commits yet — next code lands from AT-1/2/3 onward (auto-tag prerequisites for C7).
+
+#### Auto-tag prerequisites (Andy 2026-04-23 PM) — AT-1 / AT-2 / AT-3
+
+Auto-Detect currently places a polygon but leaves it untagged — user has to manually set component-tag, assembly-preset, and scope before the BEAMweb bridge can use it. **Before C7's edge-scrub refinement lands**, auto-populate these from what the classifier already knows so the user gets a polygon that's "ready to import" on first click. Keeps the loop between Auto-Detect and BEAMweb bridge tight; C7 becomes optional refinement polish, not mandatory prep.
+
+**AT-1 — Tool-mode switch on successful detect.**
+After `autoDetect()` places the polygon, switch the active tool from "navigate" to polygon-edit mode so the user lands in the right context to refine (once C7 drag handles ship) or to click-adjust vertices today. Avoids the "I pressed D, something happened, now what?" disorientation. One `setTool("measure")` or similar call at the tail of `_placeDetectedOutline()`.
+
+**AT-2 — Auto-tag from sheet classification + title keywords.**
+`classifySheet()` + the title text already determine what the polygon represents on the current page. Wire the mapping in [`js/app.mjs`](../../js/app.mjs) after `_placeDetectedOutline()` places the polygon:
+
+| Sheet classification | Title keyword match | Component tag | Scope |
+|---|---|---|---|
+| `plan` | `/\bfoundation\b/i` | `slab_foundation` | building (default) |
+| `plan` | `/\broof\b/i` | `roof_plan` | building |
+| `plan` | `/\bmain\|upper\|lower\|basement\b/i` | `slab_above_grade` | building |
+| `plan` | `/\bgarage\b/i` | `slab_above_grade` | **garage** |
+| `elevation` | (any) | `wall_exterior` | building (default) |
+| `elevation` | `/\bgarage\b/i` | `wall_exterior` | **garage** |
+
+Garage detection extends both the plan + elevation paths — the scope flag (`building` | `garage`) differentiates, not a separate tag. Matches the Q23 per-polygon scope field shipped in PR #11 (`944c720`).
+
+If no keyword matches (e.g. generic "floor plan" with no qualifier), leave the tag unset and surface the usual dropdown for manual tagging. Don't guess with low confidence.
+
+**AT-3 — Default assembly preset = Wood 2×6 for exterior-wall polygons.**
+On elevation sheets where `wall_exterior` fires, set `assembly_preset: "wood_2x6"` by default. Matches the BfCA target user (single-family wood-framed new construction); user can swap via the existing `#assembly-preset` dropdown (values: wood_2x4, wood_2x6, wood_2x8, wood_2x10, steel_stud, icf, concrete_block, other). Plan-view tags get no preset by default — presets are a wall-assembly concept, not a slab/roof concept.
+
+**Why do this before C7.** Once AT-1/2/3 are in, a user's workflow is: (a) load PDF, (b) Auto-Calibrate on a plan sheet, (c) Auto-Detect → polygon appears tagged + scoped + presetted, ready for BEAMweb bridge import. That's the "something close they can adjust" line Andy drew 2026-04-22 — we're completing it before adding more UI surface. C7's edge-scrub then refines the polygon's SHAPE, but the polygon's SEMANTICS are already correct by default.
+
+**Commit plan for AT:**
+
+| Commit | Scope |
+|---|---|
+| AT-1 | Tool-mode switch post-detect (1-line fix + Playwright verify) |
+| AT-2 | Classification → tag + scope mapping in autoDetect; extend sheet-classifier garage-title detection if needed |
+| AT-3 | Wood-2×6 default for elevation-derived polygons; verify Summary Table inline Tag + Preset selects reflect the auto-set values |
+
+Stitch all three into one cohesive commit if the diff stays small; split if any of them surfaces ambiguity.
 
 ### Status as of 2026-04-23 (session 2 AM — PR #12 opened; cleanup pass)
 

--- a/docs/workplans/MAGIC.md
+++ b/docs/workplans/MAGIC.md
@@ -6,9 +6,75 @@
 
 ## 0. Cold-start handoff
 
+### Status as of 2026-04-23 (session 3 — C7a+b + Alt opt-out shipped; paused before C7c/d for BfCA demo)
+
+**Successor agent: read this block first.** Andy is presenting this state to BfCA, so the branch is parked here intentionally. Resume with C7c (popup) or C7d (oculus) — see bottom of this block. §0 sub-sections below are historical detail.
+
+- **Active branch**: `Magic-Wand-Polish-2`, tip **`5d6f8db`**. Three code commits since `main` at `85fa550` (PR #12):
+  - `81d3358` — AT-1/2/3 auto-tag (session 2 PM)
+  - `bafaaa7` — C7a + C7b edge-scrub (per-edge drag + snap to wall-candidate detents)
+  - `5d6f8db` — C7 Alt-click opt-out (Option/Alt bypasses edge-drag → legacy insert-vertex)
+- **Dev server**: `npm run serve` on port 8000 (no-cache).
+
+#### C7a + C7b — shipped at `bafaaa7`
+
+**What works now.** On an Auto-Detected polygon:
+
+- Hover a vertical orthogonal edge → cursor is `ew-resize` (↔). Drag it → both endpoints of that edge slide in x together; release snaps to the nearest `wallVertPositions` detent.
+- Hover a horizontal orthogonal edge → cursor is `ns-resize` (↕). Same behavior on y.
+- Hover a vertex → `move` cursor, classic vertex drag still works.
+- Hover anywhere the edge-drag affordance doesn't apply (hand-drawn polygon, non-orthogonal edge, or Alt held) → `cell` cursor → click inserts a vertex.
+- Snap is **unconditional** — the edge always settles on the nearest detent when you release. Matches Andy's "scrub through candidates" language. Between-detent placement is explicitly an insert-vertex operation.
+
+**Implementation landmarks:**
+
+- `shrinkWrapBuilding` in [`js/shrink-wrap.mjs`](../../js/shrink-wrap.mjs) now returns `wallVertPositions` (x-coords) + `wallHorizPositions` (y-coords), clustered within 5pt. Clustering collapses partner-stroke duplicates (inner + outer face of the same wall) but preserves distinct walls ≥10pt apart.
+- [`js/polygon-tool.mjs`](../../js/polygon-tool.mjs) polygon record gains `_shrinkCandidates: {vert, horiz}`. New API: `edgeOrientation`, `setShrinkCandidates`, `getShrinkCandidates`, `startEdgeDrag / moveEdgeDrag / endEdgeDrag`, `isEdgeDragging`. Undo captures edge drags.
+- [`js/app.mjs`](../../js/app.mjs) `_placeDetectedOutline` threads the arrays onto the polygon via `setShrinkCandidates`. `_handleOverlayClick` picks edge-drag vs insert-vertex based on orientation × candidates × `altKey`. `_handleOverlayMouseMove` mirrors the decision in the hover cursor.
+- Also fixed a latent bug in `loadPolygons` where `scope` wasn't round-tripping through save/load (garage polygons came back as "building").
+
+**Verified via Playwright on docs/sample.pdf:**
+
+| Sheet | Candidates attached | Edge-drag behavior |
+|---|---|---|
+| p9 FOUNDATION PLAN | 15V / 34H detents | Left edge x=120.5 drag to 135 → snap to 141.2; top edge y=19.5 drag to 55 → snap to 65.4; undo returns to origin |
+| p5 EAST ELEVATION | 21V / 48H detents | Polygon placed with `wall_exterior` + `wood_2x6` preset, candidates attached |
+| hand-drawn polygon | null (graceful) | Edge-drag API no-ops gracefully; click router correctly falls through to insert-vertex |
+
+Zero console errors across the session.
+
+#### Alt-click opt-out — shipped at `5d6f8db`
+
+Edge-drag with unconditional snap left no path to insert a vertex on an orthogonal edge of a detected polygon — Andy hit this on a floor plan where the wall has a small jog (garage-door recess) that needed a new vertex, not a whole-edge nudge.
+
+Fix: holding Option/Alt during edge-click bypasses the edge-drag branch and falls through to `insertVertex` + vertex-drag. Hover cursor mirrors the modifier — `cell` when Alt is held over an otherwise edge-drag-capable edge, so the mode is visible before clicking.
+
+Stopgap until **C7c** surfaces both actions via a popup. Documenting as shipped because the modifier is usable in the interim; revisit when the popup lands.
+
+#### C7c + C7d — parked for next session
+
+Remaining C7 surface (not blocking the BfCA demo):
+
+- **C7c — ArchiCad-style popup** (~1–1.5 hr). On edge-click → "Drag edge" (default) + "Insert vertex". On vertex-click → "Drag point" (default) + "Delete vertex". Replaces the Alt-modifier with something discoverable; also closes the one real functional gap (no way to *delete* a vertex today — user has to drag-merge onto a neighbor).
+- **C7d — Oculus "tighten one step inward" button** (~30 min). Single control that snaps all 4 edges to the next inner detent simultaneously. Scope: button, not slider (Andy's default). Positioned near the polygon centroid label. Self-contained, no existing UI to modify.
+
+C6 (non-orthogonal refinement) and C8 (elevation outermost + eave-crop) remain on hold/deferred — edge-scrub + insert-vertex covers the common cases; revisit if real failures surface.
+
+#### Post-session branch state reference
+
+```
+main                                   85fa550   PR #12 merged
+└── Magic-Wand-Polish-2  (active)
+    ├── a0c81b4  MAGIC.md AT prereq notes
+    ├── 81d3358  AT-1/2/3 auto-tag
+    ├── f491e5a  MAGIC.md session-2 PM handoff
+    ├── bafaaa7  C7a+b edge-scrub
+    └── 5d6f8db  C7 Alt-click opt-out  (← tip)
+```
+
 ### Status as of 2026-04-23 (session 2 PM EOD — AT-1/2/3 shipped; paused before C7)
 
-**Successor agent: read this block first.** Andy paused the session after AT-1/2/3 landed. Context window was maxed — this block is the complete handoff; §0 sub-sections below are historical detail.
+**Historical:** kept for context on AT-1/2/3 design + verification. Superseded by the session-3 block above for current branch state.
 
 - **Active branch**: `Magic-Wand-Polish-2`, tip **`81d3358`**. Two commits since `main` at `85fa550` (merged PR #12):
   - `a0c81b4` — MAGIC.md: AT-1/2/3 prerequisites documented
@@ -53,26 +119,13 @@ One cohesive commit to [`js/app.mjs`](../../js/app.mjs). Behavior changes to `_p
 2. **ArchiCad A2.44 CD Main Level** has noisy title text (regex captures "Site Ad" from unrelated title-block labels). Component stays null — user picks from dropdown. Correct behavior; better than guessing wrong.
 3. **Attached-garage PDFs** where the main-floor plan has a "GARAGE" room label would trigger scope=garage via page-text scan. Acceptable false-positive: user overrides via Summary Table. pdfjs v4's per-glyph fragmentation coincidentally masks this on ArchiCad so the false-positive isn't observed today — but a word-level-text-emitting attached-garage PDF would see it.
 
-#### C7 is next — edge-scrub drag handles + oculus (decisions pending)
+#### C7 planning snapshot (historical — C7a+b shipped in session 3; see top block)
 
-C7 is redesigned per Andy 2026-04-22 — the original "inner/middle/outer buttons" spec in §3e is abandoned. Replace with:
+C7 was redesigned per Andy 2026-04-22 away from the original "inner/middle/outer buttons" spec (§3e). Replaced with per-edge drag handles + ArchiCad-style popup + oculus button, sliced into C7a / C7b / C7c / C7d. C7a+b shipped in session 3 with the following decisions locked in:
 
-- **Per-edge drag handles** on the detected polygon that snap through `wallVertPositions` / `wallHorizPositions` (arrays of candidate x/y values computed inside `shrinkWrapBuilding` in [`js/shrink-wrap.mjs`](../../js/shrink-wrap.mjs) — need to expose on the returned polygon record).
-- **ArchiCad-style popup** distinguishing edge-click from vertex-click: on edge → "Drag edge" (default) + "Insert vertex"; on vertex → "Drag point" (default) + "Delete vertex". Andy showed screenshots 2026-04-23 AM.
-- **Oculus control** — single "tighten inward one step" button that closes all 4 edges to next inner candidate.
-
-**Proposed slicing** (my last message to Andy before pause):
-- **C7a** hit-test distinguishes vertex vs edge + cursor feedback (~30 min)
-- **C7b** expose wall-candidate arrays + edge-drag snap (~1 hr)
-- **C7c** ArchiCad-style popup toolbar (~1.5 hr)
-- **C7d** oculus "tighten one step" button (~30 min)
-
-**Three outstanding decisions from Andy** before C7 starts (I said "my defaults if you just say go":
-- **Snap cluster radius** — cluster candidates within 5pt, or every candidate individually? *Default: cluster within 5pt.*
-- **Oculus shape** — button ("tighten one step", discrete) or slider (0–100%, continuous)? *Default: button.*
-- **Handle glyph** — small circle with arrow, OSX `<|>` chevron, or colored tick? *Default: small circle with directional arrow hint.*
-
-Ask Andy on resume; if he says "just go", ship C7a+b as one commit with defaults above.
+- **Snap cluster radius** — cluster within 5pt.
+- **Oculus shape** — button (discrete one-step).
+- **Handle glyph** — OS-native resize cursors (`ew-resize` on vertical edges, `ns-resize` on horizontal) per Andy 2026-04-23 refinement; skips drawn handle-glyphs in favor of cursor affordance.
 
 #### Post-merge branch state reference
 
@@ -404,9 +457,12 @@ Same layer-peel + shrink-wrap on elevation sheets, but always return the outermo
 | — | Matrix: stray `</body>` tag fix (prettier parse error) | ✅ shipped 2026-04-23 | `e0b5ae9` |
 | — | **PR #12 merged to `main`** | ✅ 2026-04-23 PM | `85fa550` |
 | AT-1/2/3 | Auto-tag polygon: tool-mode switch + classification → tag/scope + wood_2x6 default | ✅ shipped 2026-04-23 PM | `81d3358` |
-| C6 | non-orthogonal refinement | 🅿️ on hold — see §0 C7 redesign (edge-scrub likely covers gables) |
-| C7 | ~~inner/middle/outer snap buttons~~ → **edge-scrub drag handles + oculus** | 🔜 next session (decisions pending; see §0 EOD block) | — |
-| C8 | elevation outermost + eave-crop | ⏳ deferred until C7 lands; p5 shrink-wrap already performs well without outermost-only tweak |
+| C7a + C7b | Edge-scrub drag handles: expose wall-candidate arrays + per-edge drag + unconditional snap to detent; ew-resize / ns-resize cursor vocab | ✅ shipped 2026-04-23 | `bafaaa7` |
+| — | Alt-click opt-out: Option/Alt bypasses edge-drag into legacy insert-vertex (stopgap until C7c popup lands) | ✅ shipped 2026-04-23 | `5d6f8db` |
+| C6 | non-orthogonal refinement | 🅿️ on hold — edge-scrub + insert-vertex likely covers common cases |
+| C7c | ArchiCad-style popup: "Drag edge / Insert vertex" on edge, "Drag point / Delete vertex" on vertex — replaces Alt stopgap, adds delete-vertex (only real functional gap today) | 🔜 next session | — |
+| C7d | Oculus "tighten one step inward" button — single control closes all 4 edges to next inner detent | 🔜 next session | — |
+| C8 | elevation outermost + eave-crop | ⏳ deferred — p5 shrink-wrap already performs well |
 
 Each commit: end-to-end assertion before push, per the "tests before commits" rule. Push to both remotes (`openbuilding`, `origin`) after every commit.
 

--- a/js/app.mjs
+++ b/js/app.mjs
@@ -695,17 +695,22 @@ function _handleOverlayClick(e) {
 
   // Priority 2: Click near an edge.
   //  - If the polygon carries shrink-wrap candidates AND the edge is
-  //    orthogonal, drag the whole edge perpendicular to itself; release
-  //    snaps to the nearest wall-candidate detent (C7b).
-  //  - Otherwise fall back to the legacy behavior: insert a new vertex
-  //    at the closest point and drag it.
+  //    orthogonal AND the user is NOT holding Option/Alt, drag the whole
+  //    edge perpendicular to itself; release snaps to the nearest wall-
+  //    candidate detent (C7b).
+  //  - Option/Alt-click is the explicit opt-out: falls through to the
+  //    legacy insert-vertex path. Needed when the user wants to capture
+  //    a jog in the wall rather than nudge the whole edge. C7c will
+  //    surface this via an ArchiCad-style popup instead of a modifier.
+  //  - Non-orthogonal edges and hand-drawn polygons always use the
+  //    insert-vertex path.
   var edgeHit = PolygonTool.hitTestEdge(_currentPage, pt, hitRadius);
   if (edgeHit && !PolygonTool.isDrawing() && !skipsPolygonEdit) {
     var polysForEdge = PolygonTool.getPolygons(_currentPage);
     var edgePoly = polysForEdge[edgeHit.polyIdx];
     var orient = PolygonTool.edgeOrientation(edgePoly, edgeHit.edgeIdx);
     var hasCandidates = !!(edgePoly && edgePoly._shrinkCandidates);
-    if (orient && hasCandidates) {
+    if (orient && hasCandidates && !e.altKey) {
       if (PolygonTool.startEdgeDrag(_currentPage, edgeHit.polyIdx, edgeHit.edgeIdx)) {
         Viewer.onOverlayMouseMove(_handleDragMove);
         _bindDragEnd();
@@ -1239,7 +1244,9 @@ function _handleOverlayMouseMove(e) {
   //   move      — over a vertex (drag vertex)
   //   ew-resize — over a vertical orthogonal edge of a shrink-wrap polygon (edge-drag, x-axis)
   //   ns-resize — over a horizontal orthogonal edge of a shrink-wrap polygon (edge-drag, y-axis)
-  //   cell      — over any edge without an edge-drag affordance (insert-vertex fallback)
+  //   cell      — over any edge without an edge-drag affordance, or when
+  //               Option/Alt is held (explicit opt-out into insert-vertex mode)
+  var altHeld = !!(e && e.altKey);
   var wrap = document.getElementById("viewer-wrap");
   if (!PolygonTool.isDrawing() && !_rectStart && _currentTool !== "polyline") {
     var vertHit = PolygonTool.hitTestVertex(_currentPage, pt, hitRadius);
@@ -1253,7 +1260,7 @@ function _handleOverlayMouseMove(e) {
       var hoverPoly = polysForHover[edgeHit.polyIdx];
       var hoverOrient = PolygonTool.edgeOrientation(hoverPoly, edgeHit.edgeIdx);
       var hoverHasCands = !!(hoverPoly && hoverPoly._shrinkCandidates);
-      if (hoverOrient && hoverHasCands) {
+      if (hoverOrient && hoverHasCands && !altHeld) {
         if (wrap) wrap.style.cursor = hoverOrient === "horizontal" ? "ns-resize" : "ew-resize";
       } else if (wrap) {
         wrap.style.cursor = "cell";

--- a/js/app.mjs
+++ b/js/app.mjs
@@ -693,9 +693,28 @@ function _handleOverlayClick(e) {
     return;
   }
 
-  // Priority 2: Click near an edge — insert vertex and start dragging it
+  // Priority 2: Click near an edge.
+  //  - If the polygon carries shrink-wrap candidates AND the edge is
+  //    orthogonal, drag the whole edge perpendicular to itself; release
+  //    snaps to the nearest wall-candidate detent (C7b).
+  //  - Otherwise fall back to the legacy behavior: insert a new vertex
+  //    at the closest point and drag it.
   var edgeHit = PolygonTool.hitTestEdge(_currentPage, pt, hitRadius);
   if (edgeHit && !PolygonTool.isDrawing() && !skipsPolygonEdit) {
+    var polysForEdge = PolygonTool.getPolygons(_currentPage);
+    var edgePoly = polysForEdge[edgeHit.polyIdx];
+    var orient = PolygonTool.edgeOrientation(edgePoly, edgeHit.edgeIdx);
+    var hasCandidates = !!(edgePoly && edgePoly._shrinkCandidates);
+    if (orient && hasCandidates) {
+      if (PolygonTool.startEdgeDrag(_currentPage, edgeHit.polyIdx, edgeHit.edgeIdx)) {
+        Viewer.onOverlayMouseMove(_handleDragMove);
+        _bindDragEnd();
+        Viewer.requestRedraw();
+        var wrap3 = document.getElementById("viewer-wrap");
+        if (wrap3) wrap3.style.cursor = orient === "horizontal" ? "ns-resize" : "ew-resize";
+        return;
+      }
+    }
     var newIdx = PolygonTool.insertVertex(_currentPage, edgeHit.polyIdx, edgeHit.edgeIdx, edgeHit.point);
     if (newIdx >= 0) {
       PolygonTool.startDrag(_currentPage, edgeHit.polyIdx, newIdx);
@@ -721,8 +740,17 @@ function _handleOverlayClick(e) {
 }
 
 function _handleDragMove(e) {
-  if (!PolygonTool.isDragging()) return;
   var pt = Viewer.eventToPdfCoords(e);
+
+  if (PolygonTool.isEdgeDragging()) {
+    // Edge drag has no vector-snap overlay — it follows the pointer
+    // freely and snaps to wall-candidate detents on release only.
+    PolygonTool.moveEdgeDrag(pt);
+    Viewer.requestRedraw();
+    return;
+  }
+
+  if (!PolygonTool.isDragging()) return;
   // Snap during vertex drag
   var snapRadius = 12 / (Viewer.getZoom() * (150 / 72));
   var snap = VectorSnap.findSnap(_currentPage, pt, snapRadius);
@@ -735,20 +763,33 @@ function _handleDragMove(e) {
 function _bindDragEnd() {
   function onUp() {
     window.removeEventListener("mouseup", onUp);
+    var wrap = document.getElementById("viewer-wrap");
+    var cursorMap = {
+      measure: "crosshair",
+      window: "crosshair",
+      calibrate: "crosshair",
+      ruler: "crosshair",
+      navigate: "default"
+    };
+
+    if (PolygonTool.isEdgeDragging()) {
+      var snap = PolygonTool.endEdgeDrag();
+      setStatus(snap.snapped ? "Edge snapped to wall candidate." : "Edge moved.", "ready");
+      _snapTarget = null;
+      Viewer.onOverlayMouseMove(_handleOverlayMouseMove);
+      if (wrap) wrap.style.cursor = cursorMap[_currentTool] || "default";
+      _refreshMeasurements();
+      ProjectStore.savePolygons(_currentPage, PolygonTool.getPolygons(_currentPage));
+      Viewer.requestRedraw();
+      return;
+    }
+
     if (PolygonTool.isDragging()) {
       var mergeRadius = 10 / (Viewer.getZoom() * (150 / 72));
       var merged = PolygonTool.endDrag(mergeRadius);
       if (merged) setStatus("Vertices merged", "ready");
       _snapTarget = null; // clear snap indicator
       Viewer.onOverlayMouseMove(_handleOverlayMouseMove);
-      var wrap = document.getElementById("viewer-wrap");
-      var cursorMap = {
-        measure: "crosshair",
-        window: "crosshair",
-        calibrate: "crosshair",
-        ruler: "crosshair",
-        navigate: "default"
-      };
       if (wrap) wrap.style.cursor = cursorMap[_currentTool] || "default";
       // Update measurements and save
       _refreshMeasurements();
@@ -1193,6 +1234,12 @@ function _handleOverlayMouseMove(e) {
   // while the polyline tool is active, since that tool ignores drag-edit
   // hit-tests (see _handleOverlayClick). Showing the move/cell cursor there
   // would mislead the user.
+  //
+  // Cursor vocabulary (C7a):
+  //   move      — over a vertex (drag vertex)
+  //   ew-resize — over a vertical orthogonal edge of a shrink-wrap polygon (edge-drag, x-axis)
+  //   ns-resize — over a horizontal orthogonal edge of a shrink-wrap polygon (edge-drag, y-axis)
+  //   cell      — over any edge without an edge-drag affordance (insert-vertex fallback)
   var wrap = document.getElementById("viewer-wrap");
   if (!PolygonTool.isDrawing() && !_rectStart && _currentTool !== "polyline") {
     var vertHit = PolygonTool.hitTestVertex(_currentPage, pt, hitRadius);
@@ -1202,7 +1249,15 @@ function _handleOverlayMouseMove(e) {
     }
     var edgeHit = PolygonTool.hitTestEdge(_currentPage, pt, hitRadius);
     if (edgeHit) {
-      if (wrap) wrap.style.cursor = "cell";
+      var polysForHover = PolygonTool.getPolygons(_currentPage);
+      var hoverPoly = polysForHover[edgeHit.polyIdx];
+      var hoverOrient = PolygonTool.edgeOrientation(hoverPoly, edgeHit.edgeIdx);
+      var hoverHasCands = !!(hoverPoly && hoverPoly._shrinkCandidates);
+      if (hoverOrient && hoverHasCands) {
+        if (wrap) wrap.style.cursor = hoverOrient === "horizontal" ? "ns-resize" : "ew-resize";
+      } else if (wrap) {
+        wrap.style.cursor = "cell";
+      }
       return;
     }
   }
@@ -2114,7 +2169,16 @@ function autoDetect() {
 
       if (wrap && wrap.polygon) {
         var polyArea = _polygonArea(wrap.polygon);
-        _placeDetectedOutline({ path: wrap.polygon, area: polyArea }, 0, 1, textItems);
+        var shrinkCandidates = {
+          vert: wrap.wallVertPositions || [],
+          horiz: wrap.wallHorizPositions || []
+        };
+        _placeDetectedOutline(
+          { path: wrap.polygon, area: polyArea, shrinkCandidates: shrinkCandidates },
+          0,
+          1,
+          textItems
+        );
         return;
       }
 
@@ -2200,6 +2264,15 @@ function _placeDetectedOutline(candidate, idx, total, textItems) {
     if (autoTag.preset) {
       PolygonTool.setAssemblyPreset(_currentPage, newPolyIdx, autoTag.preset);
     }
+  }
+
+  // C7 — attach wall-candidate arrays so subsequent edge-drag interactions
+  // can snap through the shrink-wrap detents. Only present when the
+  // polygon came from the shrink-wrap path (not the closed-polygon
+  // fallback), so hand-edited polygons keep their legacy click-to-insert
+  // behavior.
+  if (newPolyIdx >= 0 && candidate.shrinkCandidates) {
+    PolygonTool.setShrinkCandidates(_currentPage, newPolyIdx, candidate.shrinkCandidates);
   }
 
   _refreshMeasurements();

--- a/js/app.mjs
+++ b/js/app.mjs
@@ -2114,7 +2114,7 @@ function autoDetect() {
 
       if (wrap && wrap.polygon) {
         var polyArea = _polygonArea(wrap.polygon);
-        _placeDetectedOutline({ path: wrap.polygon, area: polyArea }, 0, 1);
+        _placeDetectedOutline({ path: wrap.polygon, area: polyArea }, 0, 1, textItems);
         return;
       }
 
@@ -2122,7 +2122,7 @@ function autoDetect() {
       // proves itself in real use; then retire per MAGIC.md C5 discussion).
       var candidates = VectorSnap.getClosedPathsByArea(pageNum, size.width, size.height);
       if (candidates.length > 0) {
-        _placeDetectedOutline(candidates[0], 0, 1);
+        _placeDetectedOutline(candidates[0], 0, 1, textItems);
         setStatus(
           "Shrink-wrap did not find wall pairs (" +
             (wrap ? wrap.reason : "no drawing segments") +
@@ -2152,7 +2152,7 @@ function _polygonArea(pts) {
   return Math.abs(a) / 2;
 }
 
-function _placeDetectedOutline(candidate, idx, total) {
+function _placeDetectedOutline(candidate, idx, total, textItems) {
   // Remove the previous detected polygon if cycling
   var polys = PolygonTool.getPolygons(_currentPage);
   for (var i = polys.length - 1; i >= 0; i--) {
@@ -2183,14 +2183,98 @@ function _placeDetectedOutline(candidate, idx, total) {
   }
   PolygonTool.closePolygon();
 
+  // AT-2 / AT-3: auto-tag the placed polygon from the sheet's classification
+  // + title keywords. Slab / roof / wall component tag + building/garage
+  // scope + a wood-2x6 default preset for exterior walls. Fills in what
+  // Andy calls "automated polygon data" so a user can click Auto-Detect
+  // and immediately hand the result to the BEAMweb bridge without
+  // additional manual tagging.
+  var polysNow = PolygonTool.getPolygons(_currentPage);
+  var newPolyIdx = polysNow.length - 1;
+  var autoTag = _autoTagFromPage(_currentPage, textItems);
+  if (newPolyIdx >= 0 && autoTag.component) {
+    PolygonTool.setComponent(_currentPage, newPolyIdx, autoTag.component);
+    if (autoTag.scope === "garage") {
+      PolygonTool.setScope(_currentPage, newPolyIdx, "garage");
+    }
+    if (autoTag.preset) {
+      PolygonTool.setAssemblyPreset(_currentPage, newPolyIdx, autoTag.preset);
+    }
+  }
+
   _refreshMeasurements();
   ProjectStore.savePolygons(_currentPage, PolygonTool.getPolygons(_currentPage));
   Viewer.requestRedraw();
 
+  // AT-1: switch to polygon-edit ("measure") mode so the user is in the
+  // right context to refine the polygon — drag vertices today, drag edges
+  // once C7 ships. Avoids the "D pressed, polygon appeared, now what?"
+  // disorientation.
+  setTool("measure");
+
   var areaM2 = ScaleManager.pdfAreaToM2(_currentPage, candidate.area);
   var areaStr = areaM2 !== null ? areaM2.toFixed(1) + " m\u00B2" : "(uncalibrated)";
   var hint = total > 1 ? " Press D again to cycle (" + (idx + 1) + "/" + total + ")." : "";
-  setStatus("Outline: " + areaStr + ", " + verts.length + " vertices." + hint, "ready");
+  var tagStr = "";
+  if (autoTag && autoTag.component) {
+    tagStr = " tagged " + autoTag.component;
+    if (autoTag.scope === "garage") tagStr += " (garage)";
+    if (autoTag.preset) tagStr += " · " + autoTag.preset;
+    tagStr += ".";
+  }
+  setStatus("Outline: " + areaStr + ", " + verts.length + " vertices." + tagStr + hint, "ready");
+}
+
+/**
+ * AT-2: derive the polygon's component tag + scope + assembly preset
+ * from the page's sheet classification and title + page-text keywords.
+ * Returns a `{component, scope, preset}` triple; any field may be null /
+ * "building" default when classification doesn't resolve a specific value.
+ *
+ * Mapping table (MAGIC.md §0 AT prerequisites):
+ *   plan + foundation       → slab_foundation,    building|garage, no preset
+ *   plan + roof             → roof_plan,          building|garage, no preset
+ *   plan + main/upper/...   → slab_above_grade,   building|garage, no preset
+ *   elevation               → wall_exterior,      building|garage, wood_2x6
+ *   "garage" text on page   → scope = "garage" regardless of classification
+ *   anything else           → no auto-tag; user picks manually.
+ *
+ * Garage detection scans the FULL page text (not just the truncated
+ * title) because title-blocks on garage sheets are frequently blank in
+ * Calgary-style sample sets — the garage keyword only shows up as a
+ * drawing caption ("GARAGE FLOOR PLAN") or callout ("GARAGE SLAB").
+ * Trade-off: attached-garage PDFs (where the main-floor plan has a
+ * "GARAGE" room label INSIDE the drawing) will also flip scope to
+ * garage, which is wrong for the house polygon — user can manually
+ * override via the Summary Table scope dropdown. Opt for auto-correct-
+ * most-cases over miss-all-garages.
+ */
+function _autoTagFromPage(pageNum, textItems) {
+  var page = ProjectStore.getPage(pageNum);
+  if (!page) return { component: null, scope: "building", preset: null };
+  var cls = page.classification;
+  var title = (page.sheetTitle || "").toLowerCase();
+  var isGarage = /\bgarage\b/.test(title) || _pageTextContainsGarage(textItems);
+  var scope = isGarage ? "garage" : "building";
+
+  if (cls === "plan") {
+    if (/\bfoundation\b/.test(title)) return { component: "slab_foundation", scope: scope, preset: null };
+    if (/\broof\b/.test(title)) return { component: "roof_plan", scope: scope, preset: null };
+    if (/\b(main|upper|lower|basement|ground|floor)\b/.test(title) || isGarage) {
+      return { component: "slab_above_grade", scope: scope, preset: null };
+    }
+  } else if (cls === "elevation") {
+    return { component: "wall_exterior", scope: scope, preset: "wood_2x6" };
+  }
+  return { component: null, scope: scope, preset: null };
+}
+
+function _pageTextContainsGarage(textItems) {
+  if (!textItems || !textItems.length) return false;
+  for (var i = 0; i < textItems.length; i++) {
+    if (/\bgarage\b/i.test(textItems[i].str || "")) return true;
+  }
+  return false;
 }
 
 /* ── Auto-calibrate from dimension strings (MAGIC C3) ───── */

--- a/js/polygon-tool.mjs
+++ b/js/polygon-tool.mjs
@@ -110,6 +110,10 @@ export function startPolygon(pageNum, label, opts) {
     // select. Aggregator routes garage-scoped polygons to the garage_*
     // dim counterparts, reusing the same component taxonomy.
     scope: opts.scope === "garage" ? "garage" : "building",
+    // C7 — wall-candidate positions from shrink-wrap, for edge-scrub
+    // snap detents. `{vert: [...x-coords...], horiz: [...y-coords...]}`
+    // when the polygon came from Auto-Detect; null for hand-drawn.
+    _shrinkCandidates: null,
     _pageNum: pageNum
   });
   _colorIdx++;
@@ -730,6 +734,150 @@ export function isDragging() {
   return _dragState !== null;
 }
 
+/* ── C7 edge drag (shrink-wrap candidate snap) ────────── */
+
+var _edgeDragState = null; // { pageNum, polyIdx, edgeIdx, origin, axis, v1Idx, v2Idx }
+
+/**
+ * Classify a closed-polygon edge as "horizontal" (constant y), "vertical"
+ * (constant x), or null (diagonal). Orthogonality tolerance is 0.5 pt to
+ * match shrinkWrapBuilding's orthogonal-segment filter.
+ */
+export function edgeOrientation(poly, edgeIdx) {
+  if (!poly || !poly.closed) return null;
+  var verts = poly.vertices;
+  var n = verts.length;
+  if (n < 3 || edgeIdx < 0 || edgeIdx >= n) return null;
+  var a = verts[edgeIdx];
+  var b = verts[(edgeIdx + 1) % n];
+  var dx = Math.abs(b.x - a.x);
+  var dy = Math.abs(b.y - a.y);
+  if (dy < 0.5 && dx >= 1) return "horizontal";
+  if (dx < 0.5 && dy >= 1) return "vertical";
+  return null;
+}
+
+/** Attach shrink-wrap wall-candidate arrays to an existing polygon. */
+export function setShrinkCandidates(pageNum, polyIdx, candidates) {
+  var polys = _polygons[pageNum];
+  if (!polys || !polys[polyIdx]) return;
+  polys[polyIdx]._shrinkCandidates = candidates || null;
+}
+
+export function getShrinkCandidates(pageNum, polyIdx) {
+  var polys = _polygons[pageNum];
+  if (!polys || !polys[polyIdx]) return null;
+  return polys[polyIdx]._shrinkCandidates || null;
+}
+
+/**
+ * Start dragging a whole edge perpendicular to itself. Both endpoints
+ * move together. Only meaningful for orthogonal edges — caller should
+ * check `edgeOrientation()` first. Saves undo state.
+ */
+export function startEdgeDrag(pageNum, polyIdx, edgeIdx) {
+  var polys = _polygons[pageNum];
+  if (!polys || !polys[polyIdx]) return false;
+  var poly = polys[polyIdx];
+  var orient = edgeOrientation(poly, edgeIdx);
+  if (!orient) return false;
+  var v1Idx = edgeIdx;
+  var v2Idx = (edgeIdx + 1) % poly.vertices.length;
+  var origin = orient === "horizontal" ? poly.vertices[v1Idx].y : poly.vertices[v1Idx].x;
+  _pushUndo(pageNum);
+  _edgeDragState = {
+    pageNum: pageNum,
+    polyIdx: polyIdx,
+    edgeIdx: edgeIdx,
+    axis: orient, // "horizontal" (move in y) | "vertical" (move in x)
+    v1Idx: v1Idx,
+    v2Idx: v2Idx,
+    origin: origin
+  };
+  return true;
+}
+
+/**
+ * Free-follow the pointer during edge drag. Updates both endpoints'
+ * perpendicular coord to the pointer position; preserves the other
+ * coord on each vertex (keeps the edge axis-aligned).
+ */
+export function moveEdgeDrag(pt) {
+  if (!_edgeDragState) return;
+  var polys = _polygons[_edgeDragState.pageNum];
+  var poly = polys && polys[_edgeDragState.polyIdx];
+  if (!poly) return;
+  var v1 = poly.vertices[_edgeDragState.v1Idx];
+  var v2 = poly.vertices[_edgeDragState.v2Idx];
+  if (_edgeDragState.axis === "horizontal") {
+    v1.y = pt.y;
+    v2.y = pt.y;
+  } else {
+    v1.x = pt.x;
+    v2.x = pt.x;
+  }
+}
+
+/**
+ * End the edge drag. If the polygon has shrink-wrap candidates, snap the
+ * edge's perpendicular coord to the nearest candidate — unconditionally.
+ * The edge-drag metaphor is "scrub through wall detents," so the edge
+ * always settles on a detent. (If the user wants free placement, they
+ * click-insert-vertex instead and drag that vertex.) When the polygon
+ * has no candidates, leave the free-drag position.
+ *
+ * @returns {{snapped: boolean, to: number|null}}
+ */
+export function endEdgeDrag() {
+  if (!_edgeDragState) return { snapped: false, to: null };
+
+  var polys = _polygons[_edgeDragState.pageNum];
+  var poly = polys && polys[_edgeDragState.polyIdx];
+  var result = { snapped: false, to: null };
+
+  if (poly) {
+    var v1 = poly.vertices[_edgeDragState.v1Idx];
+    var v2 = poly.vertices[_edgeDragState.v2Idx];
+    var cands =
+      poly._shrinkCandidates && _edgeDragState.axis === "horizontal"
+        ? poly._shrinkCandidates.horiz
+        : poly._shrinkCandidates && _edgeDragState.axis === "vertical"
+          ? poly._shrinkCandidates.vert
+          : null;
+
+    if (cands && cands.length > 0) {
+      var cur = _edgeDragState.axis === "horizontal" ? v1.y : v1.x;
+      var bestDist = Infinity;
+      var bestVal = null;
+      for (var i = 0; i < cands.length; i++) {
+        var d = Math.abs(cands[i] - cur);
+        if (d < bestDist) {
+          bestDist = d;
+          bestVal = cands[i];
+        }
+      }
+      if (bestVal != null) {
+        if (_edgeDragState.axis === "horizontal") {
+          v1.y = bestVal;
+          v2.y = bestVal;
+        } else {
+          v1.x = bestVal;
+          v2.x = bestVal;
+        }
+        result.snapped = true;
+        result.to = bestVal;
+      }
+    }
+  }
+
+  _edgeDragState = null;
+  return result;
+}
+
+export function isEdgeDragging() {
+  return _edgeDragState !== null;
+}
+
 function _getActivePoly() {
   if (!_activePolyId) return null;
   var polys = _polygons[_activePage] || [];
@@ -769,6 +917,8 @@ export function loadPolygons(pageNum, polygons) {
       sheet_id: p.sheet_id || null,
       sheet_class: p.sheet_class || null,
       assembly_preset: p.assembly_preset || null,
+      scope: p.scope === "garage" ? "garage" : "building",
+      _shrinkCandidates: p._shrinkCandidates || null,
       _pageNum: pageNum
     };
   });

--- a/js/shrink-wrap.mjs
+++ b/js/shrink-wrap.mjs
@@ -50,6 +50,14 @@ var WALL_PARALLEL_MIN_OFFSET = 3;
 var WALL_PARALLEL_MAX_OFFSET = 25;
 var WALL_OVERLAP_MIN = 40;
 
+// Cluster wall-candidate positions within this many pt when surfacing
+// them to C7's edge-scrub UI. Raw wall-segment positions include partner
+// strokes (inner + outer face of every wall drawn as two parallels), so
+// every real wall produces two closely-spaced candidates; 5pt coalesces
+// partner-pair duplicates and tick-mark noise without collapsing real
+// distinct walls (minimum partition-wall spacing in practice > 10pt).
+var WALL_CANDIDATE_CLUSTER_RADIUS = 5;
+
 /**
  * @param {Array} segments   — [{x1,y1,x2,y2}]
  * @param {Array} textItems  — [{str, x, y, width, height}]  (unused in v1, reserved for later)
@@ -124,7 +132,18 @@ export function classifyLayers(segments, textItems, pageW, pageH, opts) {
  * @param {Array} drawingSegments — from classifyLayers().drawingSegments
  * @param {Object} drawingAreaBbox — from classifyLayers().drawingAreaBbox
  * @param {Object} [opts]
- * @returns {{polygon, bbox, wallHorizCount, wallVertCount, reason} | null}
+ * @returns {{
+ *   polygon, bbox,
+ *   wallHorizCount, wallVertCount,
+ *   wallVertPositions, wallHorizPositions,
+ *   reason
+ * } | null}
+ *
+ * wallVertPositions / wallHorizPositions are the perpendicular coords
+ * (x for vertical walls, y for horizontal walls) of detected wall-pair
+ * clusters, sorted ascending and clustered within 5pt. C7's edge-scrub
+ * UI uses these as snap detents: dragging a vertical polygon edge snaps
+ * through wallVertPositions; a horizontal edge through wallHorizPositions.
  */
 export function shrinkWrapBuilding(drawingSegments, drawingAreaBbox, opts) {
   opts = opts || {};
@@ -209,13 +228,56 @@ export function shrinkWrapBuilding(drawingSegments, drawingAreaBbox, opts) {
     { x: minX, y: maxY }
   ];
 
+  var wallVertPositions = _clusterPositions(wallVert, "x", WALL_CANDIDATE_CLUSTER_RADIUS);
+  var wallHorizPositions = _clusterPositions(wallHoriz, "y", WALL_CANDIDATE_CLUSTER_RADIUS);
+
   return {
     polygon: polygon,
     bbox: { minX: minX, minY: minY, maxX: maxX, maxY: maxY },
     wallHorizCount: wallHoriz.length,
     wallVertCount: wallVert.length,
+    wallVertPositions: wallVertPositions,
+    wallHorizPositions: wallHorizPositions,
     reason: null
   };
+}
+
+/**
+ * Collapse perpendicular-axis values (x of vertical walls, y of
+ * horizontal walls) into a sorted deduped list. Values within
+ * `clusterRadius` pt of each other collapse to their mean — partner
+ * strokes of the same wall (inner + outer face) + duplicate segments
+ * from the same stroke would otherwise show up as two adjacent detents
+ * that feel sticky under a drag.
+ */
+function _clusterPositions(segs, axisVal, clusterRadius) {
+  if (!segs || segs.length === 0) return [];
+  var vals = segs
+    .map(function (s) {
+      return s[axisVal];
+    })
+    .slice()
+    .sort(function (a, b) {
+      return a - b;
+    });
+
+  var out = [];
+  var clusterStart = vals[0];
+  var sum = vals[0];
+  var n = 1;
+  for (var i = 1; i < vals.length; i++) {
+    if (vals[i] - clusterStart <= clusterRadius) {
+      sum += vals[i];
+      n += 1;
+    } else {
+      out.push(sum / n);
+      clusterStart = vals[i];
+      sum = vals[i];
+      n = 1;
+    }
+  }
+  out.push(sum / n);
+  return out;
 }
 
 /**

--- a/schema/scripts/diag-shrink-wrap.mjs
+++ b/schema/scripts/diag-shrink-wrap.mjs
@@ -34,7 +34,9 @@ async function runFixture(fixturePath) {
   console.log(`  layer-peel:     ${layers.summary.drawing} drawing segs`);
   if (!wrap || !wrap.polygon) {
     console.log(`  shrink-wrap:    FAILED — ${wrap ? wrap.reason : "null result"}`);
-    console.log(`                  wall candidates: H=${wrap ? wrap.wallHorizCount : 0}, V=${wrap ? wrap.wallVertCount : 0}`);
+    console.log(
+      `                  wall candidates: H=${wrap ? wrap.wallHorizCount : 0}, V=${wrap ? wrap.wallVertCount : 0}`
+    );
     return;
   }
 
@@ -50,6 +52,14 @@ async function runFixture(fixturePath) {
   for (const v of wrap.polygon) {
     console.log(`                     (${v.x.toFixed(1)}, ${v.y.toFixed(1)})`);
   }
+  console.log(
+    `                  wallVertPositions (${wrap.wallVertPositions.length} detents, clustered 5pt):  ` +
+      wrap.wallVertPositions.map((v) => v.toFixed(1)).join(", ")
+  );
+  console.log(
+    `                  wallHorizPositions (${wrap.wallHorizPositions.length} detents, clustered 5pt): ` +
+      wrap.wallHorizPositions.map((v) => v.toFixed(1)).join(", ")
+  );
 
   // Compare to the prior drawing-area bbox to show how much the
   // shrink-wrap tightened.


### PR DESCRIPTION
## Summary

Two-stage polish pass on top of PR #12's shrink-wrap Auto-Detect. Builds the "Auto-Detect places a polygon that's ready for the BEAMweb bridge" end-to-end loop, then adds interactive edge-scrub for per-edge refinement. 3 code commits + 2 doc commits; branch tip `62007dd`.

- **AT-1 / AT-2 / AT-3** (`81d3358`) — Auto-Detect now auto-tags the placed polygon from sheet classification + title/page-text keywords, switches the active tool to polygon-edit mode post-detect, and defaults exterior-wall polygons to `wood_2x6` assembly preset. Single-click workflow: load → Auto-Calibrate → Auto-Detect → polygon is tagged + scoped + presetted and ready to hand to BEAMweb.
- **C7a + C7b** (`bafaaa7`) — Per-edge drag handles on detected polygons that snap to wall-candidate detents computed internally by `shrinkWrapBuilding`. `wallVertPositions` / `wallHorizPositions` are now returned by shrink-wrap (clustered within 5pt). `polygon-tool` gains an edge-drag API; `app.mjs` routes orthogonal edge-clicks to edge-drag with OS-native resize cursors (`ew-resize` / `ns-resize`). Hand-drawn polygons keep the legacy insert-vertex-on-edge-click behavior.
- **C7 Alt-click opt-out** (`5d6f8db`) — Option/Alt during edge-click bypasses edge-drag into the legacy insert-vertex path. Needed for capturing wall jogs (e.g. small garage-door recesses) that would otherwise require nudging the whole edge. Hover cursor mirrors the modifier. Stopgap until C7c surfaces both actions via a popup.

Also fixes a latent bug in `loadPolygons` where polygon `scope` wasn't round-tripping through project save/load (garage polygons imported as "building").

## Verification

- `npm run test:dim-extract` + `npm run test:layer-peel`: ALL PASS
- `node schema/scripts/diag-shrink-wrap.mjs`: p9 14V/32H detents, p4 28V/33H — 5pt clustering verified against raw wall counts
- Playwright MCP on `docs/sample.pdf`:
  - p9 FOUNDATION PLAN → polygon tagged `slab_foundation`, 15V/34H candidates attached; left-edge drag x=120.5→135 snaps to 141.2 detent; top-edge drag y=19.5→55 snaps to 65.4 detent; undo restores
  - p5 EAST ELEVATION → polygon tagged `wall_exterior` + `wood_2x6` preset, 21V/48H candidates attached
  - hand-drawn polygon → no candidates; edge-drag state machine no-ops gracefully; click router falls through to legacy insert-vertex path
- Zero console errors across the session

## Still on MAGIC.md (parked — will PR separately)

- **C7c** — ArchiCad-style popup (replaces Alt-modifier; also adds delete-vertex, the one real functional gap today)
- **C7d** — Oculus "tighten one step inward" button
- **C6 / C8** — on hold / deferred

## Test plan

- [ ] Load `docs/sample.pdf`, navigate to p9 FOUNDATION PLAN
- [ ] Press `A` (Auto-Calibrate) → scale confirms 1:64
- [ ] Press `D` (Auto-Detect) → polygon tagged `slab_foundation` appears; tool switches to measure
- [ ] Hover polygon edges — vertical edges show `ew-resize` (↔), horizontal show `ns-resize` (↕)
- [ ] Drag a side edge inward → edge snaps to nearest wall detent on release
- [ ] Undo (Ctrl/⌘-Z) returns the edge to its origin
- [ ] Hold Option/Alt, hover an edge → cursor changes to `cell`; click inserts a new vertex at that point
- [ ] Navigate to p5 EAST ELEVATION, repeat — polygon tagged `wall_exterior · wood_2x6`
- [ ] Draw a hand-drawn polygon (`M`, polygon method) → edges show `cell` cursor; click-edge still inserts a vertex (legacy UX intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
