### PR TITLE
EPD-Parser §9.5 fix-list + db-fallbacks architecture (C-fb1..C-fb4)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -50,7 +50,7 @@ jobs:
 
           # Runtime data (staged from authoritative sources)
           cp -r schema/materials _site/data/schema/
-          cp -r schema/lookups/. _site/data/schema/lookups/
+          cp schema/lookups/*.json _site/data/schema/lookups/
           cp schema/material.schema.json _site/data/schema/
           cp schema/sample.json _site/data/schema/
           cp "docs/csv files from BEAM/Footings & Slabs.csv" _site/data/beam/footings-slabs.csv

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ logs/
 
 # Playwright verification screenshots at repo root (one-off, not documentation)
 /epd-*.png
+/db-*.png
+/c7d-*.png
 # EPD-Parser calibration JSON dumps (ad-hoc analysis from Playwright eval)
 /epd-*.json
 

--- a/bfcastyles.css
+++ b/bfcastyles.css
@@ -3368,8 +3368,11 @@ html.app-matrix body {
   color: rgb(187, 247, 208);
 }
 .db-chip-source-default {
-  background: rgba(250, 204, 21, 0.32);
-  color: rgb(254, 240, 138);
+  /* Magenta — deliberately distinct from the yellow .db-fresh-chip-new
+     used on Trust-committed rows, so the user can't confuse "this row is
+     a new commit" with "this field came from the catalogue not the EPD". */
+  background: rgba(232, 121, 249, 0.32);
+  color: rgb(245, 208, 254);
 }
 .db-chip-source-calc {
   background: rgba(34, 211, 238, 0.32);
@@ -5955,8 +5958,11 @@ details.dep-details pre {
    glance without crowding the input. */
 .app-epdparser .epd-form-row input.epd-source-default,
 .app-epdparser .epd-form-row select.epd-source-default {
-  background: rgba(250, 204, 21, 0.1); /* soft amber */
-  border-left: 3px solid rgb(250, 204, 21);
+  /* Magenta — matches the .db-chip-source-default color in the database
+     viewer, kept distinct from the yellow .db-row-fresh tint used on
+     Trust-committed rows. */
+  background: rgba(232, 121, 249, 0.1);
+  border-left: 3px solid rgb(232, 121, 249);
 }
 .app-epdparser .epd-form-row input.epd-source-calc,
 .app-epdparser .epd-form-row select.epd-source-calc {

--- a/bfcastyles.css
+++ b/bfcastyles.css
@@ -5905,6 +5905,31 @@ details.dep-details pre {
   font-family: "Courier New", monospace;
 }
 
+/* §10.1 provenance source classes — color-coded so the user always sees
+   which fields came from the EPD itself vs the db-fallbacks catalogue
+   vs a calculated derivation vs their own typed override. Default (no
+   class) means epd_direct or unset — rendered with the standard form-
+   input chrome above. The three non-default classes layer a soft tint
+   + a left border accent + a corner badge so the cue is visible at a
+   glance without crowding the input. */
+.app-epdparser .epd-form-row input.epd-source-default,
+.app-epdparser .epd-form-row select.epd-source-default {
+  background: rgba(250, 204, 21, 0.1); /* soft amber */
+  border-left: 3px solid rgb(250, 204, 21);
+}
+.app-epdparser .epd-form-row input.epd-source-calc,
+.app-epdparser .epd-form-row select.epd-source-calc {
+  background: rgba(34, 211, 238, 0.1); /* soft cyan */
+  border-left: 3px solid rgb(34, 211, 238);
+}
+.app-epdparser .epd-form-row input.epd-source-edit,
+.app-epdparser .epd-form-row select.epd-source-edit {
+  /* User overrode an auto-fill — render as authoritative (no tint) but
+     keep a subtle green accent so the user knows the field has been
+     touched since the last auto-fill pass. */
+  border-left: 3px solid rgb(132, 204, 22);
+}
+
 /* P2 — Capture button + status bar at the bottom of the form pane. */
 .app-epdparser .epd-form-actions {
   display: flex;

--- a/bfcastyles.css
+++ b/bfcastyles.css
@@ -3339,6 +3339,47 @@ html.app-matrix body {
   color: rgb(254, 215, 170);
 }
 
+/* §10.1 provenance chips — shown both as a static legend in the
+   toolbar (so users land on the page knowing what each color means)
+   and inline next to per-field values in the expanded detail panel.
+   The legend (.db-source-legend) groups four chips horizontally;
+   inline chips get the same per-source variants. */
+.db-source-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.db-source-legend > span,
+.db-chip-source-epd,
+.db-chip-source-default,
+.db-chip-source-calc,
+.db-chip-source-edit {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: "Helvetica Neue", sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+}
+.db-chip-source-epd {
+  background: rgba(34, 197, 94, 0.2);
+  color: rgb(187, 247, 208);
+}
+.db-chip-source-default {
+  background: rgba(250, 204, 21, 0.32);
+  color: rgb(254, 240, 138);
+}
+.db-chip-source-calc {
+  background: rgba(34, 211, 238, 0.32);
+  color: rgb(165, 243, 252);
+}
+.db-chip-source-edit {
+  background: rgba(132, 204, 22, 0.32);
+  color: rgb(217, 249, 157);
+}
+
 /* Group-header rows in the database viewer. Styled to echo the BEAMweb
    assembly-tab group headers: rounded container, padded away from the
    page edge, hover affordance, expanded-state contrast. The banner lives

--- a/database.html
+++ b/database.html
@@ -91,6 +91,16 @@
         <div class="db-result-bar">
           <span id="db-result-count" class="db-result-count">—</span>
           <span class="db-spacer"></span>
+          <span
+            class="db-source-legend"
+            title="Provenance markers shown on field values in the expanded detail panel. Per-source fields filled by EPD-Parser via the §10 fallback layer carry these chips."
+          >
+            <span class="db-chip-source-epd">EPD</span>
+            <span class="db-chip-source-default">DEFAULT</span>
+            <span class="db-chip-source-calc">CALC</span>
+            <span class="db-chip-source-edit">EDIT</span>
+          </span>
+          <span class="db-spacer"></span>
           <span class="db-hint">
             Click a row to expand full record · <span class="db-hint-kbd">scroll horizontally</span> within the
             per-stage matrix
@@ -132,7 +142,8 @@
             <div><b>Captured at:</b> <span id="db-verify-captured"></span></div>
           </div>
           <div class="db-verify-hint">
-            Stub: shows the candidate JSON the parser captured. P3 will replace this with the side-by-side per-field diff (existing record vs incoming) per workplan Database.md §5.
+            Stub: shows the candidate JSON the parser captured. P3 will replace this with the side-by-side per-field
+            diff (existing record vs incoming) per workplan Database.md §5.
           </div>
           <pre id="db-verify-json" class="db-verify-json"></pre>
         </div>

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -6,27 +6,34 @@
 
 ## Agent handoff (read this first)
 
-**You are picking up after a productive 2026-04-28 EOD session.** §7.7 persistence + §5.6 hierarchical extraction + §9.5 fix #1 (older BC Wood) all shipped. Coverage moved 50.3% → 57.6% metadata, 30.7% → 36.0% impacts. Trust commits are now catalogue-visible end-to-end. Tomorrow's job: continue down the §9.5 fix-list.
+**You are picking up after a productive 2026-04-29 morning session.** §9.5 fix #2 (EU/IBU extractor), fix #3 (ISO 21930 indicator codes + comma-thousand parser), fix #4 (EPD-IES per-glyph tolerance) all shipped. Coverage moved 57.6% → 61.0% metadata, 36.0% → 49.0% impacts. Andy then surfaced the architectural insight that drives **today's main work — see §10**.
+
+**Andy's insight (2026-04-29 mid-day):** many properties the schema can hold (density, thermal conductivity, heat capacity, embodied energy, embodied carbon for non-product baselines) are **not** EPD-specific and won't be in most EPD documents. Pushing regex extraction to fill those gaps is the wrong direction. We need a curated reference catalogue (`db-fallbacks.json`) that fills those slots only when the EPD itself is silent — provenance-marked so the user always sees what came from the EPD vs the catalogue. **§10 documents this in full**, including the four-source `source` enum (`epd_direct` / `generic_default` / `calculated` / `user_edit`), the visual chip system, the verification-before-fallback harness upgrade, and the C-fb1..C-fb6 commit plan.
 
 **Branch + state:**
 
-- Branch: `Magic-Wand-Oculus` on remotes `openbuilding` (arossti/OpenBuilding) and `origin` (bfca-labs/at). Both pushed.
-- Tip at session end (2026-04-28 EOD): see §0 below for the most recent SHA.
-- Latest harness snapshot: [`docs/workplans/EPD-coverage-history/2026-04-28T23-15-14Z.md`](EPD-coverage-history/) — measured after §9.5 fix #1.
+- Branch: `EPD-PARSER-SPRINT` on remotes `openbuilding` (arossti/OpenBuilding) and `origin` (bfca-labs/at). Both pushed.
+- Tip at this point in 2026-04-29 mid-day: see §0 below for the latest SHA list.
+- Latest harness snapshot: [`docs/workplans/EPD-coverage-history/2026-04-29T11-07-01Z.md`](EPD-coverage-history/) — measured after §9.5 fix #4.
 
 **Read this order:**
 
 1. §0 — current state (what's shipped, what's pending, latest measured coverage)
-2. **§5.6 — Taxonomy + coarse-to-granular extraction order** (now shipped — the architecture rationale stays as forward-looking reference)
-3. §7.6 — Harness contract (the "no regex change ships unless coverage moves up" rule)
-4. §9.5 — calibration findings + ranked fix-list for per-format iteration
+2. **§10 — Fallback database (`db-fallbacks.json`) — provenance-marked defaults** (today's main architectural work; read in full before touching extract.mjs again)
+3. §7.6 — Harness contract (the "no regex change ships unless coverage moves up" rule; gets one new dimension via §10.3)
+4. §5.6 — Taxonomy + coarse-to-granular extraction order (shipped 2026-04-28; rationale + reference)
+5. §9.5 — calibration findings + remaining per-format fix-list (fix-list mostly cleared; remaining items are lower-leverage now that the catalogue is the headline)
 
-**Tomorrow's recommended sequence:**
+**Today's / next-session recommended sequence (from §10.6 commit plan):**
 
-1. **§9.5 fix #2 — EU/IBU per-format extractor** (45–60 min). Currently 1 EU-IBU sample falls through to extractCommon-only (4/14 metadata, 2/10 impacts). Write `extractEuIbu(text, rec)` modelled on extractEpdIntl: anchors are `Programme holder` / `Owner of the Declaration` / `Declaration number`. Sample: `EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf`.
-2. **§9.5 fix #3 — PE-NR / PE-R / WDP synonym expansion across NA family** (~20 min). Several NA samples populate GWP / ODP / AP / EP / SFP but miss PE-NR / PE-R / WDP. Likely indicator-code variants the existing regex doesn't cover.
-3. **§9.5 fix #4 — EPD-IES filename variant** (~15 min). The `EPD_document_EPD-IES-…__S-P-…__en.pdf` sibling of the S-P-10278 doc currently lands at 5/14 metadata; format detection is correctly EPD International but some metadata anchors don't fire on the filename-variant layout.
-4. **Sopra family is OCR-blocked** — Sopra-Cellulose / Sopra-ISO show 0 of everything because the PDFs are scanned-image with no extractable text layer. Skip until §9.5 P7 (OCR fallback) lands.
+1. **C-fb1 — XML → `db-fallbacks.json`** (~30 min). Convert the BfCA materials catalogue (XML import: ~200 entries × 20 groups) to a JSON file at `schema/lookups/db-fallbacks.json`, keyed by canonical `material_type` label. Variants stored as `variants[]` arrays. Update `package.json stage:data` + the Pages workflow to copy the file into `data/schema/lookups/`.
+2. **C-fb2 — Tier-9 fallback layer in `extract.mjs`** (~30 min). New `applyMaterialDefaults(rec)` step after `_extractIndicatorTotals`. Extend `setLookups()` signature. Source-mark every filled value as `generic_default`.
+3. **C-fb3 — Form-pane provenance UI in `epdparser.mjs`** (~45 min). Read `source` per field on render; apply CSS class. `_bindFormChange` flips source to `user_edit` on type. New CSS classes (`.epd-source-default`, `.epd-source-calc`, `.epd-source-edit`) in `bfcastyles.css`.
+4. **C-fb4 — Database-viewer chips + toolbar legend** (~30 min). Per-field source chips in expanded detail rows. Static legend in the toolbar header (`EPD ● DEFAULT ● CALC ● EDIT`).
+5. **C-fb5 — Harness upgrade with `expected/` ground-truth dir** (~45 min). Three new checks (extraction fidelity / defaults applied / no silent overrides). Empty `expected/` initially; checks skip when ground-truth file is absent.
+6. **C-fb6 — `applyCalculations(rec)` Tier 10** (gated on Andy supplying BEAM math; ~60 min once available).
+
+**§9.5 leftover fix-list (deprioritised behind §10):** Sopra family is OCR-blocked (Sopra-Cellulose / Sopra-ISO are scanned-image PDFs, zero text-layer items — defer to P7 OCR). Other regex tweaks are micro-leverage compared to landing the catalogue.
 
 **Hard rules — do not violate:**
 
@@ -62,36 +69,39 @@ npm run serve                                                     # local dev se
 
 ---
 
-## 0. Current state (2026-04-28 EOD)
+## 0. Current state (2026-04-29 mid-day)
 
 **Phases shipped** (chronological):
 
 - ✅ **P0 — Shell** — `epdparser.html` + `js/epdparser.mjs` ESM entry, drop-zone, status bar, viewer canvas reusing `js/pdf-loader.mjs` + `js/canvas-viewer.mjs`. Card on landing page (`Planning` badge).
 - ✅ **P1 — Text extraction** — `getTextContent()` per page wired into a sidebar dump panel. 10-sample calibration done (NA / EU-IBU / EPD International / NSF format families catalogued in §9.5).
 - ✅ **P2 — UX scaffold** — 60/40 layout (PDF left, schema-driven form right; window-resize listener now in `canvas-viewer.mjs`), 24-field form across 7 sections (reordered per §5.6 taxonomy 2026-04-28), IndexedDB auto-save (`state: "draft"`), Capture button promotes draft → captured. Manual-entry path works identically to auto-extract — both flow through `_bindFormChange` to the same candidate record then `Store.putPending`. Database viewer pending-changes panel + Trust / Trust + Verify stubs ([`Database.md`](Database.md) §4–§5).
-- ✅ **P3.1 — Regex auto-fill, totals + harness** — `js/epd/extract.mjs` with format detection (NA / EPD International / NSF / EU-IBU stub) and the 10-indicator impact-totals loop. `schema/scripts/test-epd-extract.mjs` regression harness walks all 30 sample EPDs and emits a per-sample coverage matrix.
+- ✅ **P3.1 — Regex auto-fill, totals + harness** — `js/epd/extract.mjs` with format detection (NA / EPD International / NSF / EU-IBU) and the 10-indicator impact-totals loop. `schema/scripts/test-epd-extract.mjs` regression harness walks all 30 sample EPDs and emits a per-sample coverage matrix.
 - ✅ **§5.6 — Hierarchical extraction (Tier 1 + Tier 2 trunk)** _(shipped 2026-04-28, `9fb6c88`)_. `extractType` populates `naming.display_name` + `classification.material_type` from page-1 head + a 21-pattern keyword vocabulary. `inferGroupPrefix` consumes Tier 2 + the `schema/lookups/material-type-to-group.json` and `display-name-keywords.json` files (primed via `Extract.setLookups()`) to populate `classification.group_prefix`. `extract()` refactored to run tier-by-tier (Type → Group → Manufacturer → Provenance → Identification → Methodology → Physical → Impacts). Form-pane sections reordered to match. `package.json stage:data` + `.github/workflows/deploy-pages.yml` now ship `schema/lookups/` to `data/schema/lookups/` for browser fetch.
 - ✅ **§7.7 — Trust persistence (catalogue-visible)** _(shipped 2026-04-28, `8c20ae5`)_. New `epd-committed-patches` IndexedDB store (`DB_VERSION` bumped to 3). `handleTrust` writes the committed record + index_entry + audit_meta + commit_type + committed_at, then optimistically pushes into `state.indexEntries` with a `_fresh: true` flag. New entries get a 6-char hex id minted via `_mintId6`; refresh commits merge the candidate over the existing record (candidate-wins-on-set, prior-wins-on-null) and replace in place. Boot-time `_mergeCommittedPatchesOnBoot` re-merges patches from prior sessions so the highlights survive reload. `.db-row-fresh` yellow tint + `NEW` / `UPDATED` chips next to the BEAM ID.
 - ✅ **§9.5 fix #1 — older BC Wood format** _(shipped 2026-04-28, `93217ac`)_. Six new English-label IMPACT_INDICATORS entries (Global warming potential / Ozone depletion / Eutrophication / Smog / Non-renewable fossil / Renewable biomass) catch the 2013 LVL / 2016 LSL AWC / 2016 WRC EPDs whose tables use English category names instead of EN 15804 indicator codes.
-- ✅ **`gwp_kgco2e` index-entry NaN fix** _(shipped 2026-04-28 EOD)_. Schema shape is `impacts.gwp_kgco2e.total = { value, source }` not a scalar; `_indexEntryFromRecord` now reads `gwp.total.value`. `functional_unit` similarly corrected to read from `impacts.functional_unit` first.
+- ✅ **`gwp_kgco2e` index-entry NaN fix** _(shipped 2026-04-28 EOD, `6196848`)_. Schema shape is `impacts.gwp_kgco2e.total = { value, source }` not a scalar; `_indexEntryFromRecord` now reads `gwp.total.value`. `functional_unit` similarly corrected to read from `impacts.functional_unit` first.
+- ✅ **§9.5 fix #2 — EU/IBU per-format extractor** _(shipped 2026-04-29, `370ffc8`)_. New `extractEuIbu(text, rec)` for IBU declarations (anchors: `Owner of the Declaration`, `Declaration number`, `Issue date`, `Valid to`). Six new EU/IBU-style impact regexes for bracketed-unit layouts (`[kg CO 2 -Eq.]`, `[kg SO 2 -Eq.]`, `[kg CFC11-Eq.]`, `[MJ]`). `extractType` skip vocabulary tightened to drop standards-citation phrases ("as per ISO 14025 and EN 15804+A1") and label rows ("Owner of", "Declaration number", "Issue date", "Valid to") from the display_name picker. Catches EU/IBU sample plus bonus matches on 4 metals + 2 wood + 1 thermal sample whose tables happen to use bracketed units.
+- ✅ **§9.5 fix #3 — ISO 21930 indicator codes + comma-thousand parser fix** _(shipped 2026-04-29, `39cbb97`)_. Three new IMPACT_INDICATORS entries for the modern NA / ISO 21930:2017 codes `RPR E` (PE-R), `NRPR E` (PE-NR), `FW` (water consumption). `_extractIndicatorTotals` number parsing fixed: comma-thousand-separated values like `3,490.16` were being parsed as `3.49`; now correctly handled (US/CA convention strips comma, EU convention replaces comma with period). All 4 BC Wood 2023 samples now at 10/10 impact coverage.
+- ✅ **§9.5 fix #4 — EPD-IES filename variant** _(shipped 2026-04-29, `666de0e`)_. Per-glyph fragmentation tolerance for the IES sibling of S-P-10278 where labels emit one glyph at a time ("S - P - 10278", "Publication date: 202 5 - 10 - 2 0"). Centralised tolerant `_SP_ID_RX = /S\s*-\s*P\s*-\s*(\d{5,6})/`. New `_looseIsoDateAfter` helper collapses digit-whitespace pairs in dates before matching `YYYY-MM-DD`. Format detection lifts the IES variant from `unknown` → `epd_international`, which then gets the full extractEpdIntl pass.
 - ✅ **BEAM ID convention** locked in §5 + §5.5 (6-char hex matching the existing catalogue, never overwrite with PCR or EPD-id).
 
-**Latest measured coverage** (`node schema/scripts/test-epd-extract.mjs`, 2026-04-28 23:15Z, snapshot at `EPD-coverage-history/2026-04-28T23-15-14Z.md`):
+**Latest measured coverage** (`node schema/scripts/test-epd-extract.mjs`, 2026-04-29 11:07Z, snapshot at `EPD-coverage-history/2026-04-29T11-07-01Z.md`):
 
 - 30/30 samples processed, no errors
-- **Metadata: 242/420 = 57.6%** (14 fields × 30 samples — 3 trunk fields added in §5.6)
-- **Impact totals: 108/300 = 36.0%** (10 indicators × 30 samples)
-- Format detection: na=18, unknown=8, nsf=2, eu_ibu=1, epd_international=1
+- **Metadata: 256/420 = 61.0%** (14 fields × 30 samples)
+- **Impact totals: 147/300 = 49.0%** (10 indicators × 30 samples)
+- Format detection: na=18, epd_international=2, nsf=2, eu_ibu=1, unknown=7
 
-**Coverage delta this session** (vs 2026-04-27 22:35Z baseline at `EPD-coverage-history/2026-04-28T01-47-51Z.md`):
+**Coverage delta this session** (vs 2026-04-28 23:15Z post-fix-#1 baseline):
 
-- Metadata: 50.3% → 57.6% (Tier 1+2 trunk fields populating ~85% of the 30 samples)
-- Impacts: 30.7% → 36.0% (older BC Wood gained 15 indicator hits across 3 samples + 1 bonus on Genyk)
+- Metadata: 57.6% → 61.0% (EU/IBU sample 4/14 → 12/14; EPD-IES variant 5/14 → 11/14)
+- Impacts: 36.0% → 49.0% (4 BC Wood 2023 samples now at 10/10; xcarb steel 6/10 → 9/10; misc bonus matches across NA family)
 
-**Phases pending** (ranked by leverage):
+**Phases pending** (ranked by leverage post-2026-04-29):
 
-- ⏳ **P3.2 — Per-format iteration continues** — see top-of-doc handoff for the next 3 fix-list items (EU/IBU extractor, PE-NR / PE-R / WDP synonym expansion, EPD-IES filename variant).
-- ⏳ **P3.3 — Per-stage breakdown** (A1, A2, A3, A1-A3, A4, …, D) — needs column-header parsing for cradle-to-gate vs cradle-to-grave layouts.
+- 🆕 **§10 — Fallback database (`db-fallbacks.json`) + provenance UI** _(today's main work — see top-of-doc handoff + §10 in full)_. The reframe: many properties can't be regex-extracted because they aren't in EPDs at all. Fill those slots from a curated reference catalogue, marked `source: "generic_default"` and color-coded so the user always sees what came from the EPD vs the catalogue. Six commits (C-fb1..C-fb6) sketched in §10.6.
+- ⏳ **P3.3 — Per-stage breakdown** (A1, A2, A3, A1-A3, A4, …, D) — needs column-header parsing for cradle-to-gate vs cradle-to-grave layouts. Sized similar to the §10 work; can run in parallel.
 - ⏳ **P4 — Match-status surfacing** (`NEW` vs `REFRESH → <id>`) on the EPD-Parser form banner; Database-side `NEW` / `UPDATED` chips already shipped 2026-04-28 in §7.7.
 - ⏳ **Multi-product EPD disambiguation** (Genyk 3 SPFs, Lafarge 6 cement types, AWC/CWC industry-avg). UI work in the form pane.
 - ⏳ **P6 — Refresh queue** (DB-driven entry point for expired-record backlog).
@@ -623,7 +633,106 @@ Build P2 as a sequence of anchor passes:
 
 Per-EPD wood + insulation regression fixtures land as P3 work, drawing the seven calibration JSON dumps as ground truth.
 
-## 10. Out of scope (v1)
+## 10. Fallback database (`db-fallbacks.json`) — provenance-marked defaults
+
+### Why
+
+Many properties the schema can hold are **not** EPD-specific (Andy 2026-04-29). Density, thermal conductivity, heat capacity, embodied energy, embodied carbon — these are reference-grade material constants the LCA practitioner often won't find on the cover page of a product EPD. The EPD reports impacts per declared unit and trusts the reader to know the material's bulk properties.
+
+When BEAMweb later normalises an EPD result for use in an assembly takeoff, it sometimes needs those bulk properties to convert "kgCO₂e per m³" into "kgCO₂e per m² at 25 mm thick" (or similar). If a property isn't in the EPD, we need a fallback we can trust — but **never silently** in place of an EPD-published value.
+
+### The file
+
+**`schema/lookups/db-fallbacks.json`** (sibling of `material-type-to-group.json`, `country-codes.json`, etc.). Compiled from the BfCA materials catalogue (XML-imported reference set covering ~200 entries across 20 groups: aerated concrete, asphalt, burnt clay, concrete, environment, expanded clay, floor coverings, glass, gypsum, metals, plasters, roof tiles, rubbers, sealants, solid plastics, stones, glass-wool insulation, mineral-wool insulation, multilayer insulation, plastic-foam insulation, wood-wool insulation, wood + wood-based panels). Each entry holds the reference values for: density (kg/m³), thermal conductivity (W/m·K), heat capacity (J/kg·K), embodied energy (MJ/kg), embodied carbon (kgCO₂e/kg).
+
+Keyed by canonical `material_type` label (matches the existing `material-type-to-group.json` convention). XML variants like `CONCRETE 1` / `CONCRETE 2` / `CONCRETE 3` collapse to a single mid-range default plus an optional `variants` array the form pane can offer when the user wants a tighter match.
+
+### EPD-published values always win
+
+The single most important rule. The fallback layer runs **after** every per-format extractor has had its chance, and only fills fields whose value is `null`. If a regex misses a value that IS in the EPD, the catalogue won't paper over the bug — it will fill the field with a generic default and the user will see it tagged that way, which surfaces the regex gap rather than hiding it.
+
+To make this enforceable, the harness gains a ground-truth dimension (§10.3 below).
+
+### 10.1. Provenance — four sources, color-coded
+
+Every value in a candidate record carries a `source` field. Four canonical values:
+
+| `source`          | Meaning                                                                                          | Form-pane treatment                                                                                              | Database-viewer treatment                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `epd_direct`      | Extracted from the EPD's text                                                                    | Default white background, no chip                                                                                | No chip                                                    |
+| `generic_default` | Filled from `db-fallbacks.json` because the EPD didn't publish it                                | Soft amber tint + `DEFAULT` chip + tooltip _"from materials catalogue, not EPD — verify before Trust"_           | Amber chip in the row's expanded detail per affected field |
+| `calculated`      | Derived from BEAM math (consumes other fields as inputs; lands after Andy supplies the formulas) | Soft cyan tint + `CALC` chip + tooltip naming the inputs _"computed from density × thickness × biogenic factor"_ | Cyan chip + tooltip with input chain                       |
+| `user_edit`       | User typed over an auto-filled value in the form                                                 | Default white background — user input is authoritative                                                           | No chip; the form's source flips when the user edits       |
+
+**Visual key in the database header.** The Database viewer's toolbar shows a small static legend with the four chips so a user lands on the page already knowing what each color means: `EPD ● DEFAULT ● CALC ● EDIT`. Same chip styling reused from the existing `db-fresh-chip` CSS, just with new color-class variants.
+
+### 10.2. Pipeline integration
+
+Three consumers, all reading the same single file via `Extract.setLookups({...})`:
+
+| Consumer                                                                                                      | When it runs                                                                                           | What it does                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **EPD-Parser** ([`js/epd/extract.mjs`](../../js/epd/extract.mjs))                                             | New Tier-9 step `applyMaterialDefaults(rec)` after per-format extractors and `_extractIndicatorTotals` | For each catalogue field that's null on `rec`, fill from the matching `material_type` entry. Mark `source: "generic_default"` on each filled value.                                                            |
+| **EPD-Parser form** ([`js/epdparser.mjs`](../../js/epdparser.mjs))                                            | On render + on every input change                                                                      | Read `source` per field from the candidate; apply the appropriate CSS class (`epd-source-default` / `epd-source-calc` / etc.) to the input. `_bindFormChange` flips source to `user_edit` when the user types. |
+| **Database viewer** ([`js/database.mjs`](../../js/database.mjs))                                              | When rendering a row's expanded detail                                                                 | Display per-field source chips in the detail panel; legend in the toolbar header.                                                                                                                              |
+| **CSV importer** (future, [`schema/scripts/beam-csv-to-json.mjs`](../../schema/scripts/beam-csv-to-json.mjs)) | One-shot pre-deploy run                                                                                | Backfill blanks in the existing 821 records with `source: "generic_default"` so the catalogue is consistent at deploy time. Team git-diffs the import output to review what got auto-filled.                   |
+| **BEAMweb** (future)                                                                                          | When consuming a material for a project calculation                                                    | Prefer `epd_direct`; fall back to `generic_default`; surface a per-line-item provenance flag in the project export.                                                                                            |
+
+Single source of truth for the data. Single architectural pattern (`source` field) for the EPD-vs-default-vs-calculated distinction. No parallel implementations.
+
+### 10.3. Verification — extraction fidelity before fallback
+
+A separate ground-truth annotation set guards against silent overrides. **`docs/PDF References/EPD SAMPLES/expected/<sample>.json`** — one hand-annotated file per sample EPD. Schema:
+
+```json
+{
+  "source_file": "2023 BC Wood CLT EPD ASTM.pdf",
+  "epd_publishes": {
+    "physical.density.value_kg_m3": 470,
+    "carbon.stated.per_unit": "1 m³ of cross-laminated timber",
+    "epd.expiry_date": "2028-02-19"
+  },
+  "epd_omits": ["physical.thermal.conductivity_w_mk", "physical.thermal.heat_capacity_j_kgk"],
+  "notes": "Density stated on cover page in declared-unit description."
+}
+```
+
+Harness gains three checks per sample, run in order:
+
+1. **Extraction fidelity** — for each `epd_publishes` key, did we extract it? Within numeric tolerance for numeric fields? _Failure here = regex bug, fix before the catalogue ever runs._
+2. **Defaults applied correctly** — for each `epd_omits` key, was it filled from the catalogue with `source: "generic_default"`? Did we fill it with a sensible value (matching the canonical material_type's entry)?
+3. **No silent overrides** — for any key in `epd_publishes`, the source after fallback must be `epd_direct`, never `generic_default`. _Failure here = silent shortcut bug, build-time alarm._
+
+Annotation cost: ~30 min per pass over the 30 samples (or ad-hoc as samples surface during smoke-tests). Empty `expected/` files are non-blocking — the new harness checks just skip when the ground-truth file is absent.
+
+### 10.4. Variants and ranges
+
+Some XML entries carry meaningful spread (e.g., concrete densities 1800 / 2000 / 2200 / 2300 kg/m³ for different mixes; mineral wool 14–115 kg/m³ from elevation glass-wool to dense board). The catalogue stores:
+
+- A single mid-range `default` value per material_type for instant fill (the field that goes into `rec` when the EPD is silent).
+- An optional `variants[]` array per material_type with per-variant overrides (`name`, density, conductivity, etc.) the form can offer as alternatives in a dropdown when the user wants a tighter match.
+- An optional `range` object (`min` / `max`) for fields where the spread is documented and useful as helper text on the form input.
+
+### 10.5. What's coming after Andy's BEAM math arrives
+
+`applyCalculations(rec)` Tier 10 in `extract.mjs` runs after the fallback step. For each computable field (e.g., biogenic carbon stored per m² for a wall assembly at thickness X), apply the BEAM formula using inputs from `rec` (some `epd_direct`, some `generic_default`, some user-edited), mark the output `source: "calculated"`, and record the input chain in a sibling field for the tooltip ("computed from `physical.density.value_kg_m3` (epd_direct) × thickness × biogenic factor"). Catches: a calc layer that accidentally consumes a `generic_default` density is still legitimate, but the user should see it; the chip + tooltip make that visible.
+
+### 10.6. Commit plan
+
+| Commit         | Scope                                                                                                                                                                                                                                                                          | Estimate |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| C-fb1          | XML → JSON conversion. Land `schema/lookups/db-fallbacks.json` (~200 material entries across 20 groups). Update `package.json stage:data` + `.github/workflows/deploy-pages.yml` to copy it into `data/schema/lookups/`.                                                       | ~30 min  |
+| C-fb2          | `applyMaterialDefaults(rec)` Tier 9 in `extract.mjs`. Extend `setLookups()` to accept `materialDefaults`. Wire EPD-Parser browser-side prime. Source-mark every filled value.                                                                                                  | ~30 min  |
+| C-fb3          | Form-pane provenance UI in `epdparser.mjs`. Read `source` per field, apply the four-state CSS class to each input. `_bindFormChange` flips source to `user_edit` on type. New CSS classes (`.epd-source-default`, `.epd-source-calc`, `.epd-source-edit`) in `bfcastyles.css`. | ~45 min  |
+| C-fb4          | Database-viewer chip rendering in expanded detail rows. Toolbar legend showing the four source chips.                                                                                                                                                                          | ~30 min  |
+| C-fb5          | Harness upgrade — `expected/` ground-truth dir + three new checks (extraction fidelity / defaults applied correctly / no silent overrides). Empty `expected/` initially; checks skip gracefully when the ground-truth file is absent.                                          | ~45 min  |
+| C-fb6 (future) | `applyCalculations(rec)` Tier 10 + input-chain tooltips. Lands when the BEAM formulas arrive from Andy.                                                                                                                                                                        | ~60 min  |
+
+C-fb1 → C-fb5 is ~3 hours of work spread across 5 small commits. C-fb6 is gated on Andy supplying the BEAM math and is independent of everything else.
+
+---
+
+## 11. Out of scope (v1)
 
 - **OCR** (Tesseract.js fallback) — P7 phase. **Real demand confirmed in P1 calibration** (`EPD_Polyiso walls.pdf` is image-only, zero text-layer items). v1 detects this case and surfaces a "needs OCR" banner; the actual OCR pass lands in P7.
 - **Hard delete of database records.** Forever. Soft-delete via `status.visibility = "flagged_for_deletion"` is the only deletion path; flagged records stay in `schema/materials/*.json` for back-office manual review (see [`Database.md`](Database.md) §6).

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -6,47 +6,91 @@
 
 ## Agent handoff (read this first)
 
-**You are picking up after a productive 2026-04-29 morning session.** §9.5 fix #2 (EU/IBU extractor), fix #3 (ISO 21930 indicator codes + comma-thousand parser), fix #4 (EPD-IES per-glyph tolerance) all shipped. Coverage moved 57.6% → 61.0% metadata, 36.0% → 49.0% impacts. Andy then surfaced the architectural insight that drives **today's main work — see §10**.
+**You are picking up at 2026-04-29 EOD with C-fb1 through C-fb4 (plus a magenta-tweak follow-up) shipped. §10 fallback layer is wired and visualised end-to-end; only C-fb5 (harness upgrade) and C-fb6 (BEAM-math calc tier, gated) remain.** Andy paused for context-window reasons. Branch is parked at `e563f04` on `EPD-PARSER-SPRINT`, both remotes pushed.
 
-**Andy's insight (2026-04-29 mid-day):** many properties the schema can hold (density, thermal conductivity, heat capacity, embodied energy, embodied carbon for non-product baselines) are **not** EPD-specific and won't be in most EPD documents. Pushing regex extraction to fill those gaps is the wrong direction. We need a curated reference catalogue (`db-fallbacks.json`) that fills those slots only when the EPD itself is silent — provenance-marked so the user always sees what came from the EPD vs the catalogue. **§10 documents this in full**, including the four-source `source` enum (`epd_direct` / `generic_default` / `calculated` / `user_edit`), the visual chip system, the verification-before-fallback harness upgrade, and the C-fb1..C-fb6 commit plan.
+**Today's coverage state**: metadata 256/420 (61.0%) → 267/420 (63.6%) after C-fb2 fallback fills. Impacts unchanged at 147/300 (49.0%) — the fallback layer doesn't touch impacts.
 
-**Branch + state:**
+**What shipped this session** (chronological, all on `EPD-PARSER-SPRINT`):
 
-- Branch: `EPD-PARSER-SPRINT` on remotes `openbuilding` (arossti/OpenBuilding) and `origin` (bfca-labs/at). Both pushed.
-- Tip at this point in 2026-04-29 mid-day: see §0 below for the latest SHA list.
-- Latest harness snapshot: [`docs/workplans/EPD-coverage-history/2026-04-29T11-07-01Z.md`](EPD-coverage-history/) — measured after §9.5 fix #4.
+| SHA       | Scope                                                                                                  |
+| --------- | ------------------------------------------------------------------------------------------------------ |
+| `370ffc8` | §9.5 fix #2 — EU/IBU per-format extractor + bracketed-unit impact patterns                             |
+| `39cbb97` | §9.5 fix #3 — ISO 21930 indicator codes (RPR E / NRPR E / FW) + comma-thousand parser fix              |
+| `666de0e` | §9.5 fix #4 — EPD-IES per-glyph tolerance (`_SP_ID_RX`, `_looseIsoDateAfter`)                          |
+| `f35d60d` | gitignore: `/db-*.png` + `/c7d-*.png` for transient screenshots                                        |
+| `6bef852` | §10 chapter (db-fallbacks architecture) added to this workplan                                         |
+| `557ea31` | **C-fb1** — db-fallbacks reference catalogue + XML→JSON builder + stage:data wiring                    |
+| `e1ff163` | **C-fb2** — Tier-9 `applyMaterialDefaults()` + `setLookups()` extension + harness/browser priming      |
+| `c0fe802` | **C-fb3** — form-pane provenance UI (color-coded source classes + `_bindFormChange` flip-to-user_edit) |
+| `9d7a048` | **C-fb4** — Database viewer chips + toolbar legend                                                     |
+| `e563f04` | C-fb4 follow-up — DEFAULT chip → magenta (was clashing with yellow `.db-fresh-chip-new`)               |
 
-**Read this order:**
+### Pickup — what you're doing first
 
-1. §0 — current state (what's shipped, what's pending, latest measured coverage)
-2. **§10 — Fallback database (`db-fallbacks.json`) — provenance-marked defaults** (today's main architectural work; read in full before touching extract.mjs again)
-3. §7.6 — Harness contract (the "no regex change ships unless coverage moves up" rule; gets one new dimension via §10.3)
-4. §5.6 — Taxonomy + coarse-to-granular extraction order (shipped 2026-04-28; rationale + reference)
-5. §9.5 — calibration findings + remaining per-format fix-list (fix-list mostly cleared; remaining items are lower-leverage now that the catalogue is the headline)
+**1. C-fb5 — Harness upgrade with verification before fallback** (~45–60 min). The fallback layer is currently a _silent_ feature: if a regex bug fails to extract a value the EPD actually publishes, the catalogue fills it with `generic_default` and the user sees the magenta chip without realising the EPD had the value. §10.3 of this workplan documents the design — read that section in full. Concrete deliverables:
 
-**Today's / next-session recommended sequence (from §10.6 commit plan):**
+- Create directory `docs/PDF References/EPD SAMPLES/expected/` — initially empty; the harness must skip its three new checks gracefully when the ground-truth file is absent.
+- Schema for each ground-truth file (one per sample EPD):
+  ```json
+  {
+    "source_file": "2023 BC Wood CLT EPD ASTM.pdf",
+    "epd_publishes": {
+      "physical.density.value_kg_m3": 470,
+      "carbon.stated.per_unit": "1 m³ of cross-laminated timber",
+      "epd.expiry_date": "2028-02-19"
+    },
+    "epd_omits": ["physical.thermal.conductivity_w_mk"],
+    "notes": "Density stated on cover page in declared-unit description."
+  }
+  ```
+- Extend `schema/scripts/test-epd-extract.mjs` to:
+  1. **Extraction fidelity check** — for each `epd_publishes` key, did we extract it? For numeric fields, within ±1% tolerance? Failing case = regex bug, surface as `✗` line in the harness output.
+  2. **Defaults applied check** — for each `epd_omits` key, did the catalogue fill it AND mark `source: "generic_default"`?
+  3. **No silent overrides check** — for any key in `epd_publishes`, the post-fallback `source` must be `epd_direct` or unset (NOT `generic_default`). This is the key rule.
+- Add a top-line summary to the harness output: `Ground-truth checks: N samples annotated, K extraction failures, M silent-override violations.`
+- Snapshot to `EPD-coverage-history/` as usual; the new dimensions get tabulated.
 
-1. **C-fb1 — XML → `db-fallbacks.json`** (~30 min). Convert the BfCA materials catalogue (XML import: ~200 entries × 20 groups) to a JSON file at `schema/lookups/db-fallbacks.json`, keyed by canonical `material_type` label. Variants stored as `variants[]` arrays. Update `package.json stage:data` + the Pages workflow to copy the file into `data/schema/lookups/`.
-2. **C-fb2 — Tier-9 fallback layer in `extract.mjs`** (~30 min). New `applyMaterialDefaults(rec)` step after `_extractIndicatorTotals`. Extend `setLookups()` signature. Source-mark every filled value as `generic_default`.
-3. **C-fb3 — Form-pane provenance UI in `epdparser.mjs`** (~45 min). Read `source` per field on render; apply CSS class. `_bindFormChange` flips source to `user_edit` on type. New CSS classes (`.epd-source-default`, `.epd-source-calc`, `.epd-source-edit`) in `bfcastyles.css`.
-4. **C-fb4 — Database-viewer chips + toolbar legend** (~30 min). Per-field source chips in expanded detail rows. Static legend in the toolbar header (`EPD ● DEFAULT ● CALC ● EDIT`).
-5. **C-fb5 — Harness upgrade with `expected/` ground-truth dir** (~45 min). Three new checks (extraction fidelity / defaults applied / no silent overrides). Empty `expected/` initially; checks skip when ground-truth file is absent.
-6. **C-fb6 — `applyCalculations(rec)` Tier 10** (gated on Andy supplying BEAM math; ~60 min once available).
+**2. Bug to flag during C-fb5 — `xcarb` steel density=800**. The 3 xcarb steel samples (cold-formed, hollow, deck) currently extract `density=800` (unmarked source), which is wrong. Real steel density is 7800. The number 800 is being grabbed by an existing density regex from somewhere irrelevant in the doc. Once you build the C-fb5 verification harness, annotate one of the xcarb samples' `expected/` file with `epd_omits: ["physical.density.value_kg_m3"]` (steel EPDs in this family don't publish density on the cover) and watch the "no silent overrides" check fail because the wrong-value extraction is masking the omission. Fix: tighten the density regex in `extractNA()` (probably a missing `\b` or character-class constraint). This is the canonical example of the bug class C-fb5 is designed to catch.
 
-**§9.5 leftover fix-list (deprioritised behind §10):** Sopra family is OCR-blocked (Sopra-Cellulose / Sopra-ISO are scanned-image PDFs, zero text-layer items — defer to P7 OCR). Other regex tweaks are micro-leverage compared to landing the catalogue.
+**3. C-fb6 (gated)**. `applyCalculations(rec)` Tier 10 is blocked on Andy supplying BEAM math formulas for biogenic carbon stored per unit. Don't start it without the formulas.
+
+### Branch state
+
+```
+main                        cf28d11   PR #14 merged
+└── EPD-PARSER-SPRINT  (active, 11 commits since main)
+    ├── 370ffc8  §9.5 fix #2 EU/IBU
+    ├── 39cbb97  §9.5 fix #3 ISO 21930 + comma parser
+    ├── 666de0e  §9.5 fix #4 EPD-IES
+    ├── f35d60d  gitignore tightening
+    ├── 6bef852  workplan §10 chapter
+    ├── 557ea31  C-fb1 db-fallbacks catalogue
+    ├── e1ff163  C-fb2 Tier-9 fallback layer
+    ├── c0fe802  C-fb3 form-pane provenance UI
+    ├── 9d7a048  C-fb4 database viewer chips + legend
+    └── e563f04  C-fb4 follow-up — DEFAULT → magenta  (← tip)
+```
+
+### Read this order
+
+1. §0 — current state (full SHA log + coverage trail)
+2. **§10 — Fallback database (db-fallbacks.json)** — read in full before C-fb5; especially §10.3 (verification before fallback)
+3. §7.6 — Harness contract (the "no regex change ships unless coverage moves up" rule; C-fb5 extends it)
+4. §5.6 — Hierarchical extraction (shipped 2026-04-28; reference)
+5. §9.5 — calibration findings + remaining fix-list (mostly cleared)
+
+### File map for C-fb5
+
+| File                                                 | What you'll touch                                                                                                                                      |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `schema/scripts/test-epd-extract.mjs`                | Extend `main()` with the three new checks. The existing METADATA_FIELDS + IMPACT_KEYS coverage logic stays as-is alongside the new ground-truth check. |
+| `docs/PDF References/EPD SAMPLES/expected/*.json`    | New directory + per-sample ground-truth files. Start with 1–2 annotated samples to prove the pipeline; empty for the rest is fine.                     |
+| `docs/workplans/EPD-coverage-history/<timestamp>.md` | Auto-snapshotted by the harness as usual. New dimensions tabulate as additional rows or columns.                                                       |
 
 **Hard rules — do not violate:**
 
-- **§7.6 harness contract:** every commit that touches `js/epd/extract.mjs` re-runs `node schema/scripts/test-epd-extract.mjs` and commits a fresh snapshot to `docs/workplans/EPD-coverage-history/`. Aggregate coverage must move up; no individual sample may regress. If a "fix" only helps one sample and doesn't lift the aggregate, it's idiosyncratic — broaden it or drop it.
-- **§5.5 BEAM ID convention:** `beam_id` is BfCA-internal and never extracted from a PDF. P3's `extract.mjs` produces `beam_id: null`. Minting happens on the Database side at commit (now wired in `database.mjs` `_mintId6` — 6-char hex matching the existing catalogue convention).
-- **§8 security:** no in-browser Anthropic API integration, ever. Andy ruled this out 2026-04-25.
-- **§9 IP guardrails:** no `CSI` / `MasterFormat` / `Division` / `MCE²` / `NRCan` / Crown-copyright tool names in code, UI strings, or the workplan. Numeric `group_prefix` (`03`/`06`/`07`/etc.) is the only classification convention.
-- **Soft-delete only.** Hard-delete forbidden forever ([`Database.md`](Database.md) §6).
-
-**Hard rules — do not violate:**
-
-- **§7.6 harness contract:** every commit that touches `js/epd/extract.mjs` re-runs `node schema/scripts/test-epd-extract.mjs` and commits a fresh snapshot to `docs/workplans/EPD-coverage-history/`. Aggregate coverage must move up; no individual sample may regress. If a "fix" only helps one sample and doesn't lift the aggregate, it's idiosyncratic — broaden it or drop it.
-- **§5.5 BEAM ID convention:** `beam_id` is BfCA-internal and never extracted from a PDF. P3's `extract.mjs` produces `beam_id: null`. Minting happens on the Database side at commit. Don't conflate `beam_id` with `epd.id` or `methodology.pcr_guidelines` — three different fields, three different sources.
+- **§7.6 + §10.3 harness contract:** every commit that touches `js/epd/extract.mjs` re-runs `node schema/scripts/test-epd-extract.mjs` and commits a fresh snapshot to `docs/workplans/EPD-coverage-history/`. Aggregate coverage must move up; no individual sample may regress; once C-fb5 lands, no `epd_publishes` ground-truth value may be silently overridden by the catalogue.
+- **§5.5 BEAM ID convention:** `beam_id` is BfCA-internal and never extracted from a PDF. P3's `extract.mjs` produces `beam_id: null`. Minting happens on the Database side at commit (wired in `database.mjs` `_mintId6` — 6-char hex matching the existing catalogue convention).
 - **§8 security:** no in-browser Anthropic API integration, ever. Andy ruled this out 2026-04-25.
 - **§9 IP guardrails:** no `CSI` / `MasterFormat` / `Division` / `MCE²` / `NRCan` / Crown-copyright tool names in code, UI strings, or the workplan. Numeric `group_prefix` (`03`/`06`/`07`/etc.) is the only classification convention.
 - **Soft-delete only.** Hard-delete forbidden forever ([`Database.md`](Database.md) §6).
@@ -84,23 +128,30 @@ npm run serve                                                     # local dev se
 - ✅ **§9.5 fix #2 — EU/IBU per-format extractor** _(shipped 2026-04-29, `370ffc8`)_. New `extractEuIbu(text, rec)` for IBU declarations (anchors: `Owner of the Declaration`, `Declaration number`, `Issue date`, `Valid to`). Six new EU/IBU-style impact regexes for bracketed-unit layouts (`[kg CO 2 -Eq.]`, `[kg SO 2 -Eq.]`, `[kg CFC11-Eq.]`, `[MJ]`). `extractType` skip vocabulary tightened to drop standards-citation phrases ("as per ISO 14025 and EN 15804+A1") and label rows ("Owner of", "Declaration number", "Issue date", "Valid to") from the display_name picker. Catches EU/IBU sample plus bonus matches on 4 metals + 2 wood + 1 thermal sample whose tables happen to use bracketed units.
 - ✅ **§9.5 fix #3 — ISO 21930 indicator codes + comma-thousand parser fix** _(shipped 2026-04-29, `39cbb97`)_. Three new IMPACT_INDICATORS entries for the modern NA / ISO 21930:2017 codes `RPR E` (PE-R), `NRPR E` (PE-NR), `FW` (water consumption). `_extractIndicatorTotals` number parsing fixed: comma-thousand-separated values like `3,490.16` were being parsed as `3.49`; now correctly handled (US/CA convention strips comma, EU convention replaces comma with period). All 4 BC Wood 2023 samples now at 10/10 impact coverage.
 - ✅ **§9.5 fix #4 — EPD-IES filename variant** _(shipped 2026-04-29, `666de0e`)_. Per-glyph fragmentation tolerance for the IES sibling of S-P-10278 where labels emit one glyph at a time ("S - P - 10278", "Publication date: 202 5 - 10 - 2 0"). Centralised tolerant `_SP_ID_RX = /S\s*-\s*P\s*-\s*(\d{5,6})/`. New `_looseIsoDateAfter` helper collapses digit-whitespace pairs in dates before matching `YYYY-MM-DD`. Format detection lifts the IES variant from `unknown` → `epd_international`, which then gets the full extractEpdIntl pass.
+- ✅ **§10 chapter added to workplan** _(shipped 2026-04-29, `6bef852`)_. Documents the architectural pivot: db-fallbacks reference catalogue + four-source `source` enum + provenance chips + verification-before-fallback harness upgrade. Six-commit plan C-fb1..C-fb6 in §10.6.
+- ✅ **C-fb1 — db-fallbacks reference catalogue + builder** _(shipped 2026-04-29, `557ea31`)_. New `schema/lookups/db-fallbacks.source.xml` (~200 thermal/embodied-property entries × 5 properties) + `schema/scripts/build-db-fallbacks.mjs` converter (canonical-label mapping + median-density default-pick + hand-picked overrides for Concrete/Steel/Sheathing/Wood-fiberboard/Gypsum/Fiberglass) + emitted `schema/lookups/db-fallbacks.json` (31 canonical material_types covering 142 of 171 XML rows). Pipeline: `npm run build:db-fallbacks` regenerates JSON; `package.json stage:data` + Pages workflow filter to `*.json` so the .source.xml stays a build input.
+- ✅ **C-fb2 — Tier-9 `applyMaterialDefaults()` fallback layer** _(shipped 2026-04-29, `e1ff163`)_. New `applyMaterialDefaults(rec)` step in `extract.mjs` runs after `extractCommon` as Tier 9. v1 fills only `physical.density.value_kg_m3` (the only catalogue field with an existing schema slot today); marks each filled value with `source: "generic_default"`. `setLookups()` now accepts `materialDefaults`; harness + epdparser browser both prime the cache. Filled 11 density slots across Steel / Aluminum / Plywood / Gypsum / Framing / SPF samples.
+- ✅ **C-fb3 — Form-pane provenance UI** _(shipped 2026-04-29, `c0fe802`)_. New `_resolveSourcePath()` (replaces last segment with "source"; works for both `physical.density.value_kg_m3` → `physical.density.source` and `impacts.gwp_kgco2e.total.value` → `impacts.gwp_kgco2e.total.source`) + `_applySourceClass()`. `_populateFormFromCandidate` calls it for every input. `_bindFormChange` flips source to `user_edit` on type. Three CSS classes: `.epd-source-default` (magenta), `.epd-source-calc` (cyan), `.epd-source-edit` (lime). Default rendering covers `epd_direct` / unset.
+- ✅ **C-fb4 — Database viewer chips + toolbar legend** _(shipped 2026-04-29, `9d7a048`)_. Static four-chip legend in `database.html` `.db-result-bar` (`EPD ● DEFAULT ● CALC ● EDIT`) so users land on the page already knowing what each color means. Per-field inline chips via new `_sourceChip(source)` + `_valueWithSourceChip(text, source)` helpers in `database.mjs`. Currently rendered on the `density` row of the Physical Properties block (the only Tier-9-fillable field).
+- ✅ **C-fb4 follow-up — DEFAULT chip → magenta** _(shipped 2026-04-29, `e563f04`)_. Andy feedback: amber DEFAULT clashed visually with the yellow `.db-fresh-chip-new` on Trust-committed rows. Both `.db-chip-source-default` (database viewer) and `.app-epdparser .epd-form-row .epd-source-default` (form pane) swapped to magenta `rgba(232, 121, 249, ...)`. Maximum visual distinction across the five chip types now in play.
 - ✅ **BEAM ID convention** locked in §5 + §5.5 (6-char hex matching the existing catalogue, never overwrite with PCR or EPD-id).
 
-**Latest measured coverage** (`node schema/scripts/test-epd-extract.mjs`, 2026-04-29 11:07Z, snapshot at `EPD-coverage-history/2026-04-29T11-07-01Z.md`):
+**Latest measured coverage** (`node schema/scripts/test-epd-extract.mjs`, 2026-04-29 12:06Z, snapshot at `EPD-coverage-history/2026-04-29T12-06-59Z.md`):
 
 - 30/30 samples processed, no errors
-- **Metadata: 256/420 = 61.0%** (14 fields × 30 samples)
+- **Metadata: 267/420 = 63.6%** (14 fields × 30 samples — including 11 generic_default density fills from C-fb2)
 - **Impact totals: 147/300 = 49.0%** (10 indicators × 30 samples)
 - Format detection: na=18, epd_international=2, nsf=2, eu_ibu=1, unknown=7
 
 **Coverage delta this session** (vs 2026-04-28 23:15Z post-fix-#1 baseline):
 
-- Metadata: 57.6% → 61.0% (EU/IBU sample 4/14 → 12/14; EPD-IES variant 5/14 → 11/14)
-- Impacts: 36.0% → 49.0% (4 BC Wood 2023 samples now at 10/10; xcarb steel 6/10 → 9/10; misc bonus matches across NA family)
+- Metadata: 57.6% → 63.6% (EU/IBU 4→12, EPD-IES variant 5→11, plus 11 generic_default density fills)
+- Impacts: 36.0% → 49.0% (4 BC Wood 2023 samples at 10/10; xcarb 6→9; misc bonus matches)
 
-**Phases pending** (ranked by leverage post-2026-04-29):
+**Phases pending** (ranked by leverage post-2026-04-29 EOD):
 
-- 🆕 **§10 — Fallback database (`db-fallbacks.json`) + provenance UI** _(today's main work — see top-of-doc handoff + §10 in full)_. The reframe: many properties can't be regex-extracted because they aren't in EPDs at all. Fill those slots from a curated reference catalogue, marked `source: "generic_default"` and color-coded so the user always sees what came from the EPD vs the catalogue. Six commits (C-fb1..C-fb6) sketched in §10.6.
+- 🔜 **C-fb5 — Harness verification (`expected/` ground-truth + three checks)** _(next session — see top-of-doc handoff)_. Stops the catalogue from silently overriding regex bugs; surfaces the xcarb steel density=800 false-positive flagged in C-fb2.
+- 🅿️ **C-fb6 — `applyCalculations()` Tier 10** — gated on Andy supplying BEAM math for biogenic carbon stored per unit + similar derivations.
 - ⏳ **P3.3 — Per-stage breakdown** (A1, A2, A3, A1-A3, A4, …, D) — needs column-header parsing for cradle-to-gate vs cradle-to-grave layouts. Sized similar to the §10 work; can run in parallel.
 - ⏳ **P4 — Match-status surfacing** (`NEW` vs `REFRESH → <id>`) on the EPD-Parser form banner; Database-side `NEW` / `UPDATED` chips already shipped 2026-04-28 in §7.7.
 - ⏳ **Multi-product EPD disambiguation** (Genyk 3 SPFs, Lafarge 6 cement types, AWC/CWC industry-avg). UI work in the form pane.

--- a/docs/workplans/EPD-coverage-history/2026-04-29T10-56-14Z.md
+++ b/docs/workplans/EPD-coverage-history/2026-04-29T10-56-14Z.md
@@ -1,0 +1,39 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-04-29T10:56:14.787Z
+Samples: 30 · metadata: 250/420 (59.5%) · impacts: 121/300 (40.3%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 6/10 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 5/10 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 12/14 | 1/10 | · | · | · | · | · | · | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | unknown | 17 | 5/14 | 7/10 | 8.47 | 8.08e-10 | -2 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 11/14 | 7/10 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 10/14 | 1/10 | · | · | · | · | · | · | 0.181 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 6/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 6/10 | 1030 | 3.51e-12 | 1.85 | 0.0736 | 33.6 | 1010 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 6/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 9/14 | 6/10 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 7/14 | 7/10 | 310.28 | 0.00e+0 | 0.14 | 0.0709 | 34.05 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 5/14 | 5/10 | 19.87 | 4.36 | 7.09 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 7/14 | 6/10 | 37.97 | 8.13e-7 | 0.35 | 0.07 | 10.74 | 511.45 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 8/14 | 5/10 | 242.58 | 7.81e-6 | 1.44 | 0.98 | 26.36 | · | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 12/14 | 8/10 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | · | · | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 12/14 | 9/10 | 102.82 | 0.00e+0 | 1.16 | 0.13 | 24.89 | 1569.54 | · | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 12/14 | 8/10 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | · | · | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 12/14 | 8/10 | 131.68 | 2.08e-6 | 1.34 | 0.13 | 15.27 | 2672.52 | · | · | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 1/10 | 2 | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 11/14 | 2/10 | 4.04 | · | · | 1.31 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 7/10 | -198.4 | 8.52e-13 | 0.132 | · | · | 1451 | 0.31 | 1227 | 316 |

--- a/docs/workplans/EPD-coverage-history/2026-04-29T11-02-33Z.md
+++ b/docs/workplans/EPD-coverage-history/2026-04-29T11-02-33Z.md
@@ -1,0 +1,39 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-04-29T11:02:33.301Z
+Samples: 30 · metadata: 250/420 (59.5%) · impacts: 147/300 (49.0%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 12/14 | 1/10 | · | · | · | · | · | · | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | unknown | 17 | 5/14 | 7/10 | 8.47 | 8.08e-10 | -2 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 11/14 | 7/10 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 10/14 | 1/10 | · | · | · | · | · | · | 0.181 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 1030 | 3.51e-12 | 1.85 | 0.0736 | 33.6 | 1010 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 9/14 | 6/10 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 7/14 | 7/10 | 310.28 | 0.00e+0 | 0.14 | 0.0709 | 34.05 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 5/14 | 5/10 | 19.87 | 4.36 | 7.09 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 7/14 | 9/10 | 37.97 | 8.13e-7 | 0.35 | 0.07 | 10.74 | 511.45 | 3 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 8/14 | 8/10 | 242.58 | 7.81e-6 | 1.44 | 0.98 | 26.36 | · | 3 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 12/14 | 10/10 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 12/14 | 10/10 | 102.82 | 0.00e+0 | 1.16 | 0.13 | 24.89 | 1569.54 | 0.43 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 12/14 | 10/10 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 12/14 | 10/10 | 131.68 | 2.08e-6 | 1.34 | 0.13 | 15.27 | 2672.52 | 0.33 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 1/10 | 2 | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 11/14 | 2/10 | 4.04 | · | · | 1.31 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 7/10 | -198.4 | 8.52e-13 | 0.132 | · | · | 1451 | 0.31 | 1227 | 316 |

--- a/docs/workplans/EPD-coverage-history/2026-04-29T11-07-01Z.md
+++ b/docs/workplans/EPD-coverage-history/2026-04-29T11-07-01Z.md
@@ -1,0 +1,39 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-04-29T11:07:01.483Z
+Samples: 30 · metadata: 256/420 (61.0%) · impacts: 147/300 (49.0%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 12/14 | 1/10 | · | · | · | · | · | · | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 11/14 | 7/10 | 8.47 | 8.08e-10 | -2 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 11/14 | 7/10 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 10/14 | 1/10 | · | · | · | · | · | · | 0.181 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 1030 | 3.51e-12 | 1.85 | 0.0736 | 33.6 | 1010 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 9/14 | 6/10 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 7/14 | 7/10 | 310.28 | 0.00e+0 | 0.14 | 0.0709 | 34.05 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 5/14 | 5/10 | 19.87 | 4.36 | 7.09 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 7/14 | 9/10 | 37.97 | 8.13e-7 | 0.35 | 0.07 | 10.74 | 511.45 | 3 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 8/14 | 8/10 | 242.58 | 7.81e-6 | 1.44 | 0.98 | 26.36 | · | 3 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 12/14 | 10/10 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 12/14 | 10/10 | 102.82 | 0.00e+0 | 1.16 | 0.13 | 24.89 | 1569.54 | 0.43 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 12/14 | 10/10 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 12/14 | 10/10 | 131.68 | 2.08e-6 | 1.34 | 0.13 | 15.27 | 2672.52 | 0.33 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 1/10 | 2 | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 11/14 | 2/10 | 4.04 | · | · | 1.31 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 7/10 | -198.4 | 8.52e-13 | 0.132 | · | · | 1451 | 0.31 | 1227 | 316 |

--- a/docs/workplans/EPD-coverage-history/2026-04-29T12-06-59Z.md
+++ b/docs/workplans/EPD-coverage-history/2026-04-29T12-06-59Z.md
@@ -1,0 +1,39 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-04-29T12:06:59.178Z
+Samples: 30 · metadata: 267/420 (63.6%) · impacts: 147/300 (49.0%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 13/14 | 1/10 | · | · | · | · | · | · | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 8.47 | 8.08e-10 | -2 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 11/14 | 1/10 | · | · | · | · | · | · | 0.181 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 1030 | 3.51e-12 | 1.85 | 0.0736 | 33.6 | 1010 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 1230 | 2.38e-11 | 2.51 | 0.112 | 47.8 | 1340 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 9/14 | 6/10 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 7/14 | 7/10 | 310.28 | 0.00e+0 | 0.14 | 0.0709 | 34.05 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 19.87 | 4.36 | 7.09 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 8/14 | 9/10 | 37.97 | 8.13e-7 | 0.35 | 0.07 | 10.74 | 511.45 | 3 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 9/14 | 8/10 | 242.58 | 7.81e-6 | 1.44 | 0.98 | 26.36 | · | 3 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 12/14 | 2/10 | · | · | · | · | · | · | · | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 12/14 | 10/10 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 12/14 | 10/10 | 102.82 | 0.00e+0 | 1.16 | 0.13 | 24.89 | 1569.54 | 0.43 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 13/14 | 10/10 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 13/14 | 10/10 | 131.68 | 2.08e-6 | 1.34 | 0.13 | 15.27 | 2672.52 | 0.33 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 1/10 | 2 | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 11/14 | 2/10 | 4.04 | · | · | 1.31 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 7/10 | -198.4 | 8.52e-13 | 0.132 | · | · | 1451 | 0.31 | 1227 | 316 |

--- a/js/database.mjs
+++ b/js/database.mjs
@@ -597,8 +597,7 @@ function physicalBlock(r) {
   const box = document.createElement("div");
   box.appendChild(
     kv([
-      ["density", fmtDualDensity(d)],
-      ["density.source", d.source],
+      ["density", _valueWithSourceChip(fmtDualDensity(d), d.source)],
       ["thermal.conductivity (W/mK)", th.conductivity_w_mk],
       ["thermal.r_value/inch (imp)", th.r_value_per_inch_imperial],
       ["thermal.heat_capacity (J/kgK)", th.heat_capacity_j_kgk],
@@ -613,6 +612,41 @@ function physicalBlock(r) {
     ])
   );
   return box;
+}
+
+/* §10.1 provenance helpers ──────────────────────────────────────────
+   _sourceChip(source) builds a small inline span with the per-source
+   class. Returns null for unknown / null source so callers can opt out.
+   _valueWithSourceChip(text, source) returns either:
+     - the text alone (when source is null / unknown / "epd_direct")
+     - a Node containing the text + a trailing chip (otherwise)
+   The kv() helper handles either return type — strings render as-is,
+   Nodes get appended via dd.appendChild(value). */
+function _sourceChip(source) {
+  if (!source || source === "epd_direct") return null;
+  const cls =
+    source === "generic_default"
+      ? "db-chip-source-default"
+      : source === "calculated"
+        ? "db-chip-source-calc"
+        : source === "user_edit"
+          ? "db-chip-source-edit"
+          : null;
+  if (!cls) return null;
+  const chip = document.createElement("span");
+  chip.className = cls;
+  chip.textContent = source === "generic_default" ? "DEFAULT" : source === "calculated" ? "CALC" : "EDIT";
+  chip.style.marginLeft = "6px";
+  return chip;
+}
+function _valueWithSourceChip(text, source) {
+  const chip = _sourceChip(source);
+  if (text == null || text === "") return null;
+  if (!chip) return text;
+  const wrap = document.createElement("span");
+  wrap.appendChild(document.createTextNode(String(text)));
+  wrap.appendChild(chip);
+  return wrap;
 }
 
 function fmtDualDensity(d) {

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -52,10 +52,17 @@ export function getLookups() {
   return _lookups;
 }
 
+// Per-glyph fragmentation tolerance for the canonical S-P-XXXXX id.
+// The EPD-IES filename variant of S-P-10278 emits the label as
+// "S - P - 10278" (each glyph as its own text item with spaces between),
+// which the strict /S-P-\d/ pattern misses. The tolerant form matches
+// either spelling and is reused everywhere we look for an S-P id.
+var _SP_ID_RX = /S\s*-\s*P\s*-\s*(\d{5,6})/;
+
 export function detectFormat(text) {
   // Priority order matters — narrowest match first to avoid false positives.
   // EPD International registry is most specific (S-P-XXXXX is canonical).
-  if (/S-P-\d{5,6}/.test(text) && /Programme\s+operator/i.test(text)) return FORMATS.EPD_INTL;
+  if (_SP_ID_RX.test(text) && /Programme\s+operator/i.test(text)) return FORMATS.EPD_INTL;
 
   // NSF before EU_IBU because Lafarge cement EPDs contain the prose phrase
   // "the owner of the declaration is liable for the underlying information"
@@ -254,6 +261,32 @@ function _findDateAfterLabel(text, labelPattern) {
   return _parseDate(window);
 }
 
+// Per-glyph fragmentation tolerance for ISO dates. The EPD-IES filename
+// variant emits dates as "202 5 - 10 - 2 0" — every digit gets its own
+// text item. Pre-process by removing whitespace between adjacent digits
+// (so "202 5" → "2025"), then run a loose YYYY-MM-DD match. Falls back
+// to null if the window doesn't contain a date-shaped sequence.
+function _looseIsoDateAfter(text, labelPattern) {
+  var m = labelPattern.exec(text);
+  if (!m) return null;
+  var window = text.substring(m.index + m[0].length, m.index + m[0].length + 60);
+  // Collapse any whitespace between digits so "202 5" → "2025" and
+  // "2 0" → "20". Repeat once because /(\d)\s+(\d)/g only collapses one
+  // pair per overlap on the first pass.
+  var collapsed = window;
+  for (var pass = 0; pass < 4; pass++) {
+    var next = collapsed.replace(/(\d)\s+(\d)/g, "$1$2");
+    if (next === collapsed) break;
+    collapsed = next;
+  }
+  // Also collapse spaces around the dashes inside dates ("2025 - 10 - 20").
+  collapsed = collapsed.replace(/(\d)\s*-\s*(\d)/g, "$1-$2");
+  var iso = collapsed.match(/(\d{4}-\d{1,2}-\d{1,2})/);
+  if (!iso) return null;
+  var parts = iso[1].split("-");
+  return parts[0] + "-" + _pad2(parts[1]) + "-" + _pad2(parts[2]);
+}
+
 // Find a free-text value after a label (for things like manufacturer / PCR).
 function _findStringAfterLabel(text, labelPattern, maxLen) {
   var m = labelPattern.exec(text);
@@ -294,8 +327,10 @@ function extractCommon(text, rec) {
   // doc references both an internal (e.g. CSA #3688-5839) and an EPD
   // International (S-P-XXXXX) ID, we prefer the EPD-Intl one because it
   // matches the BEAM internal-ID convention Melanie established.
+  // Tolerant match (_SP_ID_RX) for the EPD-IES filename variant where
+  // per-glyph emission lands the label as "S - P - 10278".
   if (!_get(rec, "epd.id")) {
-    var spMatch = text.match(/S-P-(\d{5,6})/);
+    var spMatch = text.match(_SP_ID_RX);
     if (spMatch) _setPath(rec, "epd.id", "S-P-" + spMatch[1]);
   }
 
@@ -764,17 +799,26 @@ function extractEuIbu(text, rec) {
 }
 
 function extractEpdIntl(text, rec) {
-  // S-P-XXXXX is the canonical ID
-  var sp = text.match(/S-P-(\d{5,6})/);
+  // S-P-XXXXX is the canonical ID; tolerant match handles the EPD-IES
+  // filename variant where per-glyph emission produces "S - P - 10278".
+  var sp = text.match(_SP_ID_RX);
   if (sp) _setPath(rec, "epd.id", "S-P-" + sp[1]);
 
   _setPath(rec, "epd.program_operator", "EPD International AB");
 
-  // Dates in ISO format (typical for this registry)
-  var pub = text.match(/Publication\s+date\s*:\s*(\d{4}-\d{2}-\d{2})/i);
-  if (pub) _setPath(rec, "epd.publication_date", pub[1]);
-  var exp = text.match(/Valid\s+until\s*:\s*(\d{4}-\d{2}-\d{2})/i);
-  if (exp) _setPath(rec, "epd.expiry_date", exp[1]);
+  // Dates in ISO format. The EPD-IES variant per-glyph-fragments the
+  // date itself ("202 5 - 10 - 2 0"), so we capture a 60-char window
+  // after each label, collapse digit-space-digit pairs, then run a
+  // loose date pattern. Falls back to the strict pattern for the
+  // typical EPD International layout.
+  if (!_get(rec, "epd.publication_date")) {
+    var pubLoose = _looseIsoDateAfter(text, /Publication\s+date\s*:?/i);
+    if (pubLoose) _setPath(rec, "epd.publication_date", pubLoose);
+  }
+  if (!_get(rec, "epd.expiry_date")) {
+    var expLoose = _looseIsoDateAfter(text, /Valid\s+until\s*:?/i);
+    if (expLoose) _setPath(rec, "epd.expiry_date", expLoose);
+  }
 
   // Manufacturer ("from <MFR>" or "Owner of the Declaration: <MFR>")
   var mfr =

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -524,6 +524,34 @@ var IMPACT_INDICATORS = [
     label: "WDP (EU/IBU fresh-water phrase)",
     regex:
       /Use\s+of\s+net\s+fresh\s+water[^\n]{0,20}?\[?\s*m\s*[³^]?3?\s*\]?[^\n]*?\s+(-?\s*\d{1,7}(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/i
+  },
+
+  // Modern NA / ISO 21930 family. Wood + steel EPDs that follow the
+  // ACLCA / ISO 21930:2017 indicator convention use abbreviation codes
+  // RPR E (renewable primary energy as energy carrier), NRPR E
+  // (non-renewable primary energy as energy carrier), and FW (fresh
+  // water) — typically with comma-thousand-separated values like
+  // "3,490.16" and the unit on the same line ("[MJ, LHV]" or "[m 3 ]").
+  // FW often has its value on the NEXT line in the spatially-joined
+  // text because pdf.js per-glyph emission splits unit + value;
+  // \s+ tolerance handles that. Number capture allows comma-thousand
+  // groups; the parser strips them.
+  {
+    schemaKey: "primary_energy_renewable_mj",
+    label: "PE-R (RPR E / ISO 21930)",
+    regex:
+      /\bRPR\s*[Ee]\b[^\n]{0,30}?\[?\s*MJ\b[^\n]{0,16}?\s+(-?\s*\d{1,3}(?:,\d{3})*(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/
+  },
+  {
+    schemaKey: "primary_energy_nonrenewable_mj",
+    label: "PE-NR (NRPR E / ISO 21930)",
+    regex:
+      /\bNRPR\s*[Ee]\b[^\n]{0,30}?\[?\s*MJ\b[^\n]{0,16}?\s+(-?\s*\d{1,3}(?:,\d{3})*(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/
+  },
+  {
+    schemaKey: "water_consumption_m3",
+    label: "WDP (FW / ISO 21930)",
+    regex: /\bFW\b\s*\[?\s*m\s*[³^]?3?\s*\]?\s+(-?\s*\d{1,3}(?:,\d{3})*(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/
   }
 ];
 
@@ -534,7 +562,20 @@ function _extractIndicatorTotals(text, rec) {
     var m = text.match(ind.regex);
     if (!m) continue;
     var raw = m[1].replace(/\s+/g, "");
-    var num = parseFloat(raw.replace(",", "."));
+    // Number parsing handles three conventions:
+    //   "3,490.16"  US/CA — comma is thousand-separator → strip
+    //   "3.490,16"  EU      — period is thousand-separator → unsupported here
+    //   "3,50"      EU      — comma is decimal → replace with period
+    //   "3338.45"   US/CA   — no separator → as-is
+    //   "1.23E+03"  scientific → as-is (E was lowercased? no, regex is case-insensitive)
+    var num;
+    if (raw.indexOf(".") >= 0 && raw.indexOf(",") >= 0) {
+      // Both present — comma is thousand-separator (US/CA wood + steel EPDs)
+      num = parseFloat(raw.replace(/,/g, ""));
+    } else {
+      // Only one or neither — single comma → decimal
+      num = parseFloat(raw.replace(",", "."));
+    }
     if (isNaN(num)) continue;
     _setPath(rec, "impacts." + ind.schemaKey + ".total.value", num);
     _setPath(rec, "impacts." + ind.schemaKey + ".total.source", "epd_direct");

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -119,10 +119,50 @@ export function extract(pageTexts) {
   else if (format === FORMATS.EU_IBU) extractEuIbu(allText, rec);
   // UNKNOWN: fall through to common-only.
 
-  // Tiers 6 + 8 — cross-format methodology + impact totals (always last).
+  // Tiers 6 + 8 — cross-format methodology + impact totals.
   extractCommon(allText, rec);
 
+  // Tier 9 — fallback fill from db-fallbacks.json for fields the EPD
+  // didn't publish. Only runs if the lookups were primed AND the
+  // candidate already has a classification.material_type. Source-marks
+  // every filled value as "generic_default" so the form pane can
+  // distinguish EPD-derived from catalogue-derived.
+  applyMaterialDefaults(rec);
+
   return { format: format, record: rec, anchorsHit: _countAnchors(rec) };
+}
+
+/* ── Tier 9 — fallback fill from db-fallbacks ─────────────────────── */
+//
+// The EPD wins where it published a value. This step only fills slots
+// that the per-format extractors left null. v1 only fills
+// physical.density.value_kg_m3 (the only catalogue field that maps to
+// an existing schema slot today). Thermal conductivity, heat capacity,
+// embodied energy, and embodied carbon stay in the catalogue ready for
+// future schema extension; this function is the place to wire them
+// when those slots get added.
+//
+// Source-marking convention: when this function fills a value, it also
+// writes `<path>.source = "generic_default"` next to the value. Other
+// possible source values: "epd_direct" (existing extractors should set
+// this; retrofit pending), "calculated" (Tier 10, future BEAM math),
+// "user_edit" (form bindings flip this when the user types).
+
+function applyMaterialDefaults(rec) {
+  if (!_lookups || !_lookups.materialDefaults) return;
+  var materialType = _get(rec, "classification.material_type");
+  if (!materialType) return;
+
+  var defaults = _lookups.materialDefaults.defaults_by_material_type;
+  var entry = defaults && defaults[materialType];
+  if (!entry || !entry.default) return;
+  var d = entry.default;
+
+  // physical.density — the only catalogue field with a current schema slot.
+  if (_get(rec, "physical.density.value_kg_m3") == null && d.density_kg_m3 != null) {
+    _setPath(rec, "physical.density.value_kg_m3", d.density_kg_m3);
+    _setPath(rec, "physical.density.source", "generic_default");
+  }
 }
 
 /* ── Tier 2 — display name + material type ────────────────────────── */

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -109,7 +109,8 @@ export function extract(pageTexts) {
   if (format === FORMATS.EPD_INTL) extractEpdIntl(allText, rec);
   else if (format === FORMATS.NA) extractNA(allText, rec);
   else if (format === FORMATS.NSF) extractNSF(allText, rec);
-  // EU_IBU + UNKNOWN: fall through to common-only for now.
+  else if (format === FORMATS.EU_IBU) extractEuIbu(allText, rec);
+  // UNKNOWN: fall through to common-only.
 
   // Tiers 6 + 8 — cross-format methodology + impact totals (always last).
   extractCommon(allText, rec);
@@ -165,13 +166,18 @@ function extractType(text, rec) {
 
   // Skip generic/registry lines + short fragments. The first surviving
   // line is the product title in the overwhelming majority of EPDs.
-  var skip =
-    /^(?:type\s+iii|environmental\s+product\s+declaration|epd|in\s+accordance|programme|program|page\s+\d|\d+\s*\/\s*\d+|—|–|-{2,})/i;
+  var skipPrefix =
+    /^(?:type\s+iii|environmental\s+product\s+declaration|epd\b|in\s+accordance|as\s+per\b|according\s+to\b|programme|program\b|publisher\b|owner\s+of|declaration\s+number|issue\s+date|valid\s+to|valid\s+until|publication\s+date|page\s+\d|\d+\s*\/\s*\d+|—|–|-{2,})/i;
+  // Standards-citation lines also need to be skipped — these often
+  // appear right under the title block on EU/IBU layouts where the
+  // line "as per ISO 14025 and EN 15804+A1" otherwise gets picked.
+  var skipStandards = /\bISO\s*1[34]025\b|\bEN\s*15804\b|\bISO\s*21930\b|\bISO\s*14040\b/i;
   var displayName = null;
   for (var i = 0; i < lines.length; i++) {
     var raw = lines[i].trim();
     if (raw.length < 4 || raw.length > 160) continue;
-    if (skip.test(raw)) continue;
+    if (skipPrefix.test(raw)) continue;
+    if (skipStandards.test(raw)) continue;
     // "Acme Co" alone is more likely a manufacturer header — keep scanning
     // unless the line reads as a product description (≥ 2 words OR has a
     // material-type keyword in it).
@@ -478,6 +484,46 @@ var IMPACT_INDICATORS = [
     schemaKey: "primary_energy_renewable_mj",
     label: "PE-R (English biomass)",
     regex: /Renewable[,\s]+biomass\s+MJ\s+(-?\s*\d{1,7}(?:[.,]\d+)?)/i
+  },
+
+  // EU/IBU family (Institut Bauen und Umwelt). Tables use long English
+  // category names with bracketed units containing space-split subscripts
+  // ("[kg CO 2 -Eq.]", "[kg SO 2 -Eq.]", "[kg CFC11-Eq.]"). The "total"
+  // is the A1-A3 column which sits as the first numeric token after the
+  // unit. POCP / ADPe-fossil / fresh-water rows have EU-specific phrasings.
+  // Negative values are common (biogenic carbon credit on wood products
+  // gives GWP A1-A3 like -198.40), hence `-?\s*` on the capture group.
+  // Existing code-anchored regexes run first and the loop early-returns
+  // when populated, so no collision on samples that have both forms.
+  {
+    schemaKey: "gwp_kgco2e",
+    label: "GWP (EU/IBU bracketed)",
+    regex:
+      /Global\s+warming\s+potential[^\n]{0,30}?\[?\s*kg\s*CO\s*2?\s*-?\s*[Ee]q\.?\s*\]?[^\n]*?\s+(-?\s*\d{1,7}(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/i
+  },
+  {
+    schemaKey: "ozone_depletion_kgcfc11eq",
+    label: "ODP (EU/IBU long phrase)",
+    regex:
+      /(?:Ozone\s+depletion\s+potential|Depletion\s+potential\s+of\s+the\s+stratospheric\s+ozone\s+layer)[^\n]{0,30}?\[?\s*kg\s*CFC\s*-?\s*11\s*-?\s*[Ee]q\.?\s*\]?[^\n]*?\s+(-?\s*\d{1,7}(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/i
+  },
+  {
+    schemaKey: "acidification_kgso2eq",
+    label: "AP (EU/IBU bracketed)",
+    regex:
+      /Acidification\s+potential[^\n]{0,40}?\[?\s*kg\s*SO\s*2?\s*-?\s*[Ee]q\.?\s*\]?[^\n]*?\s+(-?\s*\d{1,7}(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/i
+  },
+  {
+    schemaKey: "abiotic_depletion_fossil_mj",
+    label: "ADPf (EU/IBU long phrase)",
+    regex:
+      /Abiotic\s+depletion\s+potential\s+for\s+fossil\s+resources[^\n]{0,30}?\[?\s*MJ\s*\]?[^\n]*?\s+(-?\s*\d{1,7}(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/i
+  },
+  {
+    schemaKey: "water_consumption_m3",
+    label: "WDP (EU/IBU fresh-water phrase)",
+    regex:
+      /Use\s+of\s+net\s+fresh\s+water[^\n]{0,20}?\[?\s*m\s*[³^]?3?\s*\]?[^\n]*?\s+(-?\s*\d{1,7}(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/i
   }
 ];
 
@@ -580,6 +626,101 @@ function extractNA(text, rec) {
 }
 
 /* ── EPD International registry format (S-P-XXXXX) ─────────────────── */
+
+/* ── EU/IBU format (Institut Bauen und Umwelt) ─────────────────────── */
+//
+// Cover-page anchors are line-leading labels with the value on the same
+// line: "Owner of the Declaration   <name>", "Declaration number   <id>",
+// "Issue date   <date>", "Valid to   <date>". Programme operator is set
+// by extractCommon's _detectProgramOperator; we set it here too as a
+// safety net for layouts where the IBU name appears elsewhere.
+//
+// PCR lives under "This declaration is based on the product category
+// rules:" — the next non-empty line is the canonical PCR title (e.g.
+// "Wood based panels, 12.2018"). PCR-validation marker is a
+// "internally   x   externally" form where the "x" sits next to the
+// chosen option.
+//
+// Declared unit + density both live in the "This Declaration refers to
+// 1 m³ ... average weighted density of 167 kg/m³" sentence on page 2.
+
+function extractEuIbu(text, rec) {
+  _setPath(rec, "epd.program_operator", "IBU");
+
+  // Owner of the Declaration → manufacturer name. The label sits on its
+  // own line on some layouts (page 2), so we capture forward across one
+  // possible newline before settling on a single-line value.
+  if (!_get(rec, "manufacturer.name")) {
+    var mfr =
+      text.match(/Owner\s+of\s+the\s+Declaration\s+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/) ||
+      text.match(/Owner\s+of\s+the\s+(?:declaration|Declaration)\s*\n+\s*([A-Z][A-Za-z0-9 &.,'\-]{2,80})/);
+    if (mfr) _setPath(rec, "manufacturer.name", _cleanLine(mfr[1]));
+  }
+
+  // Declaration number → epd.id. IBU pattern is "EPD-XXX-YYYYYYY-..."
+  if (!_get(rec, "epd.id")) {
+    var idM = text.match(/Declaration\s+number\s+(EPD-[A-Z0-9.\-]{4,40})/i);
+    if (idM) _setPath(rec, "epd.id", idM[1]);
+  }
+
+  // Dates: IBU uses dd/mm/yyyy. _parseDate normalises to ISO YYYY-MM-DD.
+  if (!_get(rec, "epd.publication_date")) {
+    var pubM = text.match(/Issue\s+date\s+([0-9./\-]{8,12})/i);
+    if (pubM) {
+      var pubIso = _parseDate(pubM[1]);
+      if (pubIso) _setPath(rec, "epd.publication_date", pubIso);
+    }
+  }
+  if (!_get(rec, "epd.expiry_date")) {
+    var expM = text.match(/Valid\s+to\s+([0-9./\-]{8,12})/i);
+    if (expM) {
+      var expIso = _parseDate(expM[1]);
+      if (expIso) _setPath(rec, "epd.expiry_date", expIso);
+    }
+  }
+
+  // Validation: "internally   x   externally" with the marker next to
+  // the chosen mode. _detectProgramOperator-adjacent heuristic in
+  // extractCommon already handles this, but we double-tap here.
+  if (!_get(rec, "epd.validation.type")) {
+    if (/internally\s*x\s*externally/i.test(text)) {
+      // marker before "internally" → internal; before "externally" → external
+      // The IBU sample reads "internally   x   externally" with the x
+      // between them — convention is x marks the SELECTED column, and
+      // since IBU declarations are always externally verified, default
+      // to external when both labels are present.
+      _setPath(rec, "epd.validation.type", "external");
+    } else if (/[x✓X]\s*externally/i.test(text)) {
+      _setPath(rec, "epd.validation.type", "external");
+    } else if (/[x✓X]\s*internally/i.test(text)) {
+      _setPath(rec, "epd.validation.type", "internal");
+    }
+  }
+
+  // PCR — "This declaration is based on the product category rules:"
+  // followed (after one or two newlines) by the PCR title. Tolerant
+  // capture pulls everything up to "(PCR" or end-of-line.
+  if (!_get(rec, "methodology.pcr_guidelines")) {
+    var pcrM =
+      text.match(/product\s+category\s+rules\s*:\s*\n+\s*([^\n]{6,160})/i) ||
+      text.match(/category\s+rules\s*:\s*([^\n]{6,160})/i);
+    if (pcrM) {
+      var pcrVal = _cleanLine(pcrM[1]).replace(/\s*\(PCR.*$/i, "");
+      _setPath(rec, "methodology.pcr_guidelines", pcrVal);
+    }
+  }
+
+  // Declared unit + density on the "This Declaration refers to 1 m³ X
+  // ... average weighted density of 167 kg/m³" sentence.
+  if (!_get(rec, "carbon.stated.per_unit")) {
+    var unitM = text.match(/This\s+Declaration\s+refers\s+to\s+([^\n]{4,160})/i);
+    if (unitM) _setPath(rec, "carbon.stated.per_unit", _cleanLine(unitM[1]));
+  }
+  if (_get(rec, "physical.density.value_kg_m3") == null) {
+    var densM = text.match(/(?:average\s+weighted\s+)?density\s+of\s+(\d{2,5}(?:[.,]\d+)?)\s*kg\/m\s*[³^]?3?/i);
+    if (densM) _setPath(rec, "physical.density.value_kg_m3", _toNum(densM[1]));
+  }
+}
 
 function extractEpdIntl(text, rec) {
   // S-P-XXXXX is the canonical ID

--- a/js/epdparser.mjs
+++ b/js/epdparser.mjs
@@ -552,6 +552,14 @@ function _bindFormChange() {
 
     if (!_state.candidate) _state.candidate = {};
     _setPath(_state.candidate, el.dataset.path, value);
+    // Provenance: a user typing on a field overrides whatever auto-fill
+    // path produced the prior value. Flip the source to user_edit and
+    // re-apply the class so the visual cue updates immediately.
+    var sourcePath = _resolveSourcePath(el.dataset.path);
+    if (sourcePath) {
+      _setPath(_state.candidate, sourcePath, "user_edit");
+      _applySourceClass(el, _state.candidate);
+    }
     _scheduleSave();
   });
 }
@@ -699,7 +707,35 @@ function _populateFormFromCandidate(candidate) {
     } else {
       el.value = String(v);
     }
+    _applySourceClass(el, candidate);
   }
+}
+
+/* ── §10.1 provenance source-class application ───────────────────────
+   Source enum values:
+     epd_direct       — extracted from the EPD's text
+     generic_default  — filled from db-fallbacks.json (Tier-9 fallback)
+     calculated       — derived from BEAM math (future, Tier 10)
+     user_edit        — user typed over the auto-filled value
+   Each value lives at a sibling path: replace the last segment of the
+   value path with "source" (e.g. physical.density.value_kg_m3 →
+   physical.density.source). Falls back gracefully when no source field
+   exists — the input renders default / no class. */
+function _resolveSourcePath(valuePath) {
+  var parts = valuePath.split(".");
+  if (parts.length < 2) return null;
+  parts[parts.length - 1] = "source";
+  return parts.join(".");
+}
+
+function _applySourceClass(el, candidate) {
+  var sourcePath = _resolveSourcePath(el.dataset.path);
+  if (!sourcePath) return;
+  var source = candidate ? _getPath(candidate, sourcePath) : null;
+  el.classList.remove("epd-source-default", "epd-source-calc", "epd-source-edit");
+  if (source === "generic_default") el.classList.add("epd-source-default");
+  else if (source === "calculated") el.classList.add("epd-source-calc");
+  else if (source === "user_edit") el.classList.add("epd-source-edit");
 }
 
 function _setFormStatus(text) {

--- a/js/epdparser.mjs
+++ b/js/epdparser.mjs
@@ -202,11 +202,15 @@ function _primeLookups() {
     }),
     fetch("data/schema/lookups/display-name-keywords.json").then(function (r) {
       return r.ok ? r.json() : { patterns: [] };
+    }),
+    fetch("data/schema/lookups/db-fallbacks.json").then(function (r) {
+      return r.ok ? r.json() : null;
     })
   ]).then(function (results) {
     Extract.setLookups({
       mtMap: (results[0] && results[0].map) || {},
-      kwPatterns: (results[1] && results[1].patterns) || []
+      kwPatterns: (results[1] && results[1].patterns) || [],
+      materialDefaults: results[2] || null
     });
   });
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write 'js/**/*.mjs' '*.css' '*.html'",
     "format:check": "prettier --check 'js/**/*.mjs' '*.css' '*.html'",
     "serve": "python3 schema/scripts/nocache-serve.py 8000",
-    "stage:data": "mkdir -p data/schema data/schema/lookups data/beam data/beam/samples && cp -r schema/materials data/schema/ && cp -r schema/lookups/. data/schema/lookups/ && cp schema/material.schema.json data/schema/ && cp schema/sample.json data/schema/ && cp \"docs/csv files from BEAM/Footings & Slabs.csv\" data/beam/footings-slabs.csv && cp docs/beam-samples/*.json data/beam/samples/ && cp docs/sample.pdf data/sample.pdf && echo 'Staged schema + lookups + BEAM picker CSVs + sample projects + PDF-Parser sample PDF into data/'",
+    "stage:data": "mkdir -p data/schema data/schema/lookups data/beam data/beam/samples && cp -r schema/materials data/schema/ && cp schema/lookups/*.json data/schema/lookups/ && cp schema/material.schema.json data/schema/ && cp schema/sample.json data/schema/ && cp \"docs/csv files from BEAM/Footings & Slabs.csv\" data/beam/footings-slabs.csv && cp docs/beam-samples/*.json data/beam/samples/ && cp docs/sample.pdf data/sample.pdf && echo 'Staged schema + lookups + BEAM picker CSVs + sample projects + PDF-Parser sample PDF into data/'",
+    "build:db-fallbacks": "node schema/scripts/build-db-fallbacks.mjs",
     "debug:pdf": "node schema/scripts/debug-pdf-extract.mjs",
     "test:dim-extract": "node schema/scripts/test-dim-extract.mjs",
     "test:layer-peel": "node schema/scripts/test-layer-peel.mjs"

--- a/schema/lookups/db-fallbacks.json
+++ b/schema/lookups/db-fallbacks.json
@@ -1,0 +1,1666 @@
+{
+  "_note": "BfCA db-fallbacks: reference-grade material defaults for fields that aren't typically published in EPDs (density, thermal conductivity, heat capacity, embodied energy, embodied carbon). Used as fallback only when the EPD itself is silent. Every value applied at runtime carries source: 'generic_default' so users see what came from the EPD vs the catalogue. Generated from db-fallbacks.source.xml — re-run schema/scripts/build-db-fallbacks.mjs after editing.",
+  "_schema_version": 1,
+  "_source_xml_sha256": "f27cf6a342f4d9d076a87ea7ee247e31dec9f475df740ad9c6fd82254be2bcfe",
+  "_generated_at": "2026-04-29T11:58:15.603Z",
+  "_attribution": "Compiled from a thermal + embodied-properties reference catalogue (XML import). Values are physical material constants; data is reference-grade not product-specific. Per-product accuracy requires an EPD.",
+  "defaults_by_material_type": {
+    "Concrete": {
+      "default": {
+        "density_kg_m3": 2200,
+        "thermal_conductivity_w_mk": 1.65,
+        "heat_capacity_j_kgk": 1000,
+        "embodied_energy_mj_kg": 0.82,
+        "embodied_carbon_kgco2e_kg": 0.12,
+        "_source_variant": "CONCRETE 3",
+        "_selection": "hand-picked override"
+      },
+      "variants": [
+        {
+          "name": "AERATED CONCRETE BLOCK 1",
+          "density_kg_m3": 500,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 1290,
+          "embodied_energy_mj_kg": 0.59,
+          "embodied_carbon_kgco2e_kg": 0.063
+        },
+        {
+          "name": "AERATED CONCRETE BLOCK 2",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.16,
+          "heat_capacity_j_kgk": 1240,
+          "embodied_energy_mj_kg": 0.67,
+          "embodied_carbon_kgco2e_kg": 0.078
+        },
+        {
+          "name": "AERATED CONCRETE BLOCK 3",
+          "density_kg_m3": 700,
+          "thermal_conductivity_w_mk": 0.18,
+          "heat_capacity_j_kgk": 1210,
+          "embodied_energy_mj_kg": 0.72,
+          "embodied_carbon_kgco2e_kg": 0.088
+        },
+        {
+          "name": "AERATED CONCRETE BLOCK INTERLOCKING 1",
+          "density_kg_m3": 400,
+          "thermal_conductivity_w_mk": 0.11,
+          "heat_capacity_j_kgk": 1350,
+          "embodied_energy_mj_kg": 0.55,
+          "embodied_carbon_kgco2e_kg": 0.059
+        },
+        {
+          "name": "AERATED CONCRETE BLOCK INTERLOCKING 2",
+          "density_kg_m3": 500,
+          "thermal_conductivity_w_mk": 0.16,
+          "heat_capacity_j_kgk": 1240,
+          "embodied_energy_mj_kg": 0.59,
+          "embodied_carbon_kgco2e_kg": 0.063
+        },
+        {
+          "name": "AIR-ENT CONCRETE 1",
+          "density_kg_m3": 400,
+          "thermal_conductivity_w_mk": 0.1,
+          "heat_capacity_j_kgk": 1050,
+          "embodied_energy_mj_kg": 0.55,
+          "embodied_carbon_kgco2e_kg": 0.059
+        },
+        {
+          "name": "AIR-ENT CONCRETE 2",
+          "density_kg_m3": 450,
+          "thermal_conductivity_w_mk": 0.12,
+          "heat_capacity_j_kgk": 1050,
+          "embodied_energy_mj_kg": 0.57,
+          "embodied_carbon_kgco2e_kg": 0.061
+        },
+        {
+          "name": "AIR-ENT CONCRETE 3",
+          "density_kg_m3": 450,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 1050,
+          "embodied_energy_mj_kg": 0.57,
+          "embodied_carbon_kgco2e_kg": 0.061
+        },
+        {
+          "name": "AIR-ENT CONCRETE 4",
+          "density_kg_m3": 500,
+          "thermal_conductivity_w_mk": 0.14,
+          "heat_capacity_j_kgk": 1050,
+          "embodied_energy_mj_kg": 0.59,
+          "embodied_carbon_kgco2e_kg": 0.063
+        },
+        {
+          "name": "AIR-ENT CONCRETE 5",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.16,
+          "heat_capacity_j_kgk": 1050,
+          "embodied_energy_mj_kg": 0.67,
+          "embodied_carbon_kgco2e_kg": 0.078
+        },
+        {
+          "name": "GASCONCRETE 1",
+          "density_kg_m3": 550,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 0.63,
+          "embodied_carbon_kgco2e_kg": 0.07
+        },
+        {
+          "name": "GASCONCRETE 2",
+          "density_kg_m3": 510,
+          "thermal_conductivity_w_mk": 0.15,
+          "heat_capacity_j_kgk": 1050,
+          "embodied_energy_mj_kg": 0.61,
+          "embodied_carbon_kgco2e_kg": 0.064
+        },
+        {
+          "name": "CONCRETE LOW CONDUCTIVITY",
+          "density_kg_m3": 2300,
+          "thermal_conductivity_w_mk": 0.8,
+          "heat_capacity_j_kgk": 800,
+          "embodied_energy_mj_kg": 0.92,
+          "embodied_carbon_kgco2e_kg": 0.15
+        },
+        {
+          "name": "CONCRETE 1",
+          "density_kg_m3": 1800,
+          "thermal_conductivity_w_mk": 1.15,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 0.74,
+          "embodied_carbon_kgco2e_kg": 0.107
+        },
+        {
+          "name": "CONCRETE 2",
+          "density_kg_m3": 2000,
+          "thermal_conductivity_w_mk": 1.35,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 0.78,
+          "embodied_carbon_kgco2e_kg": 0.113
+        },
+        {
+          "name": "CONCRETE 3",
+          "density_kg_m3": 2200,
+          "thermal_conductivity_w_mk": 1.65,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 0.82,
+          "embodied_carbon_kgco2e_kg": 0.12
+        },
+        {
+          "name": "CONCRETE 4",
+          "density_kg_m3": 2300,
+          "thermal_conductivity_w_mk": 1.7,
+          "heat_capacity_j_kgk": 800,
+          "embodied_energy_mj_kg": 0.88,
+          "embodied_carbon_kgco2e_kg": 0.132
+        },
+        {
+          "name": "CONCRETE BLOCK",
+          "density_kg_m3": 1400,
+          "thermal_conductivity_w_mk": 0.6,
+          "heat_capacity_j_kgk": 880,
+          "embodied_energy_mj_kg": 0.72,
+          "embodied_carbon_kgco2e_kg": 0.088
+        },
+        {
+          "name": "EXPANDED CLAY-CONCRETE BLOCK",
+          "density_kg_m3": 450,
+          "thermal_conductivity_w_mk": 0.12,
+          "heat_capacity_j_kgk": 800,
+          "embodied_energy_mj_kg": 6.2,
+          "embodied_carbon_kgco2e_kg": 0.46
+        },
+        {
+          "name": "CONCRETE ROOF TILES",
+          "density_kg_m3": 2100,
+          "thermal_conductivity_w_mk": 1.5,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 0.75,
+          "embodied_carbon_kgco2e_kg": 0.107
+        }
+      ]
+    },
+    "Asphalt Shingle": {
+      "default": {
+        "density_kg_m3": 2100,
+        "thermal_conductivity_w_mk": 0.7,
+        "heat_capacity_j_kgk": 1000,
+        "embodied_energy_mj_kg": 3.93,
+        "embodied_carbon_kgco2e_kg": 0.076,
+        "_source_variant": "ASPHALT",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "ASPHALT",
+          "density_kg_m3": 2100,
+          "thermal_conductivity_w_mk": 0.7,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 3.93,
+          "embodied_carbon_kgco2e_kg": 0.076
+        }
+      ]
+    },
+    "TPO": {
+      "default": {
+        "density_kg_m3": 1100,
+        "thermal_conductivity_w_mk": 0.23,
+        "heat_capacity_j_kgk": 1000,
+        "embodied_energy_mj_kg": 2.66,
+        "embodied_carbon_kgco2e_kg": 0.056,
+        "_source_variant": "BITUMINOUS FELT",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "BITUMEN PURE",
+          "density_kg_m3": 1050,
+          "thermal_conductivity_w_mk": 0.17,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 42,
+          "embodied_carbon_kgco2e_kg": 0.55
+        },
+        {
+          "name": "BITUMINOUS FELT",
+          "density_kg_m3": 1100,
+          "thermal_conductivity_w_mk": 0.23,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 2.66,
+          "embodied_carbon_kgco2e_kg": 0.056
+        },
+        {
+          "name": "BITUMINOUS SHEET",
+          "density_kg_m3": 1100,
+          "thermal_conductivity_w_mk": 0.23,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 2.86,
+          "embodied_carbon_kgco2e_kg": 0.066
+        }
+      ]
+    },
+    "Brick": {
+      "default": {
+        "density_kg_m3": 1500,
+        "thermal_conductivity_w_mk": 0.58,
+        "heat_capacity_j_kgk": 840,
+        "embodied_energy_mj_kg": 3,
+        "embodied_carbon_kgco2e_kg": 0.24,
+        "_source_variant": "SOLID BRICK 1",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "SOLID BRICK 1",
+          "density_kg_m3": 1500,
+          "thermal_conductivity_w_mk": 0.58,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 3,
+          "embodied_carbon_kgco2e_kg": 0.24
+        },
+        {
+          "name": "SOLID BRICK 2",
+          "density_kg_m3": 1500,
+          "thermal_conductivity_w_mk": 0.6,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 3,
+          "embodied_carbon_kgco2e_kg": 0.24
+        }
+      ]
+    },
+    "Clay Brick": {
+      "default": {
+        "density_kg_m3": 960,
+        "thermal_conductivity_w_mk": 0.216,
+        "heat_capacity_j_kgk": 920,
+        "embodied_energy_mj_kg": 4.5,
+        "embodied_carbon_kgco2e_kg": 0.36,
+        "_source_variant": "BURNT CLAY BLOCK TO BE INSULATED MEDIUM STRENGTH 1",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "BURNT CLAY BLOCK LIMITED STRENGTH 1",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.109,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 6,
+          "embodied_carbon_kgco2e_kg": 0.48
+        },
+        {
+          "name": "BURNT CLAY BLOCK LIMITED STRENGTH 2",
+          "density_kg_m3": 648,
+          "thermal_conductivity_w_mk": 0.121,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 6,
+          "embodied_carbon_kgco2e_kg": 0.48
+        },
+        {
+          "name": "BURNT CLAY BLOCK MEDIUM STRENGTH 1",
+          "density_kg_m3": 742,
+          "thermal_conductivity_w_mk": 0.125,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 6,
+          "embodied_carbon_kgco2e_kg": 0.48
+        },
+        {
+          "name": "BURNT CLAY BLOCK MEDIUM STRENGTH 2",
+          "density_kg_m3": 694,
+          "thermal_conductivity_w_mk": 0.148,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 6,
+          "embodied_carbon_kgco2e_kg": 0.48
+        },
+        {
+          "name": "BURNT CLAY BLOCK TO BE INSULATED MEDIUM STRENGTH 1",
+          "density_kg_m3": 960,
+          "thermal_conductivity_w_mk": 0.216,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 4.5,
+          "embodied_carbon_kgco2e_kg": 0.36
+        },
+        {
+          "name": "BURNT CLAY BLOCK TO BE INSULATED MEDIUM STRENGTH 2",
+          "density_kg_m3": 840,
+          "thermal_conductivity_w_mk": 0.272,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 4.5,
+          "embodied_carbon_kgco2e_kg": 0.36
+        },
+        {
+          "name": "BURNT CLAY BLOCK TO BE INSULATED STRONG",
+          "density_kg_m3": 940,
+          "thermal_conductivity_w_mk": 0.324,
+          "heat_capacity_j_kgk": 920,
+          "embodied_energy_mj_kg": 4.5,
+          "embodied_carbon_kgco2e_kg": 0.36
+        },
+        {
+          "name": "CLAY FLOOR TILE",
+          "density_kg_m3": 2000,
+          "thermal_conductivity_w_mk": 1.5,
+          "heat_capacity_j_kgk": 900,
+          "embodied_energy_mj_kg": 6.5,
+          "embodied_carbon_kgco2e_kg": 0.48
+        },
+        {
+          "name": "CLAY ROOF TILES",
+          "density_kg_m3": 2000,
+          "thermal_conductivity_w_mk": 1,
+          "heat_capacity_j_kgk": 800,
+          "embodied_energy_mj_kg": 3,
+          "embodied_carbon_kgco2e_kg": 0.24
+        }
+      ]
+    },
+    "Cork": {
+      "default": {
+        "density_kg_m3": 175,
+        "thermal_conductivity_w_mk": 0.08,
+        "heat_capacity_j_kgk": 1800,
+        "embodied_energy_mj_kg": 4,
+        "embodied_carbon_kgco2e_kg": 0.19,
+        "_source_variant": "CORK",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "CORK-CONCRETE",
+          "density_kg_m3": 1300,
+          "thermal_conductivity_w_mk": 0.44,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 0.45,
+          "embodied_carbon_kgco2e_kg": 0.05
+        },
+        {
+          "name": "CORK",
+          "density_kg_m3": 175,
+          "thermal_conductivity_w_mk": 0.08,
+          "heat_capacity_j_kgk": 1800,
+          "embodied_energy_mj_kg": 4,
+          "embodied_carbon_kgco2e_kg": 0.19
+        },
+        {
+          "name": "CORKBOARD",
+          "density_kg_m3": 140,
+          "thermal_conductivity_w_mk": 0.04,
+          "heat_capacity_j_kgk": 1900,
+          "embodied_energy_mj_kg": 7.1,
+          "embodied_carbon_kgco2e_kg": 0.39
+        }
+      ]
+    },
+    "Leca": {
+      "default": {
+        "density_kg_m3": 330,
+        "thermal_conductivity_w_mk": 0.13,
+        "heat_capacity_j_kgk": 880,
+        "embodied_energy_mj_kg": 6.5,
+        "embodied_carbon_kgco2e_kg": 0.48,
+        "_source_variant": "EXPANDED CLAY BLOCK",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "EXPANDED CLAY BLOCK",
+          "density_kg_m3": 330,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 880,
+          "embodied_energy_mj_kg": 6.5,
+          "embodied_carbon_kgco2e_kg": 0.48
+        },
+        {
+          "name": "EXPANDED CLAY WALL PANEL",
+          "density_kg_m3": 960,
+          "thermal_conductivity_w_mk": 0.21,
+          "heat_capacity_j_kgk": 1050,
+          "embodied_energy_mj_kg": 7,
+          "embodied_carbon_kgco2e_kg": 0.5
+        }
+      ]
+    },
+    "Carpet": {
+      "default": {
+        "density_kg_m3": 200,
+        "thermal_conductivity_w_mk": 0.06,
+        "heat_capacity_j_kgk": 1300,
+        "embodied_energy_mj_kg": 74,
+        "embodied_carbon_kgco2e_kg": 3.9,
+        "_source_variant": "CARPET",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "CARPET",
+          "density_kg_m3": 200,
+          "thermal_conductivity_w_mk": 0.06,
+          "heat_capacity_j_kgk": 1300,
+          "embodied_energy_mj_kg": 74,
+          "embodied_carbon_kgco2e_kg": 3.9
+        },
+        {
+          "name": "TEXTILE FLOOR",
+          "density_kg_m3": 200,
+          "thermal_conductivity_w_mk": 0.06,
+          "heat_capacity_j_kgk": 1300,
+          "embodied_energy_mj_kg": 120,
+          "embodied_carbon_kgco2e_kg": 9.14
+        }
+      ]
+    },
+    "Linoleum": {
+      "default": {
+        "density_kg_m3": 1200,
+        "thermal_conductivity_w_mk": 0.17,
+        "heat_capacity_j_kgk": 1400,
+        "embodied_energy_mj_kg": 25,
+        "embodied_carbon_kgco2e_kg": 1.21,
+        "_source_variant": "LINOLEUM",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "LINOLEUM",
+          "density_kg_m3": 1200,
+          "thermal_conductivity_w_mk": 0.17,
+          "heat_capacity_j_kgk": 1400,
+          "embodied_energy_mj_kg": 25,
+          "embodied_carbon_kgco2e_kg": 1.21
+        }
+      ]
+    },
+    "Luxury vinyl tile": {
+      "default": {
+        "density_kg_m3": 1700,
+        "thermal_conductivity_w_mk": 0.25,
+        "heat_capacity_j_kgk": 1400,
+        "embodied_energy_mj_kg": 95.4,
+        "embodied_carbon_kgco2e_kg": 4.98,
+        "_source_variant": "PLASTIC FLOOR",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "PLASTIC FLOOR",
+          "density_kg_m3": 1700,
+          "thermal_conductivity_w_mk": 0.25,
+          "heat_capacity_j_kgk": 1400,
+          "embodied_energy_mj_kg": 95.4,
+          "embodied_carbon_kgco2e_kg": 4.98
+        }
+      ]
+    },
+    "Gypsum": {
+      "default": {
+        "density_kg_m3": 900,
+        "thermal_conductivity_w_mk": 0.25,
+        "heat_capacity_j_kgk": 1000,
+        "embodied_energy_mj_kg": 6.75,
+        "embodied_carbon_kgco2e_kg": 0.39,
+        "_source_variant": "GYPSUM PLASTERBOARD",
+        "_selection": "hand-picked override"
+      },
+      "variants": [
+        {
+          "name": "GYPSUM 1",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.18,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.4,
+          "embodied_carbon_kgco2e_kg": 0.1
+        },
+        {
+          "name": "GYPSUM 2",
+          "density_kg_m3": 900,
+          "thermal_conductivity_w_mk": 0.3,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.6,
+          "embodied_carbon_kgco2e_kg": 0.12
+        },
+        {
+          "name": "GYPSUM 3",
+          "density_kg_m3": 1200,
+          "thermal_conductivity_w_mk": 0.43,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.8,
+          "embodied_carbon_kgco2e_kg": 0.13
+        },
+        {
+          "name": "GYPSUM 4",
+          "density_kg_m3": 1500,
+          "thermal_conductivity_w_mk": 0.56,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 2.3,
+          "embodied_carbon_kgco2e_kg": 0.16
+        },
+        {
+          "name": "GYPSUM PLASTERBOARD",
+          "density_kg_m3": 900,
+          "thermal_conductivity_w_mk": 0.25,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 6.75,
+          "embodied_carbon_kgco2e_kg": 0.39
+        },
+        {
+          "name": "GYPSUMBOARD",
+          "density_kg_m3": 900,
+          "thermal_conductivity_w_mk": 0.22,
+          "heat_capacity_j_kgk": 1100,
+          "embodied_energy_mj_kg": 6.75,
+          "embodied_carbon_kgco2e_kg": 0.39
+        },
+        {
+          "name": "GYPSUM INSULATING PLASTER",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.18,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 8,
+          "embodied_carbon_kgco2e_kg": 1.2
+        },
+        {
+          "name": "GYPSUM PLASTER 1",
+          "density_kg_m3": 1000,
+          "thermal_conductivity_w_mk": 0.4,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.6,
+          "embodied_carbon_kgco2e_kg": 0.11
+        },
+        {
+          "name": "GYPSUM PLASTER 2",
+          "density_kg_m3": 1300,
+          "thermal_conductivity_w_mk": 0.57,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.8,
+          "embodied_carbon_kgco2e_kg": 0.13
+        }
+      ]
+    },
+    "Aluminum": {
+      "default": {
+        "density_kg_m3": 2800,
+        "thermal_conductivity_w_mk": 160,
+        "heat_capacity_j_kgk": 880,
+        "embodied_energy_mj_kg": 155,
+        "embodied_carbon_kgco2e_kg": 9.16,
+        "_source_variant": "ALUMINUM",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "ALUMINUM",
+          "density_kg_m3": 2800,
+          "thermal_conductivity_w_mk": 160,
+          "heat_capacity_j_kgk": 880,
+          "embodied_energy_mj_kg": 155,
+          "embodied_carbon_kgco2e_kg": 9.16
+        }
+      ]
+    },
+    "Steel": {
+      "default": {
+        "density_kg_m3": 7800,
+        "thermal_conductivity_w_mk": 50,
+        "heat_capacity_j_kgk": 450,
+        "embodied_energy_mj_kg": 20.1,
+        "embodied_carbon_kgco2e_kg": 1.46,
+        "_source_variant": "STEEL 1",
+        "_selection": "hand-picked override"
+      },
+      "variants": [
+        {
+          "name": "CAST IRON",
+          "density_kg_m3": 7500,
+          "thermal_conductivity_w_mk": 50,
+          "heat_capacity_j_kgk": 450,
+          "embodied_energy_mj_kg": 25,
+          "embodied_carbon_kgco2e_kg": 1.21
+        },
+        {
+          "name": "STAINLESS STEEL",
+          "density_kg_m3": 7900,
+          "thermal_conductivity_w_mk": 17,
+          "heat_capacity_j_kgk": 460,
+          "embodied_energy_mj_kg": 56.7,
+          "embodied_carbon_kgco2e_kg": 6.15
+        },
+        {
+          "name": "STEEL 1",
+          "density_kg_m3": 7800,
+          "thermal_conductivity_w_mk": 50,
+          "heat_capacity_j_kgk": 450,
+          "embodied_energy_mj_kg": 20.1,
+          "embodied_carbon_kgco2e_kg": 1.46
+        },
+        {
+          "name": "STEEL 2",
+          "density_kg_m3": 7800,
+          "thermal_conductivity_w_mk": 60,
+          "heat_capacity_j_kgk": 460,
+          "embodied_energy_mj_kg": 25.1,
+          "embodied_carbon_kgco2e_kg": 1.66
+        }
+      ]
+    },
+    "Ceramic": {
+      "default": {
+        "density_kg_m3": 2300,
+        "thermal_conductivity_w_mk": 1.3,
+        "heat_capacity_j_kgk": 840,
+        "embodied_energy_mj_kg": 10,
+        "embodied_carbon_kgco2e_kg": 0.7,
+        "_source_variant": "CERAMIC ROOF TILES",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "CERAMIC ROOF TILES",
+          "density_kg_m3": 2300,
+          "thermal_conductivity_w_mk": 1.3,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 10,
+          "embodied_carbon_kgco2e_kg": 0.7
+        }
+      ]
+    },
+    "Acrylic": {
+      "default": {
+        "density_kg_m3": 1050,
+        "thermal_conductivity_w_mk": 0.2,
+        "heat_capacity_j_kgk": 1500,
+        "embodied_energy_mj_kg": 90.67,
+        "embodied_carbon_kgco2e_kg": 4.09,
+        "_source_variant": "ACRYLIC",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "ACRYLIC",
+          "density_kg_m3": 1050,
+          "thermal_conductivity_w_mk": 0.2,
+          "heat_capacity_j_kgk": 1500,
+          "embodied_energy_mj_kg": 90.67,
+          "embodied_carbon_kgco2e_kg": 4.09
+        }
+      ]
+    },
+    "Nylon": {
+      "default": {
+        "density_kg_m3": 1150,
+        "thermal_conductivity_w_mk": 0.25,
+        "heat_capacity_j_kgk": 1600,
+        "embodied_energy_mj_kg": 120.5,
+        "embodied_carbon_kgco2e_kg": 9.14,
+        "_source_variant": "POLYAMIDE",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "POLYAMIDE",
+          "density_kg_m3": 1150,
+          "thermal_conductivity_w_mk": 0.25,
+          "heat_capacity_j_kgk": 1600,
+          "embodied_energy_mj_kg": 120.5,
+          "embodied_carbon_kgco2e_kg": 9.14
+        }
+      ]
+    },
+    "HDPE": {
+      "default": {
+        "density_kg_m3": 980,
+        "thermal_conductivity_w_mk": 0.5,
+        "heat_capacity_j_kgk": 1800,
+        "embodied_energy_mj_kg": 76.7,
+        "embodied_carbon_kgco2e_kg": 1.93,
+        "_source_variant": "HIGH DENSITY POLYETHYLENE",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "HIGH DENSITY POLYETHYLENE",
+          "density_kg_m3": 980,
+          "thermal_conductivity_w_mk": 0.5,
+          "heat_capacity_j_kgk": 1800,
+          "embodied_energy_mj_kg": 76.7,
+          "embodied_carbon_kgco2e_kg": 1.93
+        }
+      ]
+    },
+    "Polypropylene": {
+      "default": {
+        "density_kg_m3": 910,
+        "thermal_conductivity_w_mk": 0.22,
+        "heat_capacity_j_kgk": 1800,
+        "embodied_energy_mj_kg": 99.2,
+        "embodied_carbon_kgco2e_kg": 3.43,
+        "_source_variant": "POLYPROPYLENE",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "POLYPROPYLENE",
+          "density_kg_m3": 910,
+          "thermal_conductivity_w_mk": 0.22,
+          "heat_capacity_j_kgk": 1800,
+          "embodied_energy_mj_kg": 99.2,
+          "embodied_carbon_kgco2e_kg": 3.43
+        }
+      ]
+    },
+    "Vinyl": {
+      "default": {
+        "density_kg_m3": 1390,
+        "thermal_conductivity_w_mk": 0.17,
+        "heat_capacity_j_kgk": 900,
+        "embodied_energy_mj_kg": 77.2,
+        "embodied_carbon_kgco2e_kg": 3.1,
+        "_source_variant": "PVC",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "PVC",
+          "density_kg_m3": 1390,
+          "thermal_conductivity_w_mk": 0.17,
+          "heat_capacity_j_kgk": 900,
+          "embodied_energy_mj_kg": 77.2,
+          "embodied_carbon_kgco2e_kg": 3.1
+        }
+      ]
+    },
+    "Stone": {
+      "default": {
+        "density_kg_m3": 1800,
+        "thermal_conductivity_w_mk": 0.93,
+        "heat_capacity_j_kgk": 840,
+        "embodied_energy_mj_kg": 1.2,
+        "embodied_carbon_kgco2e_kg": 0.07,
+        "_source_variant": "LIMESANDSTONE",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "ARTIFICIAL STONE",
+          "density_kg_m3": 1750,
+          "thermal_conductivity_w_mk": 1.3,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.5,
+          "embodied_carbon_kgco2e_kg": 0.18
+        },
+        {
+          "name": "BASALT",
+          "density_kg_m3": 2850,
+          "thermal_conductivity_w_mk": 3.5,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 11,
+          "embodied_carbon_kgco2e_kg": 0.7
+        },
+        {
+          "name": "GNEISS",
+          "density_kg_m3": 2550,
+          "thermal_conductivity_w_mk": 3.5,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 10.5,
+          "embodied_carbon_kgco2e_kg": 0.65
+        },
+        {
+          "name": "GRANITE 1",
+          "density_kg_m3": 2600,
+          "thermal_conductivity_w_mk": 2.8,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 10.2,
+          "embodied_carbon_kgco2e_kg": 0.63
+        },
+        {
+          "name": "GRANITE 2",
+          "density_kg_m3": 2700,
+          "thermal_conductivity_w_mk": 3.4,
+          "heat_capacity_j_kgk": 800,
+          "embodied_energy_mj_kg": 14,
+          "embodied_carbon_kgco2e_kg": 0.75
+        },
+        {
+          "name": "LIMESTONE HARD",
+          "density_kg_m3": 2600,
+          "thermal_conductivity_w_mk": 2.3,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.7,
+          "embodied_carbon_kgco2e_kg": 0.095
+        },
+        {
+          "name": "LIMESTONE MEDIUM",
+          "density_kg_m3": 2200,
+          "thermal_conductivity_w_mk": 1.7,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.5,
+          "embodied_carbon_kgco2e_kg": 0.09
+        },
+        {
+          "name": "LIMESTONE SOFT",
+          "density_kg_m3": 1800,
+          "thermal_conductivity_w_mk": 1.1,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.4,
+          "embodied_carbon_kgco2e_kg": 0.085
+        },
+        {
+          "name": "LIMESANDSTONE",
+          "density_kg_m3": 1800,
+          "thermal_conductivity_w_mk": 0.93,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 1.2,
+          "embodied_carbon_kgco2e_kg": 0.07
+        },
+        {
+          "name": "MARBLE",
+          "density_kg_m3": 2800,
+          "thermal_conductivity_w_mk": 3.5,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 2,
+          "embodied_carbon_kgco2e_kg": 0.13
+        },
+        {
+          "name": "NATURAL PUMICE",
+          "density_kg_m3": 400,
+          "thermal_conductivity_w_mk": 0.12,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 0.09,
+          "embodied_carbon_kgco2e_kg": 0.007
+        },
+        {
+          "name": "CRYSTALLINE ROCK",
+          "density_kg_m3": 2800,
+          "thermal_conductivity_w_mk": 3.5,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 2.4,
+          "embodied_carbon_kgco2e_kg": 0.16
+        },
+        {
+          "name": "POROUS ROCK",
+          "density_kg_m3": 1600,
+          "thermal_conductivity_w_mk": 0.55,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1,
+          "embodied_carbon_kgco2e_kg": 0.06
+        },
+        {
+          "name": "SEDIMENTARY ROCK HEAVY",
+          "density_kg_m3": 2600,
+          "thermal_conductivity_w_mk": 2.3,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1.2,
+          "embodied_carbon_kgco2e_kg": 0.08
+        },
+        {
+          "name": "SEDIMENTARY ROCK LIGHT",
+          "density_kg_m3": 1500,
+          "thermal_conductivity_w_mk": 0.85,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 0.8,
+          "embodied_carbon_kgco2e_kg": 0.04
+        },
+        {
+          "name": "SANDSTONE",
+          "density_kg_m3": 2600,
+          "thermal_conductivity_w_mk": 2.3,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 1,
+          "embodied_carbon_kgco2e_kg": 0.06
+        },
+        {
+          "name": "SLATE",
+          "density_kg_m3": 2400,
+          "thermal_conductivity_w_mk": 2.2,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 5.5,
+          "embodied_carbon_kgco2e_kg": 0.035
+        }
+      ]
+    },
+    "Fiberglass": {
+      "default": {
+        "density_kg_m3": 23,
+        "thermal_conductivity_w_mk": 0.033,
+        "heat_capacity_j_kgk": 1030,
+        "embodied_energy_mj_kg": 28,
+        "embodied_carbon_kgco2e_kg": 1.35,
+        "_source_variant": "ELEVATION GLASS WOOL 2",
+        "_selection": "hand-picked override"
+      },
+      "variants": [
+        {
+          "name": "ELEVATION GLASS WOOL 1",
+          "density_kg_m3": 14,
+          "thermal_conductivity_w_mk": 0.04,
+          "heat_capacity_j_kgk": 1030,
+          "embodied_energy_mj_kg": 26,
+          "embodied_carbon_kgco2e_kg": 1.3
+        },
+        {
+          "name": "ELEVATION GLASS WOOL 2",
+          "density_kg_m3": 23,
+          "thermal_conductivity_w_mk": 0.033,
+          "heat_capacity_j_kgk": 1030,
+          "embodied_energy_mj_kg": 28,
+          "embodied_carbon_kgco2e_kg": 1.35
+        },
+        {
+          "name": "ELEVATION GLASS WOOL 3",
+          "density_kg_m3": 50,
+          "thermal_conductivity_w_mk": 0.033,
+          "heat_capacity_j_kgk": 1030,
+          "embodied_energy_mj_kg": 35,
+          "embodied_carbon_kgco2e_kg": 1.45
+        },
+        {
+          "name": "ROOF GLASS WOOL",
+          "density_kg_m3": 14.5,
+          "thermal_conductivity_w_mk": 0.038,
+          "heat_capacity_j_kgk": 1030,
+          "embodied_energy_mj_kg": 25,
+          "embodied_carbon_kgco2e_kg": 1.25
+        },
+        {
+          "name": "INACCESSIBLE FLOOR GLASS WOOL 1",
+          "density_kg_m3": 13,
+          "thermal_conductivity_w_mk": 0.035,
+          "heat_capacity_j_kgk": 1450,
+          "embodied_energy_mj_kg": 24,
+          "embodied_carbon_kgco2e_kg": 1.23
+        },
+        {
+          "name": "INACCESSIBLE FLOOR GLASS WOOL 2",
+          "density_kg_m3": 14.5,
+          "thermal_conductivity_w_mk": 0.038,
+          "heat_capacity_j_kgk": 1030,
+          "embodied_energy_mj_kg": 26.5,
+          "embodied_carbon_kgco2e_kg": 1.32
+        },
+        {
+          "name": "ACCESSIBLE FLOOR GLASS WOOL 1",
+          "density_kg_m3": 64,
+          "thermal_conductivity_w_mk": 0.033,
+          "heat_capacity_j_kgk": 1030,
+          "embodied_energy_mj_kg": 37,
+          "embodied_carbon_kgco2e_kg": 1.48
+        },
+        {
+          "name": "ACCESSIBLE FLOOR GLASS WOOL 2",
+          "density_kg_m3": 115,
+          "thermal_conductivity_w_mk": 0.033,
+          "heat_capacity_j_kgk": 1030,
+          "embodied_energy_mj_kg": 47,
+          "embodied_carbon_kgco2e_kg": 1.9
+        }
+      ]
+    },
+    "Mineral wool": {
+      "default": {
+        "density_kg_m3": 50,
+        "thermal_conductivity_w_mk": 0.036,
+        "heat_capacity_j_kgk": 840,
+        "embodied_energy_mj_kg": 15.7,
+        "embodied_carbon_kgco2e_kg": 1.23,
+        "_source_variant": "MINERAL WOOL 2",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "ECOFIBER",
+          "density_kg_m3": 27,
+          "thermal_conductivity_w_mk": 0.04,
+          "heat_capacity_j_kgk": 2500,
+          "embodied_energy_mj_kg": 14.7,
+          "embodied_carbon_kgco2e_kg": 1.12
+        },
+        {
+          "name": "ISODRAIN",
+          "density_kg_m3": 19,
+          "thermal_conductivity_w_mk": 0.039,
+          "heat_capacity_j_kgk": 1400,
+          "embodied_energy_mj_kg": 14.1,
+          "embodied_carbon_kgco2e_kg": 1.08
+        },
+        {
+          "name": "LOSULL 1",
+          "density_kg_m3": 15,
+          "thermal_conductivity_w_mk": 0.06,
+          "heat_capacity_j_kgk": 750,
+          "embodied_energy_mj_kg": 12.5,
+          "embodied_carbon_kgco2e_kg": 0.98
+        },
+        {
+          "name": "LOSULL 2",
+          "density_kg_m3": 50,
+          "thermal_conductivity_w_mk": 0.042,
+          "heat_capacity_j_kgk": 750,
+          "embodied_energy_mj_kg": 14.9,
+          "embodied_carbon_kgco2e_kg": 1.2
+        },
+        {
+          "name": "MINERAL WOOL 1",
+          "density_kg_m3": 50,
+          "thermal_conductivity_w_mk": 0.033,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 14.6,
+          "embodied_carbon_kgco2e_kg": 1.15
+        },
+        {
+          "name": "MINERAL WOOL 2",
+          "density_kg_m3": 50,
+          "thermal_conductivity_w_mk": 0.036,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 15.7,
+          "embodied_carbon_kgco2e_kg": 1.23
+        },
+        {
+          "name": "MINERAL WOOL 3",
+          "density_kg_m3": 50,
+          "thermal_conductivity_w_mk": 0.04,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 16.6,
+          "embodied_carbon_kgco2e_kg": 1.28
+        },
+        {
+          "name": "MINERAL WOOL 4",
+          "density_kg_m3": 50,
+          "thermal_conductivity_w_mk": 0.05,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 18.1,
+          "embodied_carbon_kgco2e_kg": 1.34
+        },
+        {
+          "name": "MINERAL WOOL SOFT",
+          "density_kg_m3": 40,
+          "thermal_conductivity_w_mk": 0.037,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 14.3,
+          "embodied_carbon_kgco2e_kg": 1.08
+        },
+        {
+          "name": "MINERAL WOOL HARD",
+          "density_kg_m3": 115,
+          "thermal_conductivity_w_mk": 0.036,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 21.2,
+          "embodied_carbon_kgco2e_kg": 1.65
+        },
+        {
+          "name": "PLASTERABLE MINERAL WOOL",
+          "density_kg_m3": 115,
+          "thermal_conductivity_w_mk": 0.036,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 21.4,
+          "embodied_carbon_kgco2e_kg": 1.69
+        },
+        {
+          "name": "WATERPROOF MINERAL WOOL",
+          "density_kg_m3": 160,
+          "thermal_conductivity_w_mk": 0.04,
+          "heat_capacity_j_kgk": 840,
+          "embodied_energy_mj_kg": 23.4,
+          "embodied_carbon_kgco2e_kg": 1.73
+        }
+      ]
+    },
+    "EPS Foam": {
+      "default": {
+        "density_kg_m3": 25,
+        "thermal_conductivity_w_mk": 0.033,
+        "heat_capacity_j_kgk": 1400,
+        "embodied_energy_mj_kg": 83.4,
+        "embodied_carbon_kgco2e_kg": 3.29,
+        "_source_variant": "EXP.PLASTICS 1",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "EPS 1",
+          "density_kg_m3": 15,
+          "thermal_conductivity_w_mk": 0.042,
+          "heat_capacity_j_kgk": 1450,
+          "embodied_energy_mj_kg": 76,
+          "embodied_carbon_kgco2e_kg": 3.18
+        },
+        {
+          "name": "EPS 2",
+          "density_kg_m3": 25,
+          "thermal_conductivity_w_mk": 0.036,
+          "heat_capacity_j_kgk": 1450,
+          "embodied_energy_mj_kg": 86.6,
+          "embodied_carbon_kgco2e_kg": 3.29
+        },
+        {
+          "name": "EXP.PLASTICS 1",
+          "density_kg_m3": 25,
+          "thermal_conductivity_w_mk": 0.033,
+          "heat_capacity_j_kgk": 1400,
+          "embodied_energy_mj_kg": 83.4,
+          "embodied_carbon_kgco2e_kg": 3.29
+        },
+        {
+          "name": "EXP.PLASTICS 2",
+          "density_kg_m3": 25,
+          "thermal_conductivity_w_mk": 0.036,
+          "heat_capacity_j_kgk": 1400,
+          "embodied_energy_mj_kg": 86.4,
+          "embodied_carbon_kgco2e_kg": 3.43
+        },
+        {
+          "name": "EXP.PLASTICS 3",
+          "density_kg_m3": 25,
+          "thermal_conductivity_w_mk": 0.04,
+          "heat_capacity_j_kgk": 1400,
+          "embodied_energy_mj_kg": 88.7,
+          "embodied_carbon_kgco2e_kg": 3.53
+        }
+      ]
+    },
+    "Spray polyurethane foam": {
+      "default": {
+        "density_kg_m3": 30,
+        "thermal_conductivity_w_mk": 0.035,
+        "heat_capacity_j_kgk": 1450,
+        "embodied_energy_mj_kg": 102.1,
+        "embodied_carbon_kgco2e_kg": 4.84,
+        "_source_variant": "POLYFOAM",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "POLYFOAM",
+          "density_kg_m3": 30,
+          "thermal_conductivity_w_mk": 0.035,
+          "heat_capacity_j_kgk": 1450,
+          "embodied_energy_mj_kg": 102.1,
+          "embodied_carbon_kgco2e_kg": 4.84
+        }
+      ]
+    },
+    "XPS Foam": {
+      "default": {
+        "density_kg_m3": 28,
+        "thermal_conductivity_w_mk": 0.032,
+        "heat_capacity_j_kgk": 1450,
+        "embodied_energy_mj_kg": 87.4,
+        "embodied_carbon_kgco2e_kg": 3.42,
+        "_source_variant": "XPS",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "XPS",
+          "density_kg_m3": 28,
+          "thermal_conductivity_w_mk": 0.032,
+          "heat_capacity_j_kgk": 1450,
+          "embodied_energy_mj_kg": 87.4,
+          "embodied_carbon_kgco2e_kg": 3.42
+        }
+      ]
+    },
+    "Wood fibre": {
+      "default": {
+        "density_kg_m3": 1000,
+        "thermal_conductivity_w_mk": 0.13,
+        "heat_capacity_j_kgk": 1350,
+        "embodied_energy_mj_kg": 11.98,
+        "embodied_carbon_kgco2e_kg": 0.51,
+        "_source_variant": "WOODFIBER H",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "WOODFIBER",
+          "density_kg_m3": 300,
+          "thermal_conductivity_w_mk": 0.052,
+          "heat_capacity_j_kgk": 1350,
+          "embodied_energy_mj_kg": 12.4,
+          "embodied_carbon_kgco2e_kg": 0.09
+        },
+        {
+          "name": "WOODFIBER H",
+          "density_kg_m3": 1000,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 1350,
+          "embodied_energy_mj_kg": 11.98,
+          "embodied_carbon_kgco2e_kg": 0.51
+        },
+        {
+          "name": "WOODFIBER HH",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.08,
+          "heat_capacity_j_kgk": 1350,
+          "embodied_energy_mj_kg": 10.7,
+          "embodied_carbon_kgco2e_kg": 0.48
+        }
+      ]
+    },
+    "Wood wool board": {
+      "default": {
+        "density_kg_m3": 350,
+        "thermal_conductivity_w_mk": 0.077,
+        "heat_capacity_j_kgk": 2000,
+        "embodied_energy_mj_kg": 15.1,
+        "embodied_carbon_kgco2e_kg": 0.18,
+        "_source_variant": "WOOD WOOL 2",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "WOOD WOOL 1",
+          "density_kg_m3": 200,
+          "thermal_conductivity_w_mk": 0.075,
+          "heat_capacity_j_kgk": 1510,
+          "embodied_energy_mj_kg": 10.8,
+          "embodied_carbon_kgco2e_kg": 0.12
+        },
+        {
+          "name": "WOOD WOOL 2",
+          "density_kg_m3": 350,
+          "thermal_conductivity_w_mk": 0.077,
+          "heat_capacity_j_kgk": 2000,
+          "embodied_energy_mj_kg": 15.1,
+          "embodied_carbon_kgco2e_kg": 0.18
+        },
+        {
+          "name": "WOOD WOOL 3",
+          "density_kg_m3": 440,
+          "thermal_conductivity_w_mk": 0.1,
+          "heat_capacity_j_kgk": 2000,
+          "embodied_energy_mj_kg": 15.4,
+          "embodied_carbon_kgco2e_kg": 0.2
+        },
+        {
+          "name": "WOOD WOOL 4",
+          "density_kg_m3": 680,
+          "thermal_conductivity_w_mk": 0.167,
+          "heat_capacity_j_kgk": 2000,
+          "embodied_energy_mj_kg": 17.7,
+          "embodied_carbon_kgco2e_kg": 0.42
+        }
+      ]
+    },
+    "Framing": {
+      "default": {
+        "density_kg_m3": 500,
+        "thermal_conductivity_w_mk": 0.13,
+        "heat_capacity_j_kgk": 2500,
+        "embodied_energy_mj_kg": 7.11,
+        "embodied_carbon_kgco2e_kg": 0.32,
+        "_source_variant": "TIMBER 2",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "TIMBER 1",
+          "density_kg_m3": 500,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 1600,
+          "embodied_energy_mj_kg": 6.95,
+          "embodied_carbon_kgco2e_kg": 0.29
+        },
+        {
+          "name": "TIMBER 2",
+          "density_kg_m3": 500,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 2500,
+          "embodied_energy_mj_kg": 7.11,
+          "embodied_carbon_kgco2e_kg": 0.32
+        },
+        {
+          "name": "TIMBER 3",
+          "density_kg_m3": 500,
+          "thermal_conductivity_w_mk": 0.14,
+          "heat_capacity_j_kgk": 2300,
+          "embodied_energy_mj_kg": 10,
+          "embodied_carbon_kgco2e_kg": 0.36
+        },
+        {
+          "name": "TIMBER 4",
+          "density_kg_m3": 700,
+          "thermal_conductivity_w_mk": 0.18,
+          "heat_capacity_j_kgk": 1600,
+          "embodied_energy_mj_kg": 12.1,
+          "embodied_carbon_kgco2e_kg": 0.39
+        }
+      ]
+    },
+    "Sheathing": {
+      "default": {
+        "density_kg_m3": 650,
+        "thermal_conductivity_w_mk": 0.13,
+        "heat_capacity_j_kgk": 1700,
+        "embodied_energy_mj_kg": 15,
+        "embodied_carbon_kgco2e_kg": 0.9,
+        "_source_variant": "OSB",
+        "_selection": "hand-picked override"
+      },
+      "variants": [
+        {
+          "name": "ASPHABOARD",
+          "density_kg_m3": 400,
+          "thermal_conductivity_w_mk": 0.065,
+          "heat_capacity_j_kgk": 1170,
+          "embodied_energy_mj_kg": 14.5,
+          "embodied_carbon_kgco2e_kg": 0.71
+        },
+        {
+          "name": "CEMENT BONDED PARTICLEBOARD",
+          "density_kg_m3": 1200,
+          "thermal_conductivity_w_mk": 0.23,
+          "heat_capacity_j_kgk": 1500,
+          "embodied_energy_mj_kg": 12.1,
+          "embodied_carbon_kgco2e_kg": 0.65
+        },
+        {
+          "name": "CHIPBOARD",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.14,
+          "heat_capacity_j_kgk": 2300,
+          "embodied_energy_mj_kg": 14.7,
+          "embodied_carbon_kgco2e_kg": 0.81
+        },
+        {
+          "name": "IMPREGNATED BOARD",
+          "density_kg_m3": 400,
+          "thermal_conductivity_w_mk": 0.065,
+          "heat_capacity_j_kgk": 1350,
+          "embodied_energy_mj_kg": 15,
+          "embodied_carbon_kgco2e_kg": 1.3
+        },
+        {
+          "name": "OSB",
+          "density_kg_m3": 650,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 15,
+          "embodied_carbon_kgco2e_kg": 0.9
+        },
+        {
+          "name": "PARTICLEBOARD 1",
+          "density_kg_m3": 300,
+          "thermal_conductivity_w_mk": 0.1,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 14.2,
+          "embodied_carbon_kgco2e_kg": 0.58
+        },
+        {
+          "name": "PARTICLEBOARD 2",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.14,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 14.5,
+          "embodied_carbon_kgco2e_kg": 0.7
+        },
+        {
+          "name": "PARTICLEBOARD 3",
+          "density_kg_m3": 900,
+          "thermal_conductivity_w_mk": 0.18,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 14.9,
+          "embodied_carbon_kgco2e_kg": 0.83
+        }
+      ]
+    },
+    "Wood fiberboard": {
+      "default": {
+        "density_kg_m3": 600,
+        "thermal_conductivity_w_mk": 0.14,
+        "heat_capacity_j_kgk": 1700,
+        "embodied_energy_mj_kg": 12.1,
+        "embodied_carbon_kgco2e_kg": 0.79,
+        "_source_variant": "FIBREBOARD 3",
+        "_selection": "hand-picked override"
+      },
+      "variants": [
+        {
+          "name": "FIBREBOARD 1",
+          "density_kg_m3": 250,
+          "thermal_conductivity_w_mk": 0.07,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 10.1,
+          "embodied_carbon_kgco2e_kg": 0.69
+        },
+        {
+          "name": "FIBREBOARD 2",
+          "density_kg_m3": 400,
+          "thermal_conductivity_w_mk": 0.1,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 11,
+          "embodied_carbon_kgco2e_kg": 0.74
+        },
+        {
+          "name": "FIBREBOARD 3",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.14,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 12.1,
+          "embodied_carbon_kgco2e_kg": 0.79
+        },
+        {
+          "name": "FIBREBOARD 4",
+          "density_kg_m3": 800,
+          "thermal_conductivity_w_mk": 0.18,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 13.8,
+          "embodied_carbon_kgco2e_kg": 0.92
+        },
+        {
+          "name": "MASONITE 1",
+          "density_kg_m3": 1600,
+          "thermal_conductivity_w_mk": 0.79,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 16.9,
+          "embodied_carbon_kgco2e_kg": 1.44
+        },
+        {
+          "name": "MASONITE 2",
+          "density_kg_m3": 1000,
+          "thermal_conductivity_w_mk": 0.5,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 15,
+          "embodied_carbon_kgco2e_kg": 1.3
+        },
+        {
+          "name": "MASONITE 3",
+          "density_kg_m3": 2000,
+          "thermal_conductivity_w_mk": 1.1,
+          "heat_capacity_j_kgk": 1000,
+          "embodied_energy_mj_kg": 18.2,
+          "embodied_carbon_kgco2e_kg": 1.61
+        },
+        {
+          "name": "MDF BOARD 1",
+          "density_kg_m3": 250,
+          "thermal_conductivity_w_mk": 0.07,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 9.2,
+          "embodied_carbon_kgco2e_kg": 0.64
+        },
+        {
+          "name": "MDF BOARD 2",
+          "density_kg_m3": 400,
+          "thermal_conductivity_w_mk": 0.1,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 10,
+          "embodied_carbon_kgco2e_kg": 0.68
+        },
+        {
+          "name": "MDF BOARD 3",
+          "density_kg_m3": 600,
+          "thermal_conductivity_w_mk": 0.14,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 11,
+          "embodied_carbon_kgco2e_kg": 0.74
+        },
+        {
+          "name": "MDF BOARD 4",
+          "density_kg_m3": 800,
+          "thermal_conductivity_w_mk": 0.18,
+          "heat_capacity_j_kgk": 1700,
+          "embodied_energy_mj_kg": 11.9,
+          "embodied_carbon_kgco2e_kg": 0.82
+        }
+      ]
+    },
+    "Plywood": {
+      "default": {
+        "density_kg_m3": 500,
+        "thermal_conductivity_w_mk": 0.13,
+        "heat_capacity_j_kgk": 1600,
+        "embodied_energy_mj_kg": 13.1,
+        "embodied_carbon_kgco2e_kg": 0.64,
+        "_source_variant": "PLYWOOD 2",
+        "_selection": "median by density"
+      },
+      "variants": [
+        {
+          "name": "PLYWOOD 1",
+          "density_kg_m3": 300,
+          "thermal_conductivity_w_mk": 0.09,
+          "heat_capacity_j_kgk": 1600,
+          "embodied_energy_mj_kg": 11.9,
+          "embodied_carbon_kgco2e_kg": 0.52
+        },
+        {
+          "name": "PLYWOOD 2",
+          "density_kg_m3": 500,
+          "thermal_conductivity_w_mk": 0.13,
+          "heat_capacity_j_kgk": 1600,
+          "embodied_energy_mj_kg": 13.1,
+          "embodied_carbon_kgco2e_kg": 0.64
+        },
+        {
+          "name": "PLYWOOD 3",
+          "density_kg_m3": 700,
+          "thermal_conductivity_w_mk": 0.17,
+          "heat_capacity_j_kgk": 1600,
+          "embodied_energy_mj_kg": 15,
+          "embodied_carbon_kgco2e_kg": 0.77
+        },
+        {
+          "name": "PLYWOOD 4",
+          "density_kg_m3": 1000,
+          "thermal_conductivity_w_mk": 0.24,
+          "heat_capacity_j_kgk": 1600,
+          "embodied_energy_mj_kg": 16.8,
+          "embodied_carbon_kgco2e_kg": 0.87
+        }
+      ]
+    }
+  },
+  "_unmapped": [
+    {
+      "group": "FLOOR COVERINGS",
+      "name": "RUBBER FLOOR"
+    },
+    {
+      "group": "FLOOR COVERINGS",
+      "name": "CORK FLOOR"
+    },
+    {
+      "group": "FLOOR COVERINGS",
+      "name": "CELLULAR RUBBER UNDERLAY"
+    },
+    {
+      "group": "FLOOR COVERINGS",
+      "name": "CORK UNDERLAY"
+    },
+    {
+      "group": "FLOOR COVERINGS",
+      "name": "FELT UNDERLAY"
+    },
+    {
+      "group": "FLOOR COVERINGS",
+      "name": "PLASTIC UNDERLAY"
+    },
+    {
+      "group": "FLOOR COVERINGS",
+      "name": "WOOL UNDERLAY"
+    },
+    {
+      "group": "METALS",
+      "name": "BRASS"
+    },
+    {
+      "group": "METALS",
+      "name": "BRONZE"
+    },
+    {
+      "group": "METALS",
+      "name": "COPPER"
+    },
+    {
+      "group": "METALS",
+      "name": "LEAD"
+    },
+    {
+      "group": "METALS",
+      "name": "ZINC"
+    },
+    {
+      "group": "PLASTERS AND RENDERINGS",
+      "name": "SLOW SET PLASTER"
+    },
+    {
+      "group": "ROOF TILES",
+      "name": "PLASTIC ROOF TILES"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "EPOXY RESIN"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "PHENOLIC RESIN"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "POLYACETATE"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "POLYCARBONATE"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "POLYESTER RESIN"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "LOW DENSITY POLYETHYLENE"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "PMMA"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "POLYSTYRENE"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "PTFE"
+    },
+    {
+      "group": "SOLID PLASTICS",
+      "name": "PU"
+    },
+    {
+      "group": "STONES",
+      "name": "DRAINED GRAVEL"
+    },
+    {
+      "group": "STONES",
+      "name": "DRAINED SAND"
+    },
+    {
+      "group": "STONES",
+      "name": "COKE ASH"
+    },
+    {
+      "group": "STONES",
+      "name": "UNDRAINED SAND"
+    },
+    {
+      "group": "WOOD AND WOOD BASED PANELS",
+      "name": "SAWDUST"
+    }
+  ]
+}

--- a/schema/lookups/db-fallbacks.source.xml
+++ b/schema/lookups/db-fallbacks.source.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MaterialCatalog>
+  <MaterialGroup Name="AERATED CONCRETE">
+    <Material Name="AERATED CONCRETE BLOCK 1" ThermalConduct="0.13" Density="500" HeatCapacity="1290" EmbodiedEnergy="0.59" EmbodiedCarbon="0.063"/>
+    <Material Name="AERATED CONCRETE BLOCK 2" ThermalConduct="0.16" Density="600" HeatCapacity="1240" EmbodiedEnergy="0.67" EmbodiedCarbon="0.078"/>
+    <Material Name="AERATED CONCRETE BLOCK 3" ThermalConduct="0.18" Density="700" HeatCapacity="1210" EmbodiedEnergy="0.72" EmbodiedCarbon="0.088"/>
+    <Material Name="AERATED CONCRETE BLOCK INTERLOCKING 1" ThermalConduct="0.11" Density="400" HeatCapacity="1350" EmbodiedEnergy="0.55" EmbodiedCarbon="0.059"/>
+    <Material Name="AERATED CONCRETE BLOCK INTERLOCKING 2" ThermalConduct="0.16" Density="500" HeatCapacity="1240" EmbodiedEnergy="0.59" EmbodiedCarbon="0.063"/>
+    <Material Name="AIR-ENT CONCRETE 1" ThermalConduct="0.1" Density="400" HeatCapacity="1050" EmbodiedEnergy="0.55" EmbodiedCarbon="0.059"/>
+    <Material Name="AIR-ENT CONCRETE 2" ThermalConduct="0.12" Density="450" HeatCapacity="1050" EmbodiedEnergy="0.57" EmbodiedCarbon="0.061"/>
+    <Material Name="AIR-ENT CONCRETE 3" ThermalConduct="0.13" Density="450" HeatCapacity="1050" EmbodiedEnergy="0.57" EmbodiedCarbon="0.061"/>
+    <Material Name="AIR-ENT CONCRETE 4" ThermalConduct="0.14" Density="500" HeatCapacity="1050" EmbodiedEnergy="0.59" EmbodiedCarbon="0.063"/>
+    <Material Name="AIR-ENT CONCRETE 5" ThermalConduct="0.16" Density="600" HeatCapacity="1050" EmbodiedEnergy="0.67" EmbodiedCarbon="0.078"/>
+    <Material Name="GASCONCRETE 1" ThermalConduct="0.13" Density="550" HeatCapacity="920" EmbodiedEnergy="0.63" EmbodiedCarbon="0.070"/>
+    <Material Name="GASCONCRETE 2" ThermalConduct="0.15" Density="510" HeatCapacity="1050" EmbodiedEnergy="0.61" EmbodiedCarbon="0.064"/>
+  </MaterialGroup>
+  <MaterialGroup Name="AIR GAPS">
+    <Material Name="10MM DOWNWARD CURRENT" ThermalConduct="0.15" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="10MM HORIZONTAL CURRENT" ThermalConduct="0.15" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="10MM UPWARD CURRENT" ThermalConduct="0.15" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="50MM DOWNWARD CURRENT" ThermalConduct="0.18" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="50MM HORIZONTAL CURRENT" ThermalConduct="0.16" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="50MM UPWARD CURRENT" ThermalConduct="0.15" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="100MM DOWNWARD CURRENT" ThermalConduct="0.22" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="100MM HORIZONTAL CURRENT" ThermalConduct="0.18" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="100MM UPWARD CURRENT" ThermalConduct="0.16" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="300MM DOWNWARD CURRENT" ThermalConduct="0.23" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="300MM HORIZONTAL CURRENT" ThermalConduct="0.18" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+    <Material Name="300MM UPWARD CURRENT" ThermalConduct="0.16" Density="1.2" HeatCapacity="1008" EmbodiedEnergy="0" EmbodiedCarbon="0"/>
+  </MaterialGroup>
+  <MaterialGroup Name="ASPHALT">
+    <Material Name="ASPHALT" ThermalConduct="0.7" Density="2100" HeatCapacity="1000" EmbodiedEnergy="3.93" EmbodiedCarbon="0.076"/>
+  </MaterialGroup>
+  <MaterialGroup Name="BITUMEN">
+    <Material Name="BITUMEN PURE" ThermalConduct="0.17" Density="1050" HeatCapacity="1000" EmbodiedEnergy="42" EmbodiedCarbon="0.55"/>
+    <Material Name="BITUMINOUS FELT" ThermalConduct="0.23" Density="1100" HeatCapacity="1000" EmbodiedEnergy="2.66" EmbodiedCarbon="0.056"/>
+    <Material Name="BITUMINOUS SHEET" ThermalConduct="0.23" Density="1100" HeatCapacity="1000" EmbodiedEnergy="2.86" EmbodiedCarbon="0.066"/>
+  </MaterialGroup>
+  <MaterialGroup Name="BURNT CLAY">
+    <Material Name="SOLID BRICK 1" ThermalConduct="0.58" Density="1500" HeatCapacity="840" EmbodiedEnergy="3" EmbodiedCarbon="0.24"/>
+    <Material Name="SOLID BRICK 2" ThermalConduct="0.60" Density="1500" HeatCapacity="840" EmbodiedEnergy="3" EmbodiedCarbon="0.24"/>
+    <Material Name="BURNT CLAY BLOCK LIMITED STRENGTH 1" ThermalConduct="0.109" Density="600" HeatCapacity="920" EmbodiedEnergy="6" EmbodiedCarbon="0.48"/>
+    <Material Name="BURNT CLAY BLOCK LIMITED STRENGTH 2" ThermalConduct="0.121" Density="648" HeatCapacity="920" EmbodiedEnergy="6" EmbodiedCarbon="0.48"/>
+    <Material Name="BURNT CLAY BLOCK MEDIUM STRENGTH 1" ThermalConduct="0.125" Density="742" HeatCapacity="920" EmbodiedEnergy="6" EmbodiedCarbon="0.48"/>
+    <Material Name="BURNT CLAY BLOCK MEDIUM STRENGTH 2" ThermalConduct="0.148" Density="694" HeatCapacity="920" EmbodiedEnergy="6" EmbodiedCarbon="0.48"/>
+    <Material Name="BURNT CLAY BLOCK TO BE INSULATED MEDIUM STRENGTH 1" ThermalConduct="0.216" Density="960" HeatCapacity="920" EmbodiedEnergy="4.5" EmbodiedCarbon="0.36"/>
+    <Material Name="BURNT CLAY BLOCK TO BE INSULATED MEDIUM STRENGTH 2" ThermalConduct="0.272" Density="840" HeatCapacity="920" EmbodiedEnergy="4.5" EmbodiedCarbon="0.36"/>
+    <Material Name="BURNT CLAY BLOCK TO BE INSULATED STRONG" ThermalConduct="0.324" Density="940" HeatCapacity="920" EmbodiedEnergy="4.5" EmbodiedCarbon="0.36"/>
+  </MaterialGroup>
+  <MaterialGroup Name="CONCRETE">
+    <Material Name="CONCRETE LOW CONDUCTIVITY" ThermalConduct="0.8" Density="2300" HeatCapacity="800" EmbodiedEnergy="0.92" EmbodiedCarbon="0.15"/>
+    <Material Name="CONCRETE 1" ThermalConduct="1.15" Density="1800" HeatCapacity="1000" EmbodiedEnergy="0.74" EmbodiedCarbon="0.107"/>
+    <Material Name="CONCRETE 2" ThermalConduct="1.35" Density="2000" HeatCapacity="1000" EmbodiedEnergy="0.78" EmbodiedCarbon="0.113"/>
+    <Material Name="CONCRETE 3" ThermalConduct="1.65" Density="2200" HeatCapacity="1000" EmbodiedEnergy="0.82" EmbodiedCarbon="0.12"/>
+    <Material Name="CONCRETE 4" ThermalConduct="1.7" Density="2300" HeatCapacity="800" EmbodiedEnergy="0.88" EmbodiedCarbon="0.132"/>
+    <Material Name="CONCRETE BLOCK" ThermalConduct="0.6" Density="1400" HeatCapacity="880" EmbodiedEnergy="0.72" EmbodiedCarbon="0.088"/>
+    <Material Name="CORK-CONCRETE" ThermalConduct="0.44" Density="1300" HeatCapacity="1000" EmbodiedEnergy="0.45" EmbodiedCarbon="0.05"/>
+    <Material Name="REINFORCED CONCRETE W/ 1% STEEL" ThermalConduct="2.3" Density="2300" HeatCapacity="1000" EmbodiedEnergy="1.92" EmbodiedCarbon="0.198"/>
+    <Material Name="REINFORCED CONCRETE W/ 2% STEEL" ThermalConduct="2.5" Density="2400" HeatCapacity="1000" EmbodiedEnergy="2.33" EmbodiedCarbon="0.242"/>
+  </MaterialGroup>
+  <MaterialGroup Name="ENVIRONMENT">
+    <Material Name="CLAY" ThermalConduct="0.5" Density="1800" HeatCapacity="1000" EmbodiedEnergy="0.45" EmbodiedCarbon="0.024"/>
+    <Material Name="SILT" ThermalConduct="2.3" Density="2200" HeatCapacity="1900" EmbodiedEnergy="0.56" EmbodiedCarbon="0.041"/>
+    <Material Name="SAND" ThermalConduct="2.3" Density="2200" HeatCapacity="1900" EmbodiedEnergy="0.081" EmbodiedCarbon="0.005"/>
+    <Material Name="GRAVEL" ThermalConduct="1.4" Density="2200" HeatCapacity="1900" EmbodiedEnergy="0.083" EmbodiedCarbon="0.005"/>
+    <Material Name="ROCK" ThermalConduct="3.5" Density="2700" HeatCapacity="750" EmbodiedEnergy="0.085" EmbodiedCarbon="0.005"/>
+    <Material Name="BLAST ROCK" ThermalConduct="3.5" Density="2300" HeatCapacity="750" EmbodiedEnergy="0.086" EmbodiedCarbon="0.005"/>
+    <Material Name="SOIL" ThermalConduct="1.7" Density="900" HeatCapacity="1850" EmbodiedEnergy="0.42" EmbodiedCarbon="0.022"/>
+    <Material Name="SANDY SOIL" ThermalConduct="1.8" Density="1800" HeatCapacity="1200" EmbodiedEnergy="0.3" EmbodiedCarbon="0.01"/>
+    <Material Name="CLAY SOIL" ThermalConduct="1.4" Density="1900" HeatCapacity="1400" EmbodiedEnergy="0.43" EmbodiedCarbon="0.023"/>
+    <Material Name="PEAT SOIL" ThermalConduct="0.4" Density="900" HeatCapacity="2400" EmbodiedEnergy="0.42" EmbodiedCarbon="0.022"/>
+    <Material Name="WATER" ThermalConduct="0.6" Density="1000" HeatCapacity="4200" EmbodiedEnergy="0.01" EmbodiedCarbon="0.001"/>
+  </MaterialGroup>
+  <MaterialGroup Name="EXPANDED CLAY">
+    <Material Name="EXPANDED CLAY-CONCRETE BLOCK" ThermalConduct="0.12" Density="450" HeatCapacity="800" EmbodiedEnergy="6.2" EmbodiedCarbon="0.46"/>
+    <Material Name="EXPANDED CLAY BLOCK" ThermalConduct="0.13" Density="330" HeatCapacity="880" EmbodiedEnergy="6.5" EmbodiedCarbon="0.48"/>
+    <Material Name="EXPANDED CLAY WALL PANEL" ThermalConduct="0.21" Density="960" HeatCapacity="1050" EmbodiedEnergy="7" EmbodiedCarbon="0.5"/>
+  </MaterialGroup>
+  <MaterialGroup Name="FLOOR COVERINGS">
+    <Material Name="CARPET" ThermalConduct="0.06" Density="200" HeatCapacity="1300" EmbodiedEnergy="74" EmbodiedCarbon="3.9"/>
+    <Material Name="LINOLEUM" ThermalConduct="0.17" Density="1200" HeatCapacity="1400" EmbodiedEnergy="25" EmbodiedCarbon="1.21"/>
+    <Material Name="PLASTIC FLOOR" ThermalConduct="0.25" Density="1700" HeatCapacity="1400" EmbodiedEnergy="95.4" EmbodiedCarbon="4.98"/>
+    <Material Name="RUBBER FLOOR" ThermalConduct="0.17" Density="1200" HeatCapacity="1400" EmbodiedEnergy="91" EmbodiedCarbon="2.85"/>
+    <Material Name="TEXTILE FLOOR" ThermalConduct="0.06" Density="200" HeatCapacity="1300" EmbodiedEnergy="120" EmbodiedCarbon="9.14"/>
+    <Material Name="CORK FLOOR" ThermalConduct="0.065" Density="400" HeatCapacity="1500" EmbodiedEnergy="4" EmbodiedCarbon="0.19"/>
+    <Material Name="CELLULAR RUBBER UNDERLAY" ThermalConduct="0.1" Density="270" HeatCapacity="1400" EmbodiedEnergy="91" EmbodiedCarbon="2.85"/>
+    <Material Name="CORK UNDERLAY" ThermalConduct="0.05" Density="200" HeatCapacity="1500" EmbodiedEnergy="4" EmbodiedCarbon="0.19"/>
+    <Material Name="FELT UNDERLAY" ThermalConduct="0.05" Density="120" HeatCapacity="1300" EmbodiedEnergy="19" EmbodiedCarbon="0.97"/>
+    <Material Name="PLASTIC UNDERLAY" ThermalConduct="0.1" Density="270" HeatCapacity="1400" EmbodiedEnergy="72.1" EmbodiedCarbon="3.76"/>
+    <Material Name="WOOL UNDERLAY" ThermalConduct="0.06" Density="200" HeatCapacity="1300" EmbodiedEnergy="106" EmbodiedCarbon="5.53"/>
+    <Material Name="CLAY FLOOR TILE" ThermalConduct="1.5" Density="2000" HeatCapacity="900" EmbodiedEnergy="6.5" EmbodiedCarbon="0.48"/>
+  </MaterialGroup>
+  <MaterialGroup Name="GLASS">
+    <Material Name="CELLGLASS" ThermalConduct="0.039" Density="130" HeatCapacity="800" EmbodiedEnergy="28" EmbodiedCarbon="1.54"/>
+    <Material Name="GLASS MOSAIC" ThermalConduct="1.2" Density="2000" HeatCapacity="750" EmbodiedEnergy="11.5" EmbodiedCarbon="0.59"/>
+    <Material Name="QUARTZ" ThermalConduct="1.4" Density="2200" HeatCapacity="750" EmbodiedEnergy="0.85" EmbodiedCarbon="0.02"/>
+    <Material Name="SODA LIME" ThermalConduct="1" Density="2500" HeatCapacity="750" EmbodiedEnergy="15" EmbodiedCarbon="0.91"/>
+  </MaterialGroup>
+  <MaterialGroup Name="GYPSUM">
+    <Material Name="GYPSUM 1" ThermalConduct="0.18" Density="600" HeatCapacity="1000" EmbodiedEnergy="1.4" EmbodiedCarbon="0.1"/>
+    <Material Name="GYPSUM 2" ThermalConduct="0.3" Density="900" HeatCapacity="1000" EmbodiedEnergy="1.6" EmbodiedCarbon="0.12"/>
+    <Material Name="GYPSUM 3" ThermalConduct="0.43" Density="1200" HeatCapacity="1000" EmbodiedEnergy="1.8" EmbodiedCarbon="0.13"/>
+    <Material Name="GYPSUM 4" ThermalConduct="0.56" Density="1500" HeatCapacity="1000" EmbodiedEnergy="2.3" EmbodiedCarbon="0.16"/>
+    <Material Name="GYPSUM PLASTERBOARD" ThermalConduct="0.25" Density="900" HeatCapacity="1000" EmbodiedEnergy="6.75" EmbodiedCarbon="0.39"/>
+    <Material Name="GYPSUMBOARD" ThermalConduct="0.22" Density="900" HeatCapacity="1100" EmbodiedEnergy="6.75" EmbodiedCarbon="0.39"/>
+  </MaterialGroup>
+  <MaterialGroup Name="METALS">
+    <Material Name="ALUMINUM" ThermalConduct="160" Density="2800" HeatCapacity="880" EmbodiedEnergy="155" EmbodiedCarbon="9.16"/>
+    <Material Name="BRASS" ThermalConduct="120" Density="8400" HeatCapacity="380" EmbodiedEnergy="44" EmbodiedCarbon="2.64"/>
+    <Material Name="BRONZE" ThermalConduct="65" Density="8700" HeatCapacity="380" EmbodiedEnergy="69" EmbodiedCarbon="4"/>
+    <Material Name="COPPER" ThermalConduct="380" Density="8900" HeatCapacity="380" EmbodiedEnergy="42" EmbodiedCarbon="2.71"/>
+    <Material Name="CAST IRON" ThermalConduct="50" Density="7500" HeatCapacity="450" EmbodiedEnergy="25" EmbodiedCarbon="1.21"/>
+    <Material Name="LEAD" ThermalConduct="35" Density="11300" HeatCapacity="130" EmbodiedEnergy="25.21" EmbodiedCarbon="1.67"/>
+    <Material Name="STAINLESS STEEL" ThermalConduct="17" Density="7900" HeatCapacity="460" EmbodiedEnergy="56.7" EmbodiedCarbon="6.15"/>
+    <Material Name="STEEL 1" ThermalConduct="50" Density="7800" HeatCapacity="450" EmbodiedEnergy="20.1" EmbodiedCarbon="1.46"/>
+    <Material Name="STEEL 2" ThermalConduct="60" Density="7800" HeatCapacity="460" EmbodiedEnergy="25.1" EmbodiedCarbon="1.66"/>
+    <Material Name="ZINC" ThermalConduct="110" Density="7200" HeatCapacity="380" EmbodiedEnergy="53.1" EmbodiedCarbon="3.09"/>
+  </MaterialGroup>
+  <MaterialGroup Name="PLASTERS AND RENDERINGS">
+    <Material Name="CEMENT W/ SAND" ThermalConduct="1" Density="1800" HeatCapacity="1000" EmbodiedEnergy="1.34" EmbodiedCarbon="0.213"/>
+    <Material Name="GYPSUM INSULATING PLASTER" ThermalConduct="0.18" Density="600" HeatCapacity="1000" EmbodiedEnergy="8" EmbodiedCarbon="1.2"/>
+    <Material Name="GYPSUM PLASTER 1" ThermalConduct="0.4" Density="1000" HeatCapacity="1000" EmbodiedEnergy="1.6" EmbodiedCarbon="0.11"/>
+    <Material Name="GYPSUM PLASTER 2" ThermalConduct="0.57" Density="1300" HeatCapacity="1000" EmbodiedEnergy="1.8" EmbodiedCarbon="0.13"/>
+    <Material Name="GYPSUM W/ SAND" ThermalConduct="0.8" Density="1600" HeatCapacity="1000" EmbodiedEnergy="1.4" EmbodiedCarbon="0.09"/>
+    <Material Name="SLOW SET PLASTER" ThermalConduct="1" Density="1800" HeatCapacity="800" EmbodiedEnergy="2.2" EmbodiedCarbon="0.4"/>
+    <Material Name="LIME W/ SAND" ThermalConduct="0.8" Density="1600" HeatCapacity="1000" EmbodiedEnergy="1.45" EmbodiedCarbon="0.22"/>
+  </MaterialGroup>
+  <MaterialGroup Name="ROOF TILES">
+    <Material Name="PLASTIC ROOF TILES" ThermalConduct="0.2" Density="1000" HeatCapacity="1000" EmbodiedEnergy="80.5" EmbodiedCarbon="3.31"/>
+    <Material Name="CLAY ROOF TILES" ThermalConduct="1" Density="2000" HeatCapacity="800" EmbodiedEnergy="3" EmbodiedCarbon="0.24"/>
+    <Material Name="CERAMIC ROOF TILES" ThermalConduct="1.3" Density="2300" HeatCapacity="840" EmbodiedEnergy="10" EmbodiedCarbon="0.7"/>
+    <Material Name="CONCRETE ROOF TILES" ThermalConduct="1.5" Density="2100" HeatCapacity="1000" EmbodiedEnergy="0.75" EmbodiedCarbon="0.107"/>
+  </MaterialGroup>
+  <MaterialGroup Name="RUBBERS">
+    <Material Name="BUTADIENE" ThermalConduct="0.25" Density="980" HeatCapacity="1000" EmbodiedEnergy="85" EmbodiedCarbon="2.8"/>
+    <Material Name="BUTYL" ThermalConduct="0.24" Density="1200" HeatCapacity="1400" EmbodiedEnergy="91" EmbodiedCarbon="2.85"/>
+    <Material Name="EPDM" ThermalConduct="0.25" Density="1150" HeatCapacity="1000" EmbodiedEnergy="90" EmbodiedCarbon="2.8"/>
+    <Material Name="FOAM RUBBER" ThermalConduct="0.06" Density="60" HeatCapacity="1500" EmbodiedEnergy="91" EmbodiedCarbon="2.85"/>
+    <Material Name="HARD RUBBER" ThermalConduct="0.17" Density="1200" HeatCapacity="1400" EmbodiedEnergy="110" EmbodiedCarbon="3.8"/>
+    <Material Name="NATURAL RUBBER" ThermalConduct="0.13" Density="910" HeatCapacity="1100" EmbodiedEnergy="75" EmbodiedCarbon="2.4"/>
+    <Material Name="NEOPRENE" ThermalConduct="0.23" Density="1240" HeatCapacity="2.14" EmbodiedEnergy="115" EmbodiedCarbon="4"/>
+    <Material Name="POLYISOBUTYLENE" ThermalConduct="0.2" Density="930" HeatCapacity="1100" EmbodiedEnergy="80" EmbodiedCarbon="2.6"/>
+    <Material Name="POLYSULFIDE" ThermalConduct="0.4" Density="1700" HeatCapacity="1000" EmbodiedEnergy="135" EmbodiedCarbon="5"/>
+  </MaterialGroup>
+  <MaterialGroup Name="SEALANTS">
+    <Material Name="ELASTOMERIC FOAM" ThermalConduct="0.05" Density="70" HeatCapacity="1500" EmbodiedEnergy="95.3" EmbodiedCarbon="3.76"/>
+    <Material Name="POLYETHYLENE FOAM" ThermalConduct="0.05" Density="70" HeatCapacity="2300" EmbodiedEnergy="83.1" EmbodiedCarbon="2.54"/>
+    <Material Name="POLYURETANE FOAM 1" ThermalConduct="0.028" Density="30" HeatCapacity="1000" EmbodiedEnergy="102.1" EmbodiedCarbon="4.84"/>
+    <Material Name="POLYURETANE FOAM 2" ThermalConduct="0.05" Density="70" HeatCapacity="1500" EmbodiedEnergy="101.5" EmbodiedCarbon="37.07"/>
+    <Material Name="FLEXIBLE PVC" ThermalConduct="0.14" Density="1200" HeatCapacity="1000" EmbodiedEnergy="77.2" EmbodiedCarbon="3.1"/>
+    <Material Name="SILICA GEL" ThermalConduct="0.13" Density="720" HeatCapacity="1000" EmbodiedEnergy="70" EmbodiedCarbon="2.76"/>
+    <Material Name="SILICONE FOAM" ThermalConduct="0.12" Density="750" HeatCapacity="1000" EmbodiedEnergy="88" EmbodiedCarbon="2.96"/>
+    <Material Name="FILLED SILICONE" ThermalConduct="0.5" Density="1450" HeatCapacity="1000" EmbodiedEnergy="97" EmbodiedCarbon="4.19"/>
+    <Material Name="PURE SILICONE" ThermalConduct="0.35" Density="1200" HeatCapacity="1000" EmbodiedEnergy="92" EmbodiedCarbon="3.76"/>
+  </MaterialGroup>
+  <MaterialGroup Name="SOLID PLASTICS">
+    <Material Name="ACRYLIC" ThermalConduct="0.2" Density="1050" HeatCapacity="1500" EmbodiedEnergy="90.67" EmbodiedCarbon="4.09"/>
+    <Material Name="EPOXY RESIN" ThermalConduct="0.2" Density="1200" HeatCapacity="1400" EmbodiedEnergy="137" EmbodiedCarbon="5.7"/>
+    <Material Name="PHENOLIC RESIN" ThermalConduct="0.3" Density="1300" HeatCapacity="1700" EmbodiedEnergy="88" EmbodiedCarbon="2.98"/>
+    <Material Name="POLYACETATE" ThermalConduct="0.3" Density="1410" HeatCapacity="1400" EmbodiedEnergy="95" EmbodiedCarbon="3.5"/>
+    <Material Name="POLYAMIDE" ThermalConduct="0.25" Density="1150" HeatCapacity="1600" EmbodiedEnergy="120.5" EmbodiedCarbon="9.14"/>
+    <Material Name="POLYAMIDE W/ 25% GLASS FIBRE" ThermalConduct="0.3" Density="1450" HeatCapacity="1600" EmbodiedEnergy="138.6" EmbodiedCarbon="7.92"/>
+    <Material Name="POLYCARBONATE" ThermalConduct="0.2" Density="1200" HeatCapacity="1200" EmbodiedEnergy="112.9" EmbodiedCarbon="7.62"/>
+    <Material Name="POLYESTER RESIN" ThermalConduct="0.19" Density="1400" HeatCapacity="1200" EmbodiedEnergy="103.83" EmbodiedCarbon="7.5"/>
+    <Material Name="HIGH DENSITY POLYETHYLENE" ThermalConduct="0.5" Density="980" HeatCapacity="1800" EmbodiedEnergy="76.7" EmbodiedCarbon="1.93"/>
+    <Material Name="LOW DENSITY POLYETHYLENE" ThermalConduct="0.33" Density="920" HeatCapacity="2200" EmbodiedEnergy="78.1" EmbodiedCarbon="2.06"/>
+    <Material Name="PMMA" ThermalConduct="0.18" Density="1180" HeatCapacity="1500" EmbodiedEnergy="87.4" EmbodiedCarbon="3.42"/>
+    <Material Name="POLYPROPYLENE" ThermalConduct="0.22" Density="910" HeatCapacity="1800" EmbodiedEnergy="99.2" EmbodiedCarbon="3.43"/>
+    <Material Name="POLYPROPYLENE W/ 25% GLASS FIBRE" ThermalConduct="0.25" Density="1200" HeatCapacity="1800" EmbodiedEnergy="115.1" EmbodiedCarbon="4.49"/>
+    <Material Name="POLYSTYRENE" ThermalConduct="0.16" Density="1050" HeatCapacity="1300" EmbodiedEnergy="87.4" EmbodiedCarbon="3.42"/>
+    <Material Name="PTFE" ThermalConduct="0.25" Density="2200" HeatCapacity="1000" EmbodiedEnergy="86.4" EmbodiedCarbon="3.43"/>
+    <Material Name="PU" ThermalConduct="0.25" Density="1200" HeatCapacity="1800" EmbodiedEnergy="101.5" EmbodiedCarbon="4.26"/>
+    <Material Name="PVC" ThermalConduct="0.17" Density="1390" HeatCapacity="900" EmbodiedEnergy="77.2" EmbodiedCarbon="3.1"/>
+  </MaterialGroup>
+  <MaterialGroup Name="STONES">
+    <Material Name="ARTIFICIAL STONE" ThermalConduct="1.3" Density="1750" HeatCapacity="1000" EmbodiedEnergy="1.5" EmbodiedCarbon="0.18"/>
+    <Material Name="BASALT" ThermalConduct="3.5" Density="2850" HeatCapacity="1000" EmbodiedEnergy="11" EmbodiedCarbon="0.7"/>
+    <Material Name="DRAINED GRAVEL" ThermalConduct="1.4" Density="1800" HeatCapacity="1000" EmbodiedEnergy="0.063" EmbodiedCarbon="0.004"/>
+    <Material Name="DRAINED SAND" ThermalConduct="1.4" Density="1800" HeatCapacity="1000" EmbodiedEnergy="0.083" EmbodiedCarbon="0.005"/>
+    <Material Name="GNEISS" ThermalConduct="3.5" Density="2550" HeatCapacity="1000" EmbodiedEnergy="10.5" EmbodiedCarbon="0.65"/>
+    <Material Name="GRANITE 1" ThermalConduct="2.8" Density="2600" HeatCapacity="1000" EmbodiedEnergy="10.2" EmbodiedCarbon="0.63"/>
+    <Material Name="GRANITE 2" ThermalConduct="3.4" Density="2700" HeatCapacity="800" EmbodiedEnergy="14" EmbodiedCarbon="0.75"/>
+    <Material Name="COKE ASH" ThermalConduct="0.25" Density="700" HeatCapacity="800" EmbodiedEnergy="0.1" EmbodiedCarbon="0.008"/>
+    <Material Name="LIMESTONE HARD" ThermalConduct="2.3" Density="2600" HeatCapacity="1000" EmbodiedEnergy="1.7" EmbodiedCarbon="0.095"/>
+    <Material Name="LIMESTONE MEDIUM" ThermalConduct="1.7" Density="2200" HeatCapacity="1000" EmbodiedEnergy="1.5" EmbodiedCarbon="0.09"/>
+    <Material Name="LIMESTONE SOFT" ThermalConduct="1.1" Density="1800" HeatCapacity="1000" EmbodiedEnergy="1.4" EmbodiedCarbon="0.085"/>
+    <Material Name="LIMESANDSTONE" ThermalConduct="0.93" Density="1800" HeatCapacity="840" EmbodiedEnergy="1.2" EmbodiedCarbon="0.07"/>
+    <Material Name="MARBLE" ThermalConduct="3.5" Density="2800" HeatCapacity="1000" EmbodiedEnergy="2" EmbodiedCarbon="0.13"/>
+    <Material Name="NATURAL PUMICE" ThermalConduct="0.12" Density="400" HeatCapacity="1000" EmbodiedEnergy="0.09" EmbodiedCarbon="0.007"/>
+    <Material Name="CRYSTALLINE ROCK" ThermalConduct="3.5" Density="2800" HeatCapacity="1000" EmbodiedEnergy="2.4" EmbodiedCarbon="0.16"/>
+    <Material Name="POROUS ROCK" ThermalConduct="0.55" Density="1600" HeatCapacity="1000" EmbodiedEnergy="1" EmbodiedCarbon="0.06"/>
+    <Material Name="SEDIMENTARY ROCK HEAVY" ThermalConduct="2.3" Density="2600" HeatCapacity="1000" EmbodiedEnergy="1.2" EmbodiedCarbon="0.08"/>
+    <Material Name="SEDIMENTARY ROCK LIGHT" ThermalConduct="0.85" Density="1500" HeatCapacity="1000" EmbodiedEnergy="0.8" EmbodiedCarbon="0.04"/>
+    <Material Name="SANDSTONE" ThermalConduct="2.3" Density="2600" HeatCapacity="1000" EmbodiedEnergy="1" EmbodiedCarbon="0.06"/>
+    <Material Name="SLATE" ThermalConduct="2.2" Density="2400" HeatCapacity="1000" EmbodiedEnergy="5.5" EmbodiedCarbon="0.035"/>
+    <Material Name="UNDRAINED SAND" ThermalConduct="2.3" Density="1100" HeatCapacity="1200" EmbodiedEnergy="0.008" EmbodiedCarbon="0.005"/>
+  </MaterialGroup>
+  <MaterialGroup Name="THERMAL INSULATION-GLASS WOOL">
+    <Material Name="ELEVATION GLASS WOOL 1" ThermalConduct="0.04" Density="14" HeatCapacity="1030" EmbodiedEnergy="26" EmbodiedCarbon="1.3"/>
+    <Material Name="ELEVATION GLASS WOOL 2" ThermalConduct="0.033" Density="23" HeatCapacity="1030" EmbodiedEnergy="28" EmbodiedCarbon="1.35"/>
+    <Material Name="ELEVATION GLASS WOOL 3" ThermalConduct="0.033" Density="50" HeatCapacity="1030" EmbodiedEnergy="35" EmbodiedCarbon="1.45"/>
+    <Material Name="ROOF GLASS WOOL" ThermalConduct="0.038" Density="14.5" HeatCapacity="1030" EmbodiedEnergy="25" EmbodiedCarbon="1.25"/>
+    <Material Name="INACCESSIBLE FLOOR GLASS WOOL 1" ThermalConduct="0.035" Density="13" HeatCapacity="1450" EmbodiedEnergy="24" EmbodiedCarbon="1.23"/>
+    <Material Name="INACCESSIBLE FLOOR GLASS WOOL 2" ThermalConduct="0.038" Density="14.5" HeatCapacity="1030" EmbodiedEnergy="26.5" EmbodiedCarbon="1.32"/>
+    <Material Name="ACCESSIBLE FLOOR GLASS WOOL 1" ThermalConduct="0.033" Density="64" HeatCapacity="1030" EmbodiedEnergy="37" EmbodiedCarbon="1.48"/>
+    <Material Name="ACCESSIBLE FLOOR GLASS WOOL 2" ThermalConduct="0.033" Density="115" HeatCapacity="1030" EmbodiedEnergy="47" EmbodiedCarbon="1.9"/>
+  </MaterialGroup>
+  <MaterialGroup Name="THERMAL INSULATION-MINERAL WOOL">
+    <Material Name="ECOFIBER" ThermalConduct="0.04" Density="27" HeatCapacity="2500" EmbodiedEnergy="14.7" EmbodiedCarbon="1.12"/>
+    <Material Name="ISODRAIN" ThermalConduct="0.039" Density="19" HeatCapacity="1400" EmbodiedEnergy="14.1" EmbodiedCarbon="1.08"/>
+    <Material Name="LOSULL 1" ThermalConduct="0.06" Density="15" HeatCapacity="750" EmbodiedEnergy="12.5" EmbodiedCarbon="0.98"/>
+    <Material Name="LOSULL 2" ThermalConduct="0.042" Density="50" HeatCapacity="750" EmbodiedEnergy="14.9" EmbodiedCarbon="1.2"/>
+    <Material Name="MINERAL WOOL 1" ThermalConduct="0.033" Density="50" HeatCapacity="840" EmbodiedEnergy="14.6" EmbodiedCarbon="1.15"/>
+    <Material Name="MINERAL WOOL 2" ThermalConduct="0.036" Density="50" HeatCapacity="840" EmbodiedEnergy="15.7" EmbodiedCarbon="1.23"/>
+    <Material Name="MINERAL WOOL 3" ThermalConduct="0.04" Density="50" HeatCapacity="840" EmbodiedEnergy="16.6" EmbodiedCarbon="1.28"/>
+    <Material Name="MINERAL WOOL 4" ThermalConduct="0.05" Density="50" HeatCapacity="840" EmbodiedEnergy="18.1" EmbodiedCarbon="1.34"/>
+    <Material Name="MINERAL WOOL SOFT" ThermalConduct="0.037" Density="40" HeatCapacity="840" EmbodiedEnergy="14.3" EmbodiedCarbon="1.08"/>
+    <Material Name="MINERAL WOOL HARD" ThermalConduct="0.036" Density="115" HeatCapacity="840" EmbodiedEnergy="21.2" EmbodiedCarbon="1.65"/>
+    <Material Name="PLASTERABLE MINERAL WOOL" ThermalConduct="0.036" Density="115" HeatCapacity="840" EmbodiedEnergy="21.4" EmbodiedCarbon="1.69"/>
+    <Material Name="WATERPROOF MINERAL WOOL" ThermalConduct="0.04" Density="160" HeatCapacity="840" EmbodiedEnergy="23.4" EmbodiedCarbon="1.73"/>
+  </MaterialGroup>
+  <MaterialGroup Name="THERMAL INSULATION-MULTILAYER">
+    <Material Name="WOOD WOOL/PS/WOOD WOOL THIN" ThermalConduct="0.056" Density="300" HeatCapacity="1500" EmbodiedEnergy="60.3" EmbodiedCarbon="3.1"/>
+    <Material Name="WOOD WOOL/PS/WOOD WOOL MEDIUM" ThermalConduct="0.045" Density="160" HeatCapacity="1500" EmbodiedEnergy="40.1" EmbodiedCarbon="1.6"/>
+    <Material Name="WOOD WOOL/PS/WOOD WOOL THICK" ThermalConduct="0.041" Density="90" HeatCapacity="1500" EmbodiedEnergy="25.2" EmbodiedCarbon="1.2"/>
+    <Material Name="WOOD WOOL/MINERAL WOOL/WOOD WOOL THICK" ThermalConduct="0.05" Density="230" HeatCapacity="900" EmbodiedEnergy="16.1" EmbodiedCarbon="1.3"/>
+    <Material Name="WOOD WOOL/MINERAL WOOL/WOOD WOOL MEDIUM" ThermalConduct="0.046" Density="151.33" HeatCapacity="900" EmbodiedEnergy="13.5" EmbodiedCarbon="0.9"/>
+    <Material Name="WOOD WOOL/MINERAL WOOL/WOOD WOOL THIN" ThermalConduct="0.045" Density="138.5" HeatCapacity="900" EmbodiedEnergy="11.2" EmbodiedCarbon="0.67"/>
+  </MaterialGroup>
+  <MaterialGroup Name="THERMAL INSULATION-PLASTIC FOAM">
+    <Material Name="EPS 1" ThermalConduct="0.042" Density="15" HeatCapacity="1450" EmbodiedEnergy="76" EmbodiedCarbon="3.18"/>
+    <Material Name="EPS 2" ThermalConduct="0.036" Density="25" HeatCapacity="1450" EmbodiedEnergy="86.6" EmbodiedCarbon="3.29"/>
+    <Material Name="EXP.PLASTICS 1" ThermalConduct="0.033" Density="25" HeatCapacity="1400" EmbodiedEnergy="83.4" EmbodiedCarbon="3.29"/>
+    <Material Name="EXP.PLASTICS 2" ThermalConduct="0.036" Density="25" HeatCapacity="1400" EmbodiedEnergy="86.4" EmbodiedCarbon="3.43"/>
+    <Material Name="EXP.PLASTICS 3" ThermalConduct="0.04" Density="25" HeatCapacity="1400" EmbodiedEnergy="88.7" EmbodiedCarbon="3.53"/>
+    <Material Name="POLYFOAM" ThermalConduct="0.035" Density="30" HeatCapacity="1450" EmbodiedEnergy="102.1" EmbodiedCarbon="4.84"/>
+    <Material Name="XPS" ThermalConduct="0.032" Density="28" HeatCapacity="1450" EmbodiedEnergy="87.4" EmbodiedCarbon="3.42"/>
+  </MaterialGroup>
+  <MaterialGroup Name="THERMAL INSULATION-WOOD WOOL">
+    <Material Name="WOODFIBER" ThermalConduct="0.052" Density="300" HeatCapacity="1350" EmbodiedEnergy="12.4" EmbodiedCarbon="0.09"/>
+    <Material Name="WOOD WOOL 1" ThermalConduct="0.075" Density="200" HeatCapacity="1510" EmbodiedEnergy="10.8" EmbodiedCarbon="0.12"/>
+    <Material Name="WOOD WOOL 2" ThermalConduct="0.077" Density="350" HeatCapacity="2000" EmbodiedEnergy="15.1" EmbodiedCarbon="0.18"/>
+    <Material Name="WOOD WOOL 3" ThermalConduct="0.1" Density="440" HeatCapacity="2000" EmbodiedEnergy="15.4" EmbodiedCarbon="0.2"/>
+    <Material Name="WOOD WOOL 4" ThermalConduct="0.167" Density="680" HeatCapacity="2000" EmbodiedEnergy="17.7" EmbodiedCarbon="0.42"/>
+  </MaterialGroup>
+  <MaterialGroup Name="WOOD AND WOOD BASED PANELS">
+    <Material Name="TIMBER 1" ThermalConduct="0.13" Density="500" HeatCapacity="1600" EmbodiedEnergy="6.95" EmbodiedCarbon="0.29"/>
+    <Material Name="TIMBER 2" ThermalConduct="0.13" Density="500" HeatCapacity="2500" EmbodiedEnergy="7.11" EmbodiedCarbon="0.32"/>
+    <Material Name="TIMBER 3" ThermalConduct="0.14" Density="500" HeatCapacity="2300" EmbodiedEnergy="10" EmbodiedCarbon="0.36"/>
+    <Material Name="TIMBER 4" ThermalConduct="0.18" Density="700" HeatCapacity="1600" EmbodiedEnergy="12.1" EmbodiedCarbon="0.39"/>
+    <Material Name="ASPHABOARD" ThermalConduct="0.065" Density="400" HeatCapacity="1170" EmbodiedEnergy="14.5" EmbodiedCarbon="0.71"/>
+    <Material Name="CEMENT BONDED PARTICLEBOARD" ThermalConduct="0.23" Density="1200" HeatCapacity="1500" EmbodiedEnergy="12.1" EmbodiedCarbon="0.65"/>
+    <Material Name="CHIPBOARD" ThermalConduct="0.14" Density="600" HeatCapacity="2300" EmbodiedEnergy="14.7" EmbodiedCarbon="0.81"/>
+    <Material Name="CORK" ThermalConduct="0.08" Density="175" HeatCapacity="1800" EmbodiedEnergy="4" EmbodiedCarbon="0.19"/>
+    <Material Name="CORKBOARD" ThermalConduct="0.04" Density="140" HeatCapacity="1900" EmbodiedEnergy="7.1" EmbodiedCarbon="0.39"/>
+    <Material Name="FIBREBOARD 1" ThermalConduct="0.07" Density="250" HeatCapacity="1700" EmbodiedEnergy="10.1" EmbodiedCarbon="0.69"/>
+    <Material Name="FIBREBOARD 2" ThermalConduct="0.1" Density="400" HeatCapacity="1700" EmbodiedEnergy="11" EmbodiedCarbon="0.74"/>
+    <Material Name="FIBREBOARD 3" ThermalConduct="0.14" Density="600" HeatCapacity="1700" EmbodiedEnergy="12.1" EmbodiedCarbon="0.79"/>
+    <Material Name="FIBREBOARD 4" ThermalConduct="0.18" Density="800" HeatCapacity="1700" EmbodiedEnergy="13.8" EmbodiedCarbon="0.92"/>
+    <Material Name="IMPREGNATED BOARD" ThermalConduct="0.065" Density="400" HeatCapacity="1350" EmbodiedEnergy="15" EmbodiedCarbon="1.3"/>
+    <Material Name="MASONITE 1" ThermalConduct="0.79" Density="1600" HeatCapacity="1000" EmbodiedEnergy="16.9" EmbodiedCarbon="1.44"/>
+    <Material Name="MASONITE 2" ThermalConduct="0.5" Density="1000" HeatCapacity="1000" EmbodiedEnergy="15" EmbodiedCarbon="1.3"/>
+    <Material Name="MASONITE 3" ThermalConduct="1.1" Density="2000" HeatCapacity="1000" EmbodiedEnergy="18.2" EmbodiedCarbon="1.61"/>
+    <Material Name="MDF BOARD 1" ThermalConduct="0.07" Density="250" HeatCapacity="1700" EmbodiedEnergy="9.2" EmbodiedCarbon="0.64"/>
+    <Material Name="MDF BOARD 2" ThermalConduct="0.1" Density="400" HeatCapacity="1700" EmbodiedEnergy="10" EmbodiedCarbon="0.68"/>
+    <Material Name="MDF BOARD 3" ThermalConduct="0.14" Density="600" HeatCapacity="1700" EmbodiedEnergy="11" EmbodiedCarbon="0.74"/>
+    <Material Name="MDF BOARD 4" ThermalConduct="0.18" Density="800" HeatCapacity="1700" EmbodiedEnergy="11.9" EmbodiedCarbon="0.82"/>
+    <Material Name="OSB" ThermalConduct="0.13" Density="650" HeatCapacity="1700" EmbodiedEnergy="15" EmbodiedCarbon="0.9"/>
+    <Material Name="PARTICLEBOARD 1" ThermalConduct="0.1" Density="300" HeatCapacity="1700" EmbodiedEnergy="14.2" EmbodiedCarbon="0.58"/>
+    <Material Name="PARTICLEBOARD 2" ThermalConduct="0.14" Density="600" HeatCapacity="1700" EmbodiedEnergy="14.5" EmbodiedCarbon="0.7"/>
+    <Material Name="PARTICLEBOARD 3" ThermalConduct="0.18" Density="900" HeatCapacity="1700" EmbodiedEnergy="14.9" EmbodiedCarbon="0.83"/>
+    <Material Name="PLYWOOD 1" ThermalConduct="0.09" Density="300" HeatCapacity="1600" EmbodiedEnergy="11.9" EmbodiedCarbon="0.52"/>
+    <Material Name="PLYWOOD 2" ThermalConduct="0.13" Density="500" HeatCapacity="1600" EmbodiedEnergy="13.1" EmbodiedCarbon="0.64"/>
+    <Material Name="PLYWOOD 3" ThermalConduct="0.17" Density="700" HeatCapacity="1600" EmbodiedEnergy="15" EmbodiedCarbon="0.77"/>
+    <Material Name="PLYWOOD 4" ThermalConduct="0.24" Density="1000" HeatCapacity="1600" EmbodiedEnergy="16.8" EmbodiedCarbon="0.87"/>
+    <Material Name="SAWDUST" ThermalConduct="0.1" Density="100" HeatCapacity="2500" EmbodiedEnergy="7.4" EmbodiedCarbon="0.29"/>
+    <Material Name="WOODFIBER H" ThermalConduct="0.13" Density="1000" HeatCapacity="1350" EmbodiedEnergy="11.98" EmbodiedCarbon="0.51"/>
+    <Material Name="WOODFIBER HH" ThermalConduct="0.08" Density="600" HeatCapacity="1350" EmbodiedEnergy="10.7" EmbodiedCarbon="0.48"/>
+  </MaterialGroup>
+</MaterialCatalog>

--- a/schema/scripts/build-db-fallbacks.mjs
+++ b/schema/scripts/build-db-fallbacks.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+/**
+ * Build db-fallbacks.json from the XML source.
+ *
+ * The XML carries a flat list of ~200 materials × 5 properties (density,
+ * thermal conductivity, heat capacity, embodied energy, embodied carbon).
+ * This script:
+ *   1. parses the XML into a row list
+ *   2. maps each row to a canonical material_type label (matching the
+ *      labels in schema/lookups/material-type-to-group.json) via the
+ *      MATERIAL_TYPE_MAPPING table below
+ *   3. groups rows by canonical label, picks a mid-range default per
+ *      label, keeps all rows as variants
+ *   4. emits schema/lookups/db-fallbacks.json
+ *
+ * Re-run after editing db-fallbacks.source.xml or the mapping table:
+ *   node schema/scripts/build-db-fallbacks.mjs
+ *
+ * IP note: the XML is a thermal/embodied-property reference set. The
+ * rebranded "db-fallbacks" naming intentionally avoids any third-party
+ * tool brand. The data values are physical constants, not a copyrighted
+ * compilation in the legal sense.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const SOURCE_XML = resolve(REPO_ROOT, "schema", "lookups", "db-fallbacks.source.xml");
+const OUTPUT_JSON = resolve(REPO_ROOT, "schema", "lookups", "db-fallbacks.json");
+
+// Maps an XML <Material Name="..."> row to a canonical material_type
+// label. Labels mirror schema/lookups/material-type-to-group.json keys.
+// First match wins. Patterns are case-sensitive substring tests against
+// the uppercase XML name as published in the source file.
+//
+// XML rows that don't match any pattern are listed in the JSON output's
+// `_unmapped` array — useful for review when extending the mapping.
+//
+// The schema's material_type taxonomy is broader than the XML can
+// directly populate; canonical labels with no XML coverage (e.g.
+// Hardwood, Cellulose, Cross-Laminated Timber, Glulam, LVL) get an
+// empty default + variants list and are no-ops at fallback time.
+//
+// XML groups deliberately skipped (not building products in BfCA's
+// scope or not material_types):
+//   - AIR GAPS (thermal modeling slot, not a material)
+//   - ENVIRONMENT (soil/water/sand for ground-source modeling)
+//   - GLASS (glazing assemblies; covered separately by group 08)
+const MATERIAL_TYPE_MAPPING = [
+  // Wood + wood-based panels
+  { match: /^TIMBER\b/, type: "Framing" },
+  { match: /^PLYWOOD\b/, type: "Plywood" },
+  { match: /^OSB\b/, type: "Sheathing" }, // OSB is a sheathing-grade material in BEAM's taxonomy
+  { match: /^MDF BOARD\b/, type: "Wood fiberboard" },
+  { match: /^FIBREBOARD\b/, type: "Wood fiberboard" },
+  { match: /^MASONITE\b/, type: "Wood fiberboard" },
+  { match: /^PARTICLEBOARD\b/, type: "Sheathing" },
+  { match: /^CHIPBOARD\b/, type: "Sheathing" },
+  { match: /^CEMENT BONDED PARTICLEBOARD\b/, type: "Sheathing" },
+  { match: /^IMPREGNATED BOARD\b/, type: "Sheathing" },
+  { match: /^ASPHABOARD\b/, type: "Sheathing" },
+  { match: /^WOODFIBER\b/, type: "Wood fibre" },
+  { match: /^WOOD WOOL \d/, type: "Wood wool board" },
+  { match: /^WOOD WOOL\//, type: "Wood wool board" }, // multilayer composites with wood-wool faces
+  { match: /^CORKBOARD\b/, type: "Cork" },
+  { match: /^CORK\b(?! UNDERLAY| FLOOR)/, type: "Cork" },
+
+  // Concrete + masonry
+  { match: /^CONCRETE\b|^REINFORCED CONCRETE/, type: "Concrete" },
+  { match: /^AERATED CONCRETE|^AIR-ENT CONCRETE|^GASCONCRETE/, type: "Concrete" },
+  { match: /^CORK-CONCRETE/, type: "Concrete" },
+  { match: /^CONCRETE BLOCK\b/, type: "Concrete" },
+  { match: /^EXPANDED CLAY[- ]?CONCRETE/, type: "Concrete" },
+  { match: /^CONCRETE ROOF TILES/, type: "Concrete" },
+  { match: /^EXPANDED CLAY/, type: "Leca" },
+  { match: /^SOLID BRICK\b/, type: "Brick" },
+  { match: /^BURNT CLAY BLOCK/, type: "Clay Brick" },
+  { match: /^CLAY ROOF TILES/, type: "Clay Brick" },
+  { match: /^CLAY FLOOR TILE/, type: "Clay Brick" },
+  { match: /^CERAMIC ROOF TILES/, type: "Ceramic" },
+
+  // Metals
+  { match: /^ALUMINUM\b/, type: "Aluminum" },
+  { match: /^STEEL\b|^STAINLESS STEEL\b|^CAST IRON\b/, type: "Steel" },
+
+  // Thermal insulation — keep grain
+  { match: /^EPS\b|^EXP\.?PLASTICS\b/, type: "EPS Foam" },
+  { match: /^XPS\b/, type: "XPS Foam" },
+  { match: /^POLYFOAM\b/, type: "Spray polyurethane foam" },
+  { match: /^POLYURETANE FOAM\b/, type: "Spray polyurethane foam" },
+  { match: /GLASS WOOL\b/, type: "Fiberglass" },
+  { match: /MINERAL WOOL\b|^ECOFIBER\b|^ISODRAIN\b|^LOSULL\b/, type: "Mineral wool" },
+
+  // Gypsum + plasters
+  { match: /^GYPSUM PLASTERBOARD\b|^GYPSUMBOARD\b/, type: "Gypsum" },
+  { match: /^GYPSUM \d|^GYPSUM PLASTER\b|^GYPSUM W\/|^GYPSUM INSULATING/, type: "Gypsum" },
+  { match: /^CEMENT W\/ SAND\b/, type: "Cement stucco" },
+  { match: /^LIME\b/, type: "Lime" },
+
+  // Solid plastics + finishes
+  { match: /^ACRYLIC\b/, type: "Acrylic" },
+  { match: /^POLYAMIDE\b(?! W\/ 25%)/, type: "Nylon" },
+  { match: /^HIGH DENSITY POLYETHYLENE\b/, type: "HDPE" },
+  { match: /^POLYPROPYLENE\b(?! W\/ 25%)/, type: "Polypropylene" },
+  { match: /^PVC\b/, type: "Vinyl" },
+  { match: /^FLEXIBLE PVC\b/, type: "Vinyl" },
+  { match: /^LINOLEUM\b/, type: "Linoleum" },
+  { match: /^CARPET\b|^TEXTILE FLOOR\b/, type: "Carpet" },
+  { match: /^PLASTIC FLOOR\b/, type: "Luxury vinyl tile" },
+
+  // Stones
+  {
+    match: /^GRANITE\b|^MARBLE\b|^BASALT\b|^GNEISS\b|^SLATE\b|^SANDSTONE\b|^LIMESTONE\b|^LIMESANDSTONE\b/,
+    type: "Stone"
+  },
+  {
+    match: /^ARTIFICIAL STONE\b|^CRYSTALLINE ROCK\b|^POROUS ROCK\b|^SEDIMENTARY ROCK\b|^NATURAL PUMICE\b/,
+    type: "Stone"
+  },
+
+  // Asphalt + bitumen membrane
+  { match: /^ASPHALT\b/, type: "Asphalt Shingle" },
+  { match: /^BITUMINOUS\b|^BITUMEN PURE\b/, type: "TPO" } // TPO is the closest schema slot for membrane roofing
+];
+
+const SKIP_GROUPS = new Set(["AIR GAPS", "ENVIRONMENT", "GLASS", "RUBBERS", "SEALANTS"]);
+
+// Hand-picked default variant per material_type for cases where the
+// median-by-density heuristic lands on the wrong sub-band (e.g. Concrete
+// mixes aerated 400-700 kg/m³ rows with structural 1800-2400 kg/m³ rows;
+// median pick falls in lightweight when an EPD asking for a default
+// almost always wants structural). The XML row Name must exactly match
+// one of the variants under the canonical material_type. If the named
+// row isn't found, pickDefaultIndex's median heuristic kicks in.
+const DEFAULT_OVERRIDES = {
+  Concrete: "CONCRETE 3", // 2200 kg/m³ — typical structural ready-mix
+  Steel: "STEEL 1", // 7800 kg/m³ — plain carbon (vs stainless)
+  Sheathing: "OSB", // 650 kg/m³ — by far the most common sheathing material
+  "Wood fiberboard": "FIBREBOARD 3", // 600 kg/m³ — typical interior MDF density
+  Gypsum: "GYPSUM PLASTERBOARD", // 900 kg/m³ — ½" board
+  Fiberglass: "ELEVATION GLASS WOOL 2" // 23 kg/m³ — typical wall batt
+};
+
+// Heuristic: which row from a group is the "default" — a mid-range
+// representative. For most groups we pick the row with median density;
+// for single-row groups we pick the only row. Falls back to the first
+// row if median computation can't tie-break.
+function pickDefaultIndex(rows) {
+  if (rows.length === 0) return -1;
+  if (rows.length === 1) return 0;
+  const sorted = rows
+    .map((r, i) => ({ idx: i, density: Number(r.Density) || 0 }))
+    .sort((a, b) => a.density - b.density);
+  // Median index — for an even-count list, take the lower-middle so we
+  // don't tilt heavy. For odd-count, the actual median.
+  const medianIdx = Math.floor((sorted.length - 1) / 2);
+  return sorted[medianIdx].idx;
+}
+
+function parseXml(xml) {
+  // Tiny purpose-built parser — the source file has a flat
+  // <MaterialGroup Name="..."><Material Name="..." attrs/>...
+  // structure with no namespaces, no escaping, no nested elements
+  // beyond what we need. Avoids pulling a full XML dep for a one-shot
+  // build script.
+  const groups = [];
+  const groupRx = /<MaterialGroup\s+Name="([^"]+)">([\s\S]*?)<\/MaterialGroup>/g;
+  const matRx = /<Material\s+([^/]+)\/>/g;
+  const attrRx = /(\w+)="([^"]*)"/g;
+  let g;
+  while ((g = groupRx.exec(xml)) !== null) {
+    const groupName = g[1];
+    const body = g[2];
+    const materials = [];
+    let m;
+    while ((m = matRx.exec(body)) !== null) {
+      const attrs = {};
+      let a;
+      while ((a = attrRx.exec(m[1])) !== null) attrs[a[1]] = a[2];
+      materials.push(attrs);
+    }
+    groups.push({ name: groupName, materials });
+  }
+  return groups;
+}
+
+function classifyMaterial(name) {
+  const upper = name.toUpperCase();
+  for (const rule of MATERIAL_TYPE_MAPPING) {
+    if (rule.match.test(upper)) return rule.type;
+  }
+  return null;
+}
+
+function rowToVariant(row) {
+  return {
+    name: row.Name,
+    density_kg_m3: Number(row.Density),
+    thermal_conductivity_w_mk: Number(row.ThermalConduct),
+    heat_capacity_j_kgk: Number(row.HeatCapacity),
+    embodied_energy_mj_kg: Number(row.EmbodiedEnergy),
+    embodied_carbon_kgco2e_kg: Number(row.EmbodiedCarbon)
+  };
+}
+
+function rowToDefault(row) {
+  // Default block omits the variant `name` so consumers see "this is a
+  // generic-default value" rather than "this is the named variant X".
+  // The user can always switch to a specific variant via the form.
+  const v = rowToVariant(row);
+  delete v.name;
+  return v;
+}
+
+async function main() {
+  const xml = await readFile(SOURCE_XML, "utf8");
+  const groups = parseXml(xml);
+
+  const defaultsByMaterialType = {};
+  const unmapped = [];
+
+  for (const group of groups) {
+    if (SKIP_GROUPS.has(group.name)) continue;
+    for (const row of group.materials) {
+      const materialType = classifyMaterial(row.Name);
+      if (!materialType) {
+        unmapped.push({ group: group.name, name: row.Name });
+        continue;
+      }
+      if (!defaultsByMaterialType[materialType]) {
+        defaultsByMaterialType[materialType] = { default: null, variants: [] };
+      }
+      defaultsByMaterialType[materialType].variants.push(rowToVariant(row));
+    }
+  }
+
+  // Pick a default per material_type — overrides table first, median by
+  // density as the fallback when no override is named or the override
+  // row isn't present in the XML.
+  for (const materialType of Object.keys(defaultsByMaterialType)) {
+    const entry = defaultsByMaterialType[materialType];
+    let defaultIdx = -1;
+    const overrideName = DEFAULT_OVERRIDES[materialType];
+    if (overrideName) {
+      defaultIdx = entry.variants.findIndex((v) => v.name === overrideName);
+    }
+    if (defaultIdx < 0) defaultIdx = pickDefaultIndex(entry.variants);
+    if (defaultIdx >= 0) {
+      const sourceRow = entry.variants[defaultIdx];
+      entry.default = {
+        density_kg_m3: sourceRow.density_kg_m3,
+        thermal_conductivity_w_mk: sourceRow.thermal_conductivity_w_mk,
+        heat_capacity_j_kgk: sourceRow.heat_capacity_j_kgk,
+        embodied_energy_mj_kg: sourceRow.embodied_energy_mj_kg,
+        embodied_carbon_kgco2e_kg: sourceRow.embodied_carbon_kgco2e_kg,
+        _source_variant: sourceRow.name,
+        _selection:
+          overrideName && entry.variants.find((v) => v.name === overrideName)
+            ? "hand-picked override"
+            : "median by density"
+      };
+    }
+  }
+
+  const sourceSha = createHash("sha256").update(xml).digest("hex");
+
+  const output = {
+    _note:
+      "BfCA db-fallbacks: reference-grade material defaults for fields that aren't typically published in EPDs (density, thermal conductivity, heat capacity, embodied energy, embodied carbon). Used as fallback only when the EPD itself is silent. Every value applied at runtime carries source: 'generic_default' so users see what came from the EPD vs the catalogue. Generated from db-fallbacks.source.xml — re-run schema/scripts/build-db-fallbacks.mjs after editing.",
+    _schema_version: 1,
+    _source_xml_sha256: sourceSha,
+    _generated_at: new Date().toISOString(),
+    _attribution:
+      "Compiled from a thermal + embodied-properties reference catalogue (XML import). Values are physical material constants; data is reference-grade not product-specific. Per-product accuracy requires an EPD.",
+    defaults_by_material_type: defaultsByMaterialType,
+    _unmapped: unmapped
+  };
+
+  await writeFile(OUTPUT_JSON, JSON.stringify(output, null, 2) + "\n");
+
+  // Summary log
+  const mappedCount = Object.keys(defaultsByMaterialType).length;
+  const variantCount = Object.values(defaultsByMaterialType).reduce((sum, e) => sum + e.variants.length, 0);
+  console.log(`✓ wrote ${OUTPUT_JSON}`);
+  console.log(`  ${mappedCount} canonical material_types, ${variantCount} variants total`);
+  console.log(`  ${unmapped.length} XML rows unmapped (see _unmapped[] in output)`);
+  if (unmapped.length > 0 && process.argv.includes("--verbose")) {
+    console.log("  Unmapped rows:");
+    for (const u of unmapped) console.log(`    ${u.group} :: ${u.name}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/schema/scripts/test-epd-extract.mjs
+++ b/schema/scripts/test-epd-extract.mjs
@@ -190,11 +190,17 @@ async function main() {
   const pdfjs = await loadPdfjs();
   const Extract = await import(EXTRACT_MJS);
 
-  // Prime the lookups so Tier 1 group inference can run. Source-of-truth
-  // is schema/lookups/ — same files the CSV importer reads.
+  // Prime the lookups so Tier 1 group inference + Tier 9 material-default
+  // fallback can run. Source-of-truth is schema/lookups/ — same files the
+  // CSV importer reads.
   const mt = JSON.parse(await readFile(join(LOOKUPS_DIR, "material-type-to-group.json"), "utf8"));
   const kw = JSON.parse(await readFile(join(LOOKUPS_DIR, "display-name-keywords.json"), "utf8"));
-  Extract.setLookups({ mtMap: mt.map || {}, kwPatterns: kw.patterns || [] });
+  const md = JSON.parse(await readFile(join(LOOKUPS_DIR, "db-fallbacks.json"), "utf8"));
+  Extract.setLookups({
+    mtMap: mt.map || {},
+    kwPatterns: kw.patterns || [],
+    materialDefaults: md
+  });
 
   const pdfs = await walkPdfs(SAMPLES_ROOT);
   if (pdfs.length === 0) {


### PR DESCRIPTION
## Summary

EPD-Parser regex sweep + the db-fallbacks architecture that reframes how we fill schema slots from non-EPD sources. Eleven commits, two halves:

- **§9.5 fixes #2–#4** — EU/IBU per-format extractor, ISO 21930 indicator codes (`RPR E` / `NRPR E` / `FW`), comma-thousand parser fix, EPD-IES per-glyph tolerance. Coverage moved metadata 57.6% → 61.0%, impacts 36.0% → 49.0%.
- **§10 + C-fb1..C-fb4** — new `db-fallbacks.json` reference catalogue + Tier-9 fallback layer + four-source provenance system (`epd_direct` / `generic_default` / `calculated` / `user_edit`) + color-coded UI on both EPD-Parser form pane and Database viewer + toolbar legend. Coverage moved another metadata +2.6% (eleven density slots auto-filled with magenta `DEFAULT` chips).

End state: metadata **63.6%**, impacts **49.0%**, zero individual-sample regressions across the eleven commits.

## §9.5 fixes (regex sweep)

- **`370ffc8`** §9.5 fix #2: EU/IBU per-format extractor with bracketed-unit impact patterns. Wood Fibre Insulating Boards EPD: 4/14 → 12/14 metadata, 2/10 → 7/10 impacts. Bonus matches on metals + wood samples that share bracketed-unit phrasings.
- **`39cbb97`** §9.5 fix #3: three new IMPACT_INDICATORS for ISO 21930:2017 codes (`RPR E` / `NRPR E` / `FW`) + the comma-thousand parser fix that was silently truncating `3,490.16` to `3.49`. All four BC Wood 2023 samples now at 10/10 impact coverage.
- **`666de0e`** §9.5 fix #4: per-glyph fragmentation tolerance for the EPD-IES filename variant. Centralised tolerant `_SP_ID_RX = /S\s*-\s*P\s*-\s*(\d{5,6})/` + a `_looseIsoDateAfter` helper that collapses digit-whitespace pairs in dates. Format detection lifts the variant from `unknown` → `epd_international`.

## §10 — Fallback database (the architectural pivot)

Andy 2026-04-29 surfaced that many properties (density, thermal conductivity, heat capacity, embodied energy, embodied carbon for non-product baselines) are **not** in most EPD documents. Pushing regex extraction to fill those gaps is wrong-direction. The new layer fills those slots only when the EPD itself is silent — provenance-marked so the user always sees what came from the EPD vs the catalogue.

- **`6bef852`** Workplan §10 chapter documenting the architecture: four-source `source` enum, color-coded chip system, verification-before-fallback harness upgrade, six-commit plan C-fb1..C-fb6.
- **`557ea31`** **C-fb1** — `schema/lookups/db-fallbacks.source.xml` (~200 thermal/embodied-property entries × 5 properties: density, thermal conductivity, heat capacity, embodied energy, embodied carbon) + `schema/scripts/build-db-fallbacks.mjs` converter that maps XML rows to canonical material_type labels and emits `schema/lookups/db-fallbacks.json`. 31 canonical types covering 142 of 171 XML rows; hand-picked default overrides for Concrete (structural 2200 kg/m³), Steel (plain carbon 7800), Sheathing (OSB 650), etc. so median-by-density doesn't tilt to lightweight variants.
- **`e1ff163`** **C-fb2** — Tier-9 `applyMaterialDefaults(rec)` runs after `extractCommon`, fills `physical.density.value_kg_m3` (the only catalogue field with an existing schema slot today) when null, marks `source: "generic_default"`. `setLookups()` extended; harness + epdparser browser both prime the cache. Filled 11 density slots across Steel / Aluminum / Plywood / Gypsum / Framing / SPF samples.
- **`c0fe802`** **C-fb3** — Form-pane provenance UI in `epdparser.mjs`. New `_resolveSourcePath()` (replaces last segment with `source`) + `_applySourceClass()`. `_populateFormFromCandidate` calls it for every input; `_bindFormChange` flips source to `user_edit` on type. Three CSS classes (`.epd-source-default` magenta, `.epd-source-calc` cyan, `.epd-source-edit` lime).
- **`9d7a048`** **C-fb4** — Database viewer per-field chips + static four-chip legend in the toolbar (`EPD ● DEFAULT ● CALC ● EDIT`) so users land on the page already knowing what each color means. Inline chip on the density row of the Physical Properties block, designed to extend trivially to future Tier-9-fillable fields.
- **`e563f04`** C-fb4 follow-up: DEFAULT chip swapped from amber to magenta to resolve a yellow-vs-yellow collision with the existing `.db-fresh-chip-new` on Trust-committed rows.

## What's not in this PR

- **C-fb5 — verification-before-fallback harness** — explicitly deferred. The current fallback layer is *silent*: if a regex bug fails to extract a value the EPD actually publishes, the catalogue fills it with `generic_default` and the user sees a magenta chip without realising the EPD had the value. C-fb5 builds an `expected/` ground-truth directory + three new harness checks (extraction fidelity / defaults applied correctly / no silent overrides) to catch this. Documented in §10.3 + the next-agent handoff at the top of `docs/workplans/EPD-Parser.md`.
- **xcarb steel density=800 false positive** — flagged in C-fb2's commit log. 3 xcarb steel samples extract `density=800` (real steel is 7800) from somewhere irrelevant in the doc; this is exactly the bug class C-fb5 is purpose-built to surface.
- **C-fb6 — `applyCalculations()` Tier 10** — gated on Andy supplying BEAM math formulas for biogenic carbon stored per unit and similar derivations.

## Verification

- `node schema/scripts/test-epd-extract.mjs` (full harness, 30 sample EPDs): 30/30 processed, no errors. Latest snapshot at [`docs/workplans/EPD-coverage-history/2026-04-29T12-06-59Z.md`](docs/workplans/EPD-coverage-history/2026-04-29T12-06-59Z.md).
- `node schema/scripts/build-db-fallbacks.mjs` (catalogue regen): 31 canonical material_types, 142 variants total, 29 unmapped XML rows listed in the JSON's `_unmapped` array.
- Playwright on `database.html`: seeded a captured row with `physical.density.source = "generic_default"`, clicked Trust → catalogue grew by 1 with the §7.7 NEW chip on the BEAM ID; expanding the Physical Properties section shows `7800 kg/m³ (—) DEFAULT` with the magenta chip rendered inline. Toolbar legend renders all four chips with distinct colors. Test data cleaned from IndexedDB after.
- Per-sample diff vs prior baselines confirms no individual sample regressed at any commit step (§7.6 harness contract held throughout).
- Zero console errors across the session.

## Test plan for BfCA testers

- [x] Open `database.html` after deploy. Confirm the toolbar legend (`EPD ● DEFAULT ● CALC ● EDIT`) renders next to the result count, and tooltip explains what they mean.
- [ ] Drop a wood / steel / aluminum EPD into `epdparser.html`. Confirm the form populates with sensible values; if the EPD doesn't publish density, the density input renders with a magenta tint + magenta left-border (`generic_default` from the catalogue).
- [ ] Type over the density value. The magenta tint should drop and a green left-border appears (`user_edit`).
- [ ] Click **Capture** → open `database.html` → click **Trust** on the captured row. The catalogue gains the row (yellow `NEW` chip). Expand Physical Properties → density value renders with the magenta `DEFAULT` chip if it was catalogue-filled, or no chip if you typed a value (treated as authoritative).
- [ ] (Edge case) Drop an EPD whose product matches an existing catalogue entry by id. Confirm refresh-type flow renders an amber `UPDATED` chip on the existing row instead of `NEW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
