### PR TITLE
EPD-Parser: pause per-format inflation + §12 architecture review + Mélanie biogenic answers

### DIFF
--- a/docs/PDF References/EPD SAMPLES/expected/xcarb-epd-for-cold-formed-sections-final_v3_updated.json
+++ b/docs/PDF References/EPD SAMPLES/expected/xcarb-epd-for-cold-formed-sections-final_v3_updated.json
@@ -12,6 +12,13 @@
     "impacts.functional_unit": "1 metric ton",
     "physical.density.value_kg_m3": 7800,
 
+    "impacts.gwp_kgco2e.total.value": 1257,
+    "impacts.acidification_kgso2eq.total.value": 2.6046,
+    "impacts.eutrophication_kgneq.total.value": 0.11893,
+    "impacts.ozone_depletion_kgcfc11eq.total.value": 8.498e-10,
+    "impacts.smog_kgo3eq.total.value": 49.516,
+    "impacts.abiotic_depletion_fossil_mj.total.value": 1398.4,
+
     "impacts.gwp_kgco2e.by_stage.A1.value": 1230,
     "impacts.gwp_kgco2e.by_stage.A2.value": 11.7,
     "impacts.gwp_kgco2e.by_stage.A3.value": 15.3,
@@ -67,5 +74,5 @@
     "impacts.abiotic_depletion_fossil_mj.by_stage.D.value": -16.1
   },
   "epd_omits": [],
-  "notes": "ArcelorMittal Dofasco XCarb cold-formed steel sections. Cradle-to-gate-with-options scope: A1, A2, A3, C1, C2, C3, C4, D (8 columns, NO A1-A3 composite total in the published table). Per-stage values from Table on page 5 (IPCC AR5 100yr GWP + TRACI 2.1 for AP/EP/ODP/SFP/ADPfossil — note 'GWP 100' is the 100-year-time-horizon methodology label, not a numeric value). Sign on module D values is load-bearing (-241 kgCO2e D = end-of-life recycling credit). Density IS published in the declared-product line: '1 metric ton of cold formed steel sections with a density of 7,800 kg/m3' — fix to the density regex (per-fix-after-rev3) handles US thousand-comma form so 7,800 doesn't truncate to 800. KNOWN-BUG-TO-FIX-LATER: impacts.gwp_kgco2e.total.value currently = 1230 (= A1 only, NOT A1-A3 sum which would be ~1257). For cradle-to-gate-with-options EPDs that don't publish an A1-A3 composite, the extractor should either compute total = A1 + A2 + A3 OR leave total null and rely on by_stage. Out of scope this round; deliberately not annotated in epd_publishes so the harness's coverage check still counts the (wrong) value as filled while this note flags it."
+  "notes": "ArcelorMittal Dofasco XCarb cold-formed steel sections. Cradle-to-gate-with-options scope: A1, A2, A3, C1, C2, C3, C4, D (8 columns, NO A1-A3 composite total in the published table). Per-stage values from Table on page 5 (IPCC AR5 100yr GWP + TRACI 2.1 for AP/EP/ODP/SFP/ADPfossil — note 'GWP 100' is the 100-year-time-horizon methodology label, not a numeric value). Sign on module D values is load-bearing (-241 kgCO2e D = end-of-life recycling credit). Density IS published in the declared-product line: '1 metric ton of cold formed steel sections with a density of 7,800 kg/m3' — density regex now handles US thousand-comma form so 7,800 doesn't truncate to 800. Totals (impacts.<key>.total.value) are RECOMPUTED as A1+A2+A3 sum with source: 'calculated' because the EPD does NOT publish an A1-A3 composite column — the per-indicator headerUsedFor gating ensures we don't recompute when the EPD does publish a composite (e.g. Kalesnikoff's 'A1-A3 A1 A2 A3' header). Asserted values: GWP=1257, AP=2.6046, EP=0.11893, ODP=8.498e-10, SFP=49.516, ADPf=1398.4. Note this round's xcarb total=A1 false-positive fix is now structural — covers all cradle-to-gate-with-options EPDs going forward (xcarb +3 samples, plus surfaced totals on Fabricated Steel Plates, BC Wood OSB, Sopra-XPS, Genyk where per-stage data was extracting but no total was being grabbed)."
 }

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -6,7 +6,13 @@
 
 ## Agent handoff (read this first)
 
-**You are picking up at 2026-04-30, with Andy shifting context to a funder report.** The EPD-Parser is in a clean state: PR #16 (8 commits) merged into main 2026-04-29 evening, sprint-3 branch is +3 commits ahead with three additive improvements (shared text-join module, biogenic-calc workplan chapter, by_stage harness dimension + xcarb per-stage extraction). No open bugs blocking next steps; work is queued on the four follow-ups in `## Open follow-ups (next agent to triage)` below.
+**You are picking up at 2026-04-30 evening, with TWO decision-points pending and a directive to pause adding format-specific extractors.** Andy paused mid-implementation of CISC + 2023 BC Wood ASTM per-format extractors with the directive: *"You seem to be in a loop making highly customized readers for a handful of specific EPDs where we need GENERALIZED functionality for ANY EPD the Parser loads."* See §12 (new) for the architecture-review chapter + 5 questions for Andy.
+
+**Two decisions are gating further code work:**
+1. **§11 — Mélanie's review of the biogenic-calc principle + 6 schema-naming / storage-factor questions.** Gates C-fb6 (Tier-10 biogenic).
+2. **§12 — Andy's choice between Option A (geometric table extraction) / Option B (declarative format library) / Option C (HITL form-pane UX) / hybrid.** Gates any further per-format extractor work.
+
+**A larger sample directory is incoming 2026-05-01.** The harness now accepts `--root <dir>` (workplan §12.6) so it can scan that directory in place. The new per-format breakdown + per-parameter aggregate hit-rate (workplan §12.5) tabulates which formats / fields are under-served at scale — feeds the §12.3 architectural decision.
 
 **Coverage state, end of 2026-04-29 (live numbers from `docs/workplans/EPD-coverage-history/2026-04-29T21-47-50Z.md`):**
 - Metadata: **279/420 (66.4%)** across 30 samples (14 fields each)
@@ -53,7 +59,17 @@
 
 ### Pickup — what you're doing next
 
-**Today (2026-04-30): Andy is writing a funder report.** The EPD-Parser side is in a stable state for that work. No urgent code action required. When code work resumes, the four open follow-ups below are pre-prioritised.
+**Do NOT add new format-specific patterns to `IMPACT_INDICATORS`, `_BYSTAGE_LABELS`, or any analogous list until §12.3 is resolved.** This was the explicit reason for today's pause. The audit data the harness now produces (per-format breakdown + per-parameter aggregate hit-rate, §12.5) is the input to that decision.
+
+When Andy returns:
+1. Resolve §12.3 (architecture choice) — answer the 5 questions in §12.4.
+2. If Option A or B chosen: refactor begins. Existing per-format patterns may be deprecated.
+3. If Option C chosen: shift focus to form-pane UX work.
+4. Independently: chase §11.8 with Mélanie to unblock C-fb6.
+5. When Andy supplies the larger sample directory tomorrow:
+   - Run `node schema/scripts/test-epd-extract.mjs --root <dir>`.
+   - Examine per-format breakdown + per-parameter aggregate. This is the canonical scaling test.
+   - Per-pattern hit-count audit (which existing patterns matched 0 samples in the larger set?) drives deprecation candidates.
 
 ### Open follow-ups (next agent to triage)
 
@@ -74,17 +90,16 @@ Listed with concrete repro / fix sketches so the next agent can pick the highest
 
 **Follow-up #5 — Per-stage extension to other formats.** Current per-stage coverage: Kalesnikoff 30/170, xcarb 48/170, Sopra-XPS 36/170, Genyk 31/170. To reach higher density on Sopra/Genyk/EU-IBU/2023 BC Wood, audit which `_BYSTAGE_LABELS` patterns aren't matching and either tighten or add variants. Driven by ground-truth annotation: pick a sample, annotate, run harness, see what fails.
 
-### Branch state (2026-04-30 morning)
+### Branch state (2026-04-30 evening)
 
 ```
-main                            046108a   PR #16 merged 2026-04-29 evening
-└── EPD-PARSER-SPRINT-3  (active, 3 commits since main)
-    ├── 607a4ed  shared text-join module
-    ├── 0c2c70d  §11 Biogenic Calculations chapter (review-pending)
-    └── 34570bc  by_stage harness dimension + xcarb per-stage + density fix (← tip)
+main                       3fd57e2   PR #17 merged 2026-04-30
+└── EPD-PARSER-4  (active, 2 commits since main)
+    ├── 3839b47  cradle-to-gate-with-options total recompute + CISC compact-label per-stage
+    └── (tip — workplan §12 + harness --root flag + per-format/per-param audit)
 ```
 
-Both remotes synced. No PR open yet (waiting for either Mélanie's §11 review to land C-fb6, or another batch of work to bundle).
+Both remotes synced. The `3839b47` commit added CISC-format extraction; flagged in §12.2 as per-EPD baggage, may be deprecated depending on §12.3 decision (Option A geometric extraction would replace it; Option B declarative would relocate it; Option C HITL would deprecate it in favour of form-pane UX). No PR open until §12.3 lands.
 
 ### Read this order
 
@@ -985,7 +1000,108 @@ Once these are answered, C-fb6 implementation (Tier 10 + the 3 new schema fields
 
 ---
 
-## 12. Out of scope (v1)
+## 12. Architecture review — generalization vs per-format pattern inflation (decision-pending)
+
+> **Status:** Drafted 2026-04-30 PM after Andy paused mid-implementation of CISC + 2023 BC Wood ASTM per-format extractors. Decision needed on the architectural shape before any further extractor work. **Do not add new format-specific patterns until §12.3 is resolved.**
+
+### 12.1. The problem
+
+The parser currently grows a hand-tuned regex library per EPD format encountered. Examples accumulated by 2026-04-30:
+
+- `IMPACT_INDICATORS` — ~24 regex entries, multiple per indicator (NA short codes, English long form, EU/IBU bracketed, ISO 21930 codes, …)
+- `_BYSTAGE_LABELS` — ~16 entries
+- `_CISC_LABEL_PATTERNS` + `_findCISCDataRowKey` look-around — CISC-specific multi-line layout
+- Pre-paused: `_ASTM_INDICATOR_PATTERNS` for 2023 BC Wood ASTM family (reverted, not committed)
+- Format-specific extractors: `extractNA`, `extractEpdIntl`, `extractNSF`, `extractEuIbu`
+
+This shape **does not scale** to "any EPD the parser loads". The wood-EPD families alone use 4+ distinct table layouts; there are dozens of program operators issuing EPDs in their own templates. Calibration samples grow → regex library grows linearly → maintenance cost grows superlinearly (each new pattern can interact with existing ones).
+
+The parser was designed to handle 30 calibration EPDs. Andy is bringing a much larger directory tomorrow (2026-05-01). The current shape will produce diminishing returns — many new samples will extract poorly, a handful will need bespoke regex additions, and overall coverage will plateau.
+
+### 12.2. What's general vs over-fitted in the current code
+
+**General (worth keeping regardless of architecture choice):**
+
+- `js/shared/text-join.mjs` — pdf.js item → text reconstruction. Browser-vs-Node parity. Format-agnostic.
+- C-fb5 harness ground-truth check — works for any annotated sample.
+- Density thousand-comma fix — genuinely general regex bug (`7,800` → 7800).
+- Sign + sci-not preservation via x-gap heuristic — pdf.js-level, not format-specific.
+- `_extractByStage` shell: stage-header detection + position-mapping logic.
+- xcarb total-recompute (`3839b47`): "if the indicator's used header has no A1-A3 composite, sum A1+A2+A3 to derive total" — generally correct LCA math, not per-format.
+- Tier-9 db-fallbacks layer (catalogue defaults with provenance marking).
+- `_normalizeDeclaredUnit` — extracts canonical unit token from descriptive prose; format-agnostic.
+
+**Per-EPD baggage (over-fitted; subject to deprecation depending on §12.3 choice):**
+
+- All format-specific entries in `IMPACT_INDICATORS` — 24+ regex variants
+- All entries in `_BYSTAGE_LABELS` — 16 patterns
+- `_CISC_LABEL_PATTERNS` + look-around heuristics (committed in `3839b47`; flagged for revisit)
+- Per-format extractors `extractNA` / `extractEpdIntl` / `extractNSF` / `extractEuIbu` — partially over-fitted; the format-detection signals (`detectFormat`) are general but the per-format probes are largely format-tuned
+
+### 12.3. Three architectural options on the table
+
+**Option A — Geometric / column-based table extraction.**
+Use pdf.js item `x`/`y` positions to detect column boundaries and row groupings. Build a 2D table model. Map indicator label → row, stage code → column, look up cell by intersection. This is how Tabula / pdfplumber / Camelot work.
+
+- Pros: replaces 80%+ of per-format pattern files with one general engine. Scales to arbitrary table layouts. Handles split-line headers and centred labels structurally.
+- Cons: ~1-2 weeks of foundational work. Requires re-architecting `_extractByStage` and `_extractIndicatorTotals`. Still needs an indicator-label vocabulary to map row labels → schema keys (but vocabulary, not regex-spaghetti).
+- Best for: long-term scaling. Andy's "any EPD" stated goal.
+
+**Option B — Declarative format library.**
+A `schema/lookups/epd-formats.json` describing each program operator's table layout (anchor strings, column count, indicator-code vocabulary, header patterns). Adding a new format = adding a JSON entry, not editing extract.mjs.
+
+- Pros: Lower bar than (A). Makes per-format patterns reviewable + diff-friendly. Mélanie or other reviewers could add format entries without touching code.
+- Cons: Doesn't solve the inflation problem — still N entries for N formats. Just relocates the spaghetti from .mjs to .json.
+- Best for: stopgap if (A) is too big a rewrite right now.
+
+**Option C — Live with partial extraction + better human-in-the-loop.**
+Accept 50-60% extraction coverage. Invest in form-pane UX: per-row "extract this column" buttons, copy-cell-from-text helpers, OCR overlay for clicking on a value to extract it.
+
+- Pros: EPD-Parser is already human-reviewed (form pane, Trust commit). Practitioners are domain experts who can quickly fix a row. Avoids the architecture-rewrite cost entirely.
+- Cons: Doesn't reduce per-EPD reviewer burden as the catalogue grows. Coverage will plateau at whatever the current regex library handles.
+- Best for: pragmatic shipping if engineering time is the constraint.
+
+**Hybrid (most likely outcome):** (A) as the primary extraction path + (C) for cells (A) misses. (B) as a fallback shim during the (A) build-out.
+
+### 12.4. Decision-pending — questions for Andy
+
+1. Which option (A / B / C / hybrid)?
+2. If (A): what's the time budget? Block the larger sample set's coverage targets behind it, or run per-format patterns in parallel as a fallback?
+3. If (B): is the JSON schema per-program-operator (UL Environment, ASTM, CSA, NSF, IBU, EPD International) or per-table-layout (some program operators issue multiple template versions)?
+4. If (C): what's the form-pane UX target — click-to-extract from PDF render? Or a structured-paste-from-text input?
+5. Mélanie's review of §11 (biogenic) is independently pending. Do we want to ship Tier-10 (biogenic) BEFORE Option A/B/C decision lands, or wait?
+
+### 12.5. Re-test plan against today's code (before tomorrow's larger sample set)
+
+Once §12.3 decision lands, re-run the harness against the current 30 samples and audit per-format which patterns are EARNING THEIR KEEP vs which are dead weight from over-fitting:
+
+1. **Per-pattern hit count.** For each entry in `IMPACT_INDICATORS` and `_BYSTAGE_LABELS`, log how many samples actually match. Patterns matching 0 or 1 samples are candidates for removal (the cost is greater than the value).
+2. **Per-format coverage breakdown.** Tabulate metadata + impact + by_stage coverage by detected format (na / epd_international / nsf / eu_ibu / unknown). Surface which formats are most under-served.
+3. **Per-parameter extraction rate.** For each schema field (e.g. `manufacturer.name`, `epd.id`, `physical.density.value_kg_m3`), aggregate hit rate across all 30 samples. Surface which fields have systemic gaps vs which are sample-idiosyncratic.
+
+Tomorrow when Andy supplies the larger sample directory, the same harness should run against that with `--root <dir>` (see §12.6 below for the new flag) and produce the same per-format / per-parameter breakdown — that's the canonical test of whether each pattern earns its keep at scale.
+
+### 12.6. Harness `--root <dir>` flag (shipped 2026-04-30 evening)
+
+To support tomorrow's larger sample set without copying PDFs into `docs/PDF References/EPD SAMPLES/`, the harness now accepts `--root <directory>`:
+
+```bash
+node schema/scripts/test-epd-extract.mjs --root /path/to/larger/sample/set
+```
+
+The harness recursively walks the directory for `*.pdf` files, runs the same extraction + per-sample coverage matrix, and emits the same markdown snapshot to `docs/workplans/EPD-coverage-history/`. Sample names are recorded as `<basename>` (no group prefix, since the larger set may not follow the `03/05/06/07` group convention).
+
+Combined with the per-pattern-hit-count and per-format / per-parameter breakdown (§12.5), the harness against a 100-sample directory will tell us within a few minutes:
+
+- What % of the larger set extracts cleanly with current patterns
+- Which formats need new generalization (informs Option A's scope)
+- Which existing patterns matched 0 samples and should be deprecated (cleanup target)
+
+The `--root` flag is purely additive — running the harness without it falls back to the canonical 30-sample EPD SAMPLES/ tree as before.
+
+---
+
+## 13. Out of scope (v1)
 
 - **OCR** (Tesseract.js fallback) — P7 phase. **Real demand confirmed in P1 calibration** (`EPD_Polyiso walls.pdf` is image-only, zero text-layer items). v1 detects this case and surfaces a "needs OCR" banner; the actual OCR pass lands in P7.
 - **Hard delete of database records.** Forever. Soft-delete via `status.visibility = "flagged_for_deletion"` is the only deletion path; flagged records stay in `schema/materials/*.json` for back-office manual review (see [`Database.md`](Database.md) §6).

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -9,8 +9,8 @@
 **You are picking up at 2026-04-30 evening, with TWO decision-points pending and a directive to pause adding format-specific extractors.** Andy paused mid-implementation of CISC + 2023 BC Wood ASTM per-format extractors with the directive: *"You seem to be in a loop making highly customized readers for a handful of specific EPDs where we need GENERALIZED functionality for ANY EPD the Parser loads."* See §12 (new) for the architecture-review chapter + 5 questions for Andy.
 
 **Two decisions are gating further code work:**
-1. **§11 — Mélanie's review of the biogenic-calc principle + 6 schema-naming / storage-factor questions.** Gates C-fb6 (Tier-10 biogenic).
-2. **§12 — Andy's choice between Option A (geometric table extraction) / Option B (declarative format library) / Option C (HITL form-pane UX) / hybrid.** Gates any further per-format extractor work.
+1. **§11 — Mélanie answered the 6 questions on 2026-05-05 (see §11.8).** Her answers SIGNIFICANTLY EXPAND the C-fb6 scope: biogenic_factor isn't a single material-type default; it's derived from the EPD's Material Content of the Product table, with carbon content from EITHER the EPD or the Phyllis 2 biomass database (https://phyllis.nl/). Three distinct biogenic-source paths (EPD GWP-bio / EPD BCRP / BfCA-calculated). NEW captures needed: material content table + biogenic inventory table (BCRP/BCEP/BCRK/BCEW per stage). Revised commit plan in §11.9 — was ~3 hrs, now ~19 hrs across 7 sub-commits. Remaining open items for Monday review listed in §11.10.
+2. **§12 — Andy's choice between Option A (geometric table extraction) / Option B (declarative format library) / Option C (HITL form-pane UX) / hybrid.** Gates any further per-format extractor work. Note: Mélanie's expanded C-fb6 scope (material-content table extraction, biogenic-inventory table extraction) is itself a per-format extraction problem — these sub-commits are gated on §12.3 too.
 
 **A larger sample directory is incoming 2026-05-01.** The harness now accepts `--root <dir>` (workplan §12.6) so it can scan that directory in place. The new per-format breakdown + per-parameter aggregate hit-rate (workplan §12.5) tabulates which formats / fields are under-served at scale — feeds the §12.3 architectural decision.
 
@@ -226,7 +226,7 @@ npm run serve                                                     # local dev se
 
 **Phases pending** (ranked by leverage post-2026-04-29 evening):
 
-- 🟨 **C-fb6 — `applyCalculations()` Tier 10** — review-pending. The BEAM-CSV inventory confirmed all formula inputs are present; §11 drafts the principle for Mélanie's review. Six concrete questions in §11.8 need sign-off; once answered, ~3 hrs of mechanical implementation.
+- 🟧 **C-fb6 — `applyCalculations()` Tier 10** — design-pending (revised 2026-05-05 after Mélanie's answers in §11.8). Was estimated ~3 hrs; now ~19 hrs across 7 sub-commits (§11.9). Mélanie clarified: biogenic_factor isn't a per-material-type default — it's derived from the EPD's Material Content table + Phyllis 2 biomass carbon-content lookup (https://phyllis.nl/). Three distinct biogenic-source paths (EPD GWP-bio / EPD BCRP / BfCA-calculated). New schema: `classification.material_content[]`, `physical.beam_calc.{full_c_kgco2e, biogenic_source, storage_cycle, ...}`, `impacts.biogenic_inventory.{bcrp, bcep, bcrk, bcew}.by_stage.*`. Compound-gated on Monday's Mélanie review (§11.10) AND §12.3 architecture choice (material-content table extraction is itself a per-format problem).
 - 🔜 **xcarb total = A1 false positive** — for cradle-to-gate-with-options EPDs without a published A1-A3 composite, the IMPACT_INDICATORS regex grabs A1 as "total". Should compute total = A1+A2+A3 OR leave null. Annotated in xcarb cold-formed ground-truth notes; not asserted (so harness doesn't fail on it). See follow-up #2 in agent handoff.
 - 🔜 **CISC water "Use of net fresh water 1 mt 2.88E+00"** — regex variant for the "1 mt" functional-unit prefix between label and value. CISC currently 0/10 impacts and 0/170 by_stage; this would unblock at least WDP. See follow-up #3 in agent handoff.
 - 🔜 **C-fb5 ground-truth backlog** — only 2/30 samples annotated. Priority: 2023 BC Wood ASTM family (CLT/GLT/SPF/SPF-Plywood — same format as Kalesnikoff, low risk, locks in coverage), EU/IBU Wood Fibre (different format, exercises EU/IBU paths), Lafarge cement (NSF format).
@@ -977,26 +977,146 @@ After C-fb6 lands, the placeholders fill in. The `stated` line shows the **EPD-p
 - **No BEAMweb-side assembly math.** Per-component roll-up (studs/m², coverage factors, hybrid-component weighted averages) is BEAMweb's job, not EPD-Parser's. Tier 10 produces per-material per-declared-unit derivative values; BEAMweb then projects those onto its assembly geometry.
 - **No "carbon storage" claims to end users beyond what EPDs state.** BfCA's display surfaces are factual: "this EPD reports A1 = –1045.63 kgCO₂e biogenic." We don't editorialize. The 0.9 WWF storage factor (when applied) is labelled explicitly in the audit trail so practitioners can see it's a BfCA convention layered on top of the EPD value.
 
-### 11.8. Open questions for Mélanie's review
+### 11.8. Mélanie's answers — 2026-05-05
 
-Listed concretely so this chapter can be skimmed and approved in one pass:
+> **Status:** Mélanie's responses inline, with my interpretation and implementation impact noted under each. Several answers expand the scope significantly; revised implementation roadmap in §11.9. Items still needing back-and-forth flagged for the Monday review in §11.10.
 
-1. **Storage factor source.** Should `storage_factor = 0.9` be a hard-coded BfCA constant (current BEAM CSV behaviour, col 28) or read from each EPD's biogenic methodology section if stated? If the latter, what's the schema slot — `methodology.storage_factor`?
-2. **Biogenic factor + carbon content fallbacks.** When the EPD doesn't publish `biogenic_factor` or `carbon_content_kgC_kg` explicitly, BEAM CSV uses material-type-keyed defaults (Wood = 0.989, 0.5 respectively from Glulam row). Should these defaults live in `db-fallbacks.json` alongside density / k / Cp etc., or in a separate biogenic-specific lookup? The former matches the existing pattern; the latter is more semantically clean.
-3. **Schema-field naming.** Proposed new fields:
-   - `methodology.biogenic_factor` (kg-biomass / kg-product, default 1.0 for solid wood)
-   - `methodology.carbon_content_kgc_kg` (kgC / kg-biomass, default 0.5 for wood)
-   - `methodology.beam_calc.{full_c_kgco2e, stored_kgco2e, inputs[]}` (Tier 10 output, source: "calculated")
-   
-   Do these names match BEAM's existing terminology? Should `beam_calc` be under `methodology` or `physical`?
+**Q1 — Storage factor source.** Should `storage_factor = 0.9` be hard-coded or per-EPD?
 
-4. **BEAM CSV column 23 — `GWP-bio from EPD`.** This appears to already capture the EPD-direct biogenic value for the existing 821 records. After C-fb6 lands, EPD-Parser's `impacts.gwp_bio_kgco2e.total.value` should round-trip to this column. Confirm the column header convention.
+> **MT:** Right now it is a constant hard-coded BfCA constant.
 
-5. **Per-stage biogenic vs aggregate.** The EPD publishes per-stage biogenic (Kalesnikoff GLT: A1 = –1045.63, A3 = +1045.63, net total = 0). BEAM CSV col 31 (`Full C value`) appears to be a single number per material — is that the A1 value (carbon stored), the A1-A3 net (≈ 0 for cradle-to-gate), or something else? P3.3 already extracts the per-stage matrix; need clarity on which slot BEAMweb wants for its assembly math.
+→ **Confirmed.** Stays at `0.9` as a BfCA convention. No per-EPD override needed. **But see Q3 below** — Mélanie clarifies that this `0.9` is specifically the **carbon storage long cycle** factor (not just a generic storage factor). Schema needs a flag for long-cycle vs short-cycle storage.
 
-6. **Validation samples.** After Tier 10 ships, can we validate by comparing `methodology.beam_calc.full_c_kgco2e` for the 5 samples we'll have annotated under C-fb5 (Kalesnikoff CLT, GLT, xcarb cold-formed, etc.) against the corresponding rows in `BEAM Database-DUMP.csv`? Numeric tolerance ±5%? Per-row mismatches would surface either a formula misunderstanding on our side or a computed-vs-published difference in BEAM's source data.
+**Q2 — Biogenic factor + carbon content fallbacks.** Where do default values live when the EPD doesn't publish them explicitly?
 
-Once these are answered, C-fb6 implementation (Tier 10 + the 3 new schema fields + form-pane render of the audit trail) is ~3 hours of work. Schema bump requires Mélanie sign-off; everything else is mechanical.
+> **MT:** The biogenic factor is usually from the EPD. They usually list the "Material Content of the Product" with %, then we identify which material of the product contains biogenic material (usually only one material, but can be two). Then, using the Phyllis 2 database (https://phyllis.nl/), we find the carbon content for those materials. Some EPDs provide the carbon content now, but not all. Based on this information, which structure do you propose?
+
+→ **Significant scope expansion.** This is more layered than my draft assumed:
+- The "biogenic factor" isn't one number per material_type — it's derived from the EPD's **Material Content of the Product** table (e.g. "70% wood + 30% adhesive" → biogenic_factor for wood-component is 0.7).
+- Each biogenic component then needs a **carbon content** value, which comes from EITHER the EPD itself (when published) OR the **Phyllis 2 database** (https://phyllis.nl/, Dutch ECN biomass composition reference) for the relevant biomass type.
+- So Tier-10 needs THREE inputs the parser must capture / look up:
+  1. Material content breakdown (per-material % of the product)
+  2. Which materials are biogenic (BfCA-curated tagging of biomass types)
+  3. Carbon content per biomass type (EPD-published OR Phyllis 2 lookup)
+
+**My proposed structure (for Mélanie's Monday review):**
+
+```
+schema/lookups/phyllis2-biomass-carbon-content.json   ← curated lookup
+  { "wood_softwood_dry":   { "carbon_content_kgC_kg": 0.50, "source": "Phyllis 2 / NREL" },
+    "wood_hardwood_dry":   { "carbon_content_kgC_kg": 0.49, ... },
+    "bamboo":              { "carbon_content_kgC_kg": 0.524, ... },
+    "straw":               { "carbon_content_kgC_kg": 0.48, ... },
+    "wool":                { "carbon_content_kgC_kg": 0.50, ... },
+    ... (~20 entries covering BfCA-relevant biomass types)
+  }
+
+EPD-Parser extracts:
+  classification.material_content[] = [
+    { material_type: "softwood", percent: 0.70, biogenic: true },
+    { material_type: "phenolic_resin_adhesive", percent: 0.30, biogenic: false }
+  ]
+
+Tier-10 derives, per biogenic component:
+  biogenic_factor = component.percent  (e.g. 0.70)
+  carbon_content  = lookup(component.material_type) OR EPD-published
+  full_C contribution = density × thickness × biogenic_factor × carbon_content × 3.67
+  Sum across all biogenic components.
+```
+
+Implementation impact: new schema field `classification.material_content[]`, new lookup file `phyllis2-biomass-carbon-content.json`, EPD-Parser extraction of the Material Content of the Product table (which is its own per-format challenge — table layouts vary). **Tier-10 implementation is no longer ~3 hours; revised estimate ~8-10 hours plus the Phyllis 2 curation.**
+
+**Q3 — Schema-field naming.**
+
+> **MT:** I'm not sure I understand the difference between methodology and physical. Also about "default 1.0 for solid wood" — I don't know how the machine read this, but a product can have solid wood as part of its material content, but it wouldn't be a factor of 1 necessarily. Those names make sense to me. Also, in the repo when you reference the "WWF Storage Factor kgCO2e/kgC" column, this is actually the **carbon storage long cycle**. But the methodology is the same to calculate it. We would need a way to flag it as carbon storage long cycle.
+
+→ **Three clarifications:**
+1. **methodology vs physical** — pragmatic call: I'll put `beam_calc` directly under `physical` (since it's about physical properties of the material as derived/normalized for BEAMweb). Mélanie can override on Monday.
+2. **"default 1.0 for solid wood" was wrong** — confirmed by the Q2 answer above. There's no universal default; it always comes from the EPD's material content table (or Phyllis 2 fallback for the carbon-content piece).
+3. **Long-cycle vs short-cycle storage flag** — NEW. The `0.9` storage factor specifically applies to LONG-CYCLE (durable, building-life) storage. Different materials/uses might be short-cycle (annual crops, packaging). Schema needs:
+   ```
+   physical.beam_calc.storage_cycle: "long_cycle" | "short_cycle"
+   physical.beam_calc.storage_factor: 0.9 (when long_cycle, BfCA constant)
+   ```
+   Default for construction materials = `long_cycle`. Short-cycle would be flagged for materials like straw bales used non-permanently, or packaging.
+
+**Q4 — BEAM CSV column 23 (`GWP-bio from EPD`).** Round-trip to this column?
+
+> **MT:** I'm not sure to understand. There are 3 ways we calculate biogenic carbon:
+> 1. EPDs has no mention of biogenic storage, but human know there are some based on the material content: BfCA methodology: mass × biogenic content × carbon factor × 44/12.
+> 2. EPDs provide BCRP = Biogenic carbon removal from product.
+> 3. EPDs provide the GWP-bio.
+>
+> The current structure in the BEAM database is all over the place and not optimal, and we should take some time to think about the new structure. GWP-bio from EPD include BCRP and GWP-bio in the current database.
+
+→ **Schema needs a derivation-source flag.** Three distinct origins of the biogenic value, which BEAMweb / database viewer must surface separately:
+```
+physical.beam_calc.biogenic_source: "epd_gwp_bio" | "epd_bcrp" | "calculated_from_material_content"
+```
+
+The current `BEAM Database-DUMP.csv` col 23 mixes #2 and #3 (EPD-direct biogenic, regardless of whether it's GWP-bio or BCRP). Going forward we should separate them; legacy 821 records will need a one-time migration to attribute their col-23 values to the right source (Mélanie + curator review).
+
+**Q5 — Per-stage biogenic vs aggregate.** Which slot does BEAMweb consume?
+
+> **MT:** Some EPDs that look at cradle-to-gate only, and using the -1/+1 methodology for carbon storage, where they say that all the carbon is released at end of life, all the other stages are captured in A3, so carbon storage equals to 0.
+> Also GWP-bio when listed per stage, includes in A3 the BCRK = Biogenic carbon removal from packaging; which we have not been including, since the packaging won't make it to the assembly, and is not part of the carbon content of the product. So yes, we often take the **A1 value only for GWP-bio**.
+> (Reference: https://www.woodworks.org/resources/understanding-the-carbon-numbers-in-a-wood-epd/ — though as you'll see, they only provide GWP total (including biogenic) and GWP. Usually we have GWP-total, GWP fossil, GWP bio.)
+> We should **extract from the EPD all the stages of GWP-bio**, AND also extract the table with the **BCRP, BCEP, BCRK, BCEW** for all the stages provided.
+
+→ **Two captures needed:**
+
+1. **Per-stage GWP-bio** (already in P3.3 — `impacts.gwp_bio_kgco2e.by_stage.{A1, A2, ...}`). **A1 is the load-bearing slot for BEAMweb assembly math** (= carbon stored in product; excludes packaging contributions in A3).
+
+2. **NEW: Biogenic inventory table** with 4 categories per stage:
+   ```
+   impacts.biogenic_inventory.bcrp.by_stage.{A1, A2, ..., D}   ← Biogenic Carbon Removal from Product
+   impacts.biogenic_inventory.bcep.by_stage.{...}              ← Biogenic Carbon Emission from Product
+   impacts.biogenic_inventory.bcrk.by_stage.{...}              ← Biogenic Carbon Removal from packaging (excluded from BEAMweb math)
+   impacts.biogenic_inventory.bcew.by_stage.{...}              ← Biogenic Carbon Emission from Waste
+   ```
+   This is a SEPARATE table on most EPDs (we already saw it in Kalesnikoff GLT — Table 2 "Biogenic Carbon Inventory Parameters" with columns `Total | A1 | A2 | A3 | A5 | C3/C4`).
+
+**For BEAMweb consumption priority:**
+- Prefer `impacts.gwp_bio_kgco2e.by_stage.A1.value` (the EPD's per-stage GWP-bio A1, with packaging already netted by the EPD)
+- Fall back to `impacts.biogenic_inventory.bcrp.by_stage.A1` (Biogenic Carbon Removal from Product specifically — excludes BCRK packaging)
+- Fall back to BfCA-calculated value (`physical.beam_calc.full_c_kgco2e`) when EPD has neither
+
+**Q6 — Validation samples.** Compare `methodology.beam_calc.full_c_kgco2e` against `BEAM Database-DUMP.csv` for already-annotated samples?
+
+> **MT:** Not sure I understand the question. Let's revise it together on Monday, or you can provide more explanation here. Thanks! :)
+
+→ **Restated for Monday's review:**
+
+Once Tier-10 (`applyCalculations`) is implemented, every record produced by EPD-Parser will have a `physical.beam_calc.full_c_kgco2e` (or whatever we settle on for the field name) — this is BEAM's normalized biogenic-carbon value, computed from the EPD inputs.
+
+For the 821 existing records in `BEAM Database-DUMP.csv` (which were imported from BEAM's original spreadsheet), col 31 already contains a "Full C value" computed by Mélanie's spreadsheet using the same formula. **We can use these as a regression test:** for each of our currently-annotated C-fb5 samples (Kalesnikoff GLT, xcarb cold-formed) — IF those samples also have rows in `BEAM Database-DUMP.csv` — re-extract via EPD-Parser, run Tier-10, and compare `physical.beam_calc.full_c_kgco2e` against the spreadsheet's col 31. Numeric agreement within ±5% would mean our formula implementation matches Mélanie's. Mismatches would surface either a formula misunderstanding on our side OR a stale/inconsistent value in the existing BEAM database.
+
+The question is whether you (Mélanie) think ±5% tolerance is reasonable, or whether the spreadsheet's values should be exactly reproducible (±0.1%)?
+
+### 11.9. Revised implementation roadmap (post-Mélanie review)
+
+C-fb6 has grown from "~3 hours of mechanical implementation" to a multi-step build with new data-acquisition work. Revised commit plan:
+
+| Commit | Scope | Estimate |
+|---|---|---|
+| C-fb6.1 | Schema bump: add `classification.material_content[]` array, `physical.beam_calc.{full_c_kgco2e, stored_kgco2e, biogenic_source, storage_cycle, storage_factor, inputs[]}`, `impacts.biogenic_inventory.{bcrp, bcep, bcrk, bcew}.by_stage.*` | ~2 hrs |
+| C-fb6.2 | Curate `schema/lookups/phyllis2-biomass-carbon-content.json` from Phyllis 2 (~20 entries covering BfCA materials) | ~3 hrs (mostly data work, needs Mélanie review) |
+| C-fb6.3 | Extract Material Content of the Product table from EPDs (per-format extraction; format detection for the table varies wildly — same architectural concern as §12) | ~4 hrs (gated on §12.3 architecture decision — geometric extraction would handle this generically) |
+| C-fb6.4 | Extract Biogenic Inventory (BCRP/BCEP/BCRK/BCEW) per-stage table | ~3 hrs (also gated on §12.3) |
+| C-fb6.5 | Implement Tier-10 `applyCalculations(rec)` with BEAM formula + provenance chain + storage_cycle handling | ~3 hrs |
+| C-fb6.6 | Form-pane audit-trail render (already scaffolded — fill in the placeholders with calculated values + chips) | ~2 hrs |
+| C-fb6.7 | Validation harness: compare Tier-10 output against `BEAM Database-DUMP.csv` col 31 for annotated samples (per Q6) | ~2 hrs |
+
+**Total revised estimate: ~19 hours** (was ~3 hours pre-review). Most of the inflation is C-fb6.3 + C-fb6.4 — material-content table extraction — which is the same per-format extraction problem §12 paused on. **C-fb6 is now compound-gated:** §11.10 (Monday review with Mélanie) AND §12.3 (Andy's architecture choice).
+
+### 11.10. Open items needing Monday review (with Mélanie)
+
+1. **Schema-field locations.** Confirm `physical.beam_calc.*` (under `physical`, not `methodology`) is the right home. Confirm `classification.material_content[]` is the right slot for the Material Content table.
+2. **`storage_cycle` enum values.** Proposed: `"long_cycle"` (durable building materials, default) | `"short_cycle"` (packaging, annual crops). Are there other values needed (e.g. `"medium_cycle"` for materials with reuse / refurbishment cycles)?
+3. **Phyllis 2 lookup curation.** Mélanie review the proposed ~20-entry list of biomass types + carbon content values before C-fb6.2 ships. Probably easiest to do this against a draft JSON file in a Monday session.
+4. **Material Content table extraction.** Format varies per EPD program operator; this is an instance of the §12 architecture problem. Discuss whether to wait for §12.3 decision or build a stop-gap per-format extractor for the most common 3-4 layouts.
+5. **Existing 821 records — derivation_source migration.** The BEAM CSV col 23 mixes EPD-GWP-bio + EPD-BCRP. Should the migration be: (a) one-shot manual review with Mélanie tagging each row's source, (b) re-extract from the original EPD PDFs (most aren't archived in our repo), or (c) leave the legacy records flagged `biogenic_source: "legacy_unknown"` and only attribute new EPD-Parser commits going forward?
+6. **Validation tolerance.** ±5% as proposed in Q6, or stricter?
 
 ---
 

--- a/docs/workplans/EPD-coverage-history/2026-05-05T00-06-33Z.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-05T00-06-33Z.md
@@ -1,0 +1,85 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-05T00:06:33.210Z
+Samples: 30 · metadata: 279/420 (66.4%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 13/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 10/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 7/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 10/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 11/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 13/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 13/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 13/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 13/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 11/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/docs/workplans/EPD-coverage-history/2026-05-05T02-01-41Z.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-05T02-01-41Z.md
@@ -1,0 +1,85 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-05T02:01:41.515Z
+Samples: 30 · metadata: 279/420 (66.4%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 13/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 10/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 7/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 10/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 11/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 13/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 13/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 13/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 13/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 11/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -747,7 +747,13 @@ var IMPACT_INDICATORS = [
     schemaKey: "water_consumption_m3",
     label: "WDP (FW / ISO 21930)",
     regex: /\bFW\b\s*\[?\s*m\s*[³^]?3?\s*\]?\s+(-?\s*\d{1,3}(?:,\d{3})*(?:[.,]\d+)?(?:E\s*[-+]?\s*\d+)?)/
-  }
+  },
+
+  // (CISC standalone water row removed — it has 3 per-stage values
+  // [A1, A2, A3] in the spatially-joined `1 mt VALUE_A1 VALUE_A2
+  // VALUE_A3` line, NOT a single value. The CISC look-back path in
+  // _extractByStage routes this row to by_stage extraction; the
+  // recompute-totals block then sums A1+A2+A3 → calculated total.)
 ];
 
 function _extractIndicatorTotals(text, rec) {
@@ -911,6 +917,60 @@ function _tokenizeImpactNumbers(line) {
   return out;
 }
 
+// CISC look-around: when a line begins with "1 mt" / "1 ton" / "1 metric ton"
+// / "1 short ton" followed by a sci-not value, the indicator label sits on
+// a NEARBY but separate line (CISC's table has the label centred at the
+// y-midpoint of its 2-row value cell, so spatial-join puts it BETWEEN the
+// two value rows). Layout pattern repeating per indicator:
+//   <data 1 mt>           ← line i (first data row)
+//   <label>               ← line i+1 (centred label)
+//   <unit + 1 ton>        ← line i+2
+//   <data 1 ton>          ← line i+3 (second data row)
+// So for "1 mt" rows, label is at i+1 (forward 1).
+// For "1 ton" rows, label is at i-2 (back 2).
+// Try those two positions in order; first match wins.
+var _CISC_LABEL_PATTERNS = [
+  { rx: /^\s*Global\s+warming\s*$/i, key: "gwp_kgco2e" },
+  { rx: /^\s*Ozone\s+depletion\s*$/i, key: "ozone_depletion_kgcfc11eq" },
+  { rx: /^\s*Acidification\s+of\s+land\s+and\s+water\s*$/i, key: "acidification_kgso2eq" },
+  { rx: /^\s*Eutrophication\s*$/i, key: "eutrophication_kgneq" },
+  { rx: /^\s*Smog\s*$/i, key: "smog_kgo3eq" },
+  { rx: /^\s*Depletion\s+of\s+abiotic\s+resources\s*\(\s*fossil\s*\)\s*$/i, key: "abiotic_depletion_fossil_mj" },
+  // CISC water row uses Pattern B layout (label ABOVE the data row,
+  // then unit-continuation, then "1 ton" data). Probe i-1 covers it.
+  { rx: /^\s*Use\s+of\s+net\s+fresh\s+water\s*$/i, key: "water_consumption_m3" }
+];
+var _CISC_DATA_ROW_RX = /^\s*1\s+(?:mt|ton|metric\s+ton|short\s+ton)\s+-?\s*\d/i;
+
+function _findCISCDataRowKey(lines, i) {
+  var unitMatch = lines[i].match(/^\s*1\s+(mt|ton|metric\s+ton|short\s+ton)\s+-?\s*\d/i);
+  if (!unitMatch) return null;
+  var unit = unitMatch[1].toLowerCase().replace(/\s+/g, " ");
+  var isMt = unit === "mt" || unit === "metric ton";
+  // For "1 mt" first-row data: label at i+1 (Pattern A — centred label
+  // sits between the two value rows), or i-1 (Pattern B — label sits
+  // ABOVE the data row, e.g. CISC water row). Also probe i-2 as a
+  // fall-through.
+  // For "1 ton" second-row data: label at i-2 (Pattern A only). DO NOT
+  // probe i+1 from a "1 ton" row because i+1 is the NEXT indicator's
+  // "1 mt" data row, not a label — without this restriction, a "1 ton"
+  // row from an unrelated resource indicator (e.g. "Recovered energy
+  // 1 ton 0.00..." on line 588) would false-pair with the water label
+  // on line 589 and write 0/0/0 to water before the real water row at
+  // line 590 fires.
+  var candidates = isMt ? [i + 1, i - 1, i - 2] : [i - 2];
+  for (var c = 0; c < candidates.length; c++) {
+    var idx = candidates[c];
+    if (idx < 0 || idx >= lines.length) continue;
+    var probe = lines[idx];
+    if (probe == null) continue;
+    for (var pl = 0; pl < _CISC_LABEL_PATTERNS.length; pl++) {
+      if (_CISC_LABEL_PATTERNS[pl].rx.test(probe)) return _CISC_LABEL_PATTERNS[pl].key;
+    }
+  }
+  return null;
+}
+
 function _extractByStage(text, rec) {
   var headers = _detectStageHeaders(text);
   if (headers.length === 0) return;
@@ -920,9 +980,58 @@ function _extractByStage(text, rec) {
   var headerLineSet = {};
   for (var h = 0; h < headers.length; h++) headerLineSet[headers[h].lineIdx] = true;
 
+  // Per-indicator: which header was used for this indicator's row?
+  // Used after the loop to decide whether to recompute total — only the
+  // header actually consumed by a real indicator row is load-bearing,
+  // not prose descriptions like "EPD scope ... (A1-A3), C1-C4 and D"
+  // that pass _detectStageHeaders' >=3-stage-code threshold.
+  var headerUsedFor = {};
+
   for (var i = 0; i < lines.length; i++) {
     if (headerLineSet[i]) continue;
     var line = lines[i];
+
+    // CISC look-back: data row (1 mt / 1 ton + sci-not) with label on
+    // a separate preceding line. Synthesize a fake "lm" with the
+    // looked-back key so the existing stage-mapping code below applies
+    // unchanged. Only fires when no inline label match would catch the
+    // line (prevents double-processing).
+    var cscKey = _findCISCDataRowKey(lines, i);
+    if (cscKey) {
+      var nums = _tokenizeImpactNumbers(line);
+      if (nums.length === 0) continue;
+      var stages = null;
+      for (var pp = headers.length - 1; pp >= 0; pp--) {
+        if (headers[pp].lineIdx > i) continue;
+        if (headers[pp].stages.length === nums.length) {
+          stages = headers[pp].stages;
+          break;
+        }
+      }
+      if (!stages) {
+        for (var qq = headers.length - 1; qq >= 0; qq--) {
+          if (headers[qq].lineIdx > i) continue;
+          stages = headers[qq].stages;
+          break;
+        }
+      }
+      if (!stages) continue;
+      headerUsedFor[cscKey] = stages;
+      for (var kk = 0; kk < stages.length && kk < nums.length; kk++) {
+        var sst = stages[kk];
+        if (sst === "A1-A3") {
+          if (_get(rec, "impacts." + cscKey + ".total.value") != null) continue;
+          _setPath(rec, "impacts." + cscKey + ".total.value", nums[kk]);
+          _setPath(rec, "impacts." + cscKey + ".total.source", "epd_direct");
+          continue;
+        }
+        if (_get(rec, "impacts." + cscKey + ".by_stage." + sst + ".value") != null) continue;
+        _setPath(rec, "impacts." + cscKey + ".by_stage." + sst + ".value", nums[kk]);
+        _setPath(rec, "impacts." + cscKey + ".by_stage." + sst + ".source", "epd_direct");
+      }
+      continue; // CISC line consumed; move on
+    }
+
     for (var j = 0; j < _BYSTAGE_LABELS.length; j++) {
       var lm = _BYSTAGE_LABELS[j];
       if (!lm.rx.test(line)) continue;
@@ -961,18 +1070,75 @@ function _extractByStage(text, rec) {
       }
       if (!stages) break;
 
-      // Map numbers to stages by position. "A1-A3" is the total slot
-      // (already populated by Tier 8) — skip; the rest map to individual
+      // Record which header is being used for THIS indicator. Used by
+      // the recompute-total block below to decide whether the EPD
+      // published an A1-A3 composite for this indicator (per the actual
+      // table header, not a prose mention elsewhere in the doc).
+      headerUsedFor[lm.key] = stages;
+
+      // Map numbers to stages by position. "A1-A3" is the total slot —
+      // when the EPD publishes a composite column (e.g. CISC's
+      // "A1 A2 A3 A1-A3" header), write that value to total.value
+      // (only if the slot is null — IMPACT_INDICATORS regex still wins
+      // when both sources extract). Other stages map to individual
       // by_stage entries. Stages with no positional value stay null.
       for (var k = 0; k < stages.length && k < nums.length; k++) {
         var st = stages[k];
-        if (st === "A1-A3") continue;
+        if (st === "A1-A3") {
+          if (_get(rec, "impacts." + lm.key + ".total.value") != null) continue;
+          _setPath(rec, "impacts." + lm.key + ".total.value", nums[k]);
+          _setPath(rec, "impacts." + lm.key + ".total.source", "epd_direct");
+          continue;
+        }
         if (_get(rec, "impacts." + lm.key + ".by_stage." + st + ".value") != null) continue;
         _setPath(rec, "impacts." + lm.key + ".by_stage." + st + ".value", nums[k]);
         _setPath(rec, "impacts." + lm.key + ".by_stage." + st + ".source", "epd_direct");
       }
       break; // line matched one indicator; don't try the rest
     }
+  }
+
+  // After by_stage extraction: per-indicator, if the header actually
+  // used for that indicator's row did NOT include the "A1-A3" composite
+  // column AND we have all three stage cells (A1, A2, A3) populated,
+  // recompute total = A1+A2+A3 and mark source: "calculated". This
+  // handles cradle-to-gate-with-options EPDs (xcarb steel) whose
+  // published table has A1 / A2 / A3 / C1-D columns but NO precomputed
+  // A1-A3 composite. The IMPACT_INDICATORS regex would otherwise grab
+  // A1 as the "total" (1230 instead of A1+A2+A3 = ~1257 for xcarb GWP).
+  // Per-indicator gating (via headerUsedFor) prevents prose mentions of
+  // "A1-A3" elsewhere in the doc from inhibiting the recompute.
+  var indicators = [
+    "gwp_kgco2e",
+    "gwp_bio_kgco2e",
+    "ozone_depletion_kgcfc11eq",
+    "acidification_kgso2eq",
+    "eutrophication_kgneq",
+    "smog_kgo3eq",
+    "abiotic_depletion_fossil_mj",
+    "water_consumption_m3",
+    "primary_energy_nonrenewable_mj",
+    "primary_energy_renewable_mj"
+  ];
+  for (var ki = 0; ki < indicators.length; ki++) {
+    var key = indicators[ki];
+    var usedHeader = headerUsedFor[key];
+    if (!usedHeader) continue;
+    var a1 = _get(rec, "impacts." + key + ".by_stage.A1.value");
+    var a2 = _get(rec, "impacts." + key + ".by_stage.A2.value");
+    var a3 = _get(rec, "impacts." + key + ".by_stage.A3.value");
+    if (a1 == null || a2 == null || a3 == null) continue;
+    var hasA1A3InHeader = usedHeader.indexOf("A1-A3") >= 0;
+    var totalAlreadySet = _get(rec, "impacts." + key + ".total.value") != null;
+    // Skip recompute ONLY when the EPD published a composite total
+    // (A1-A3 stage in the actual table header) AND that composite was
+    // captured. Recompute fires when:
+    //   - usedHeader has no A1-A3 (xcarb cradle-to-gate-with-options)
+    //   - usedHeader has A1-A3 but the composite cell wasn't filled
+    //     (CISC water row: 3-value layout under a 4-stage header)
+    if (hasA1A3InHeader && totalAlreadySet) continue;
+    _setPath(rec, "impacts." + key + ".total.value", a1 + a2 + a3);
+    _setPath(rec, "impacts." + key + ".total.source", "calculated");
   }
 }
 

--- a/schema/scripts/test-epd-extract.mjs
+++ b/schema/scripts/test-epd-extract.mjs
@@ -73,12 +73,13 @@ const IMPACT_KEYS = [
 ];
 
 function parseArgs(argv) {
-  const args = { json: null, md: null, only: null };
+  const args = { json: null, md: null, only: null, root: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--json") args.json = argv[++i];
     else if (a === "--md") args.md = argv[++i];
     else if (a === "--only") args.only = argv[++i];
+    else if (a === "--root") args.root = argv[++i];
   }
   return args;
 }
@@ -327,10 +328,19 @@ async function main() {
     materialGroups: mg
   });
 
-  const pdfs = await walkPdfs(SAMPLES_ROOT);
+  // --root <dir> overrides the default 30-sample EPD SAMPLES tree.
+  // Used to point the harness at a larger external sample directory
+  // for scaling tests (workplan §12.6). Resolved against CWD to
+  // accept both absolute paths and paths relative to the user's
+  // current working directory.
+  const sampleRoot = args.root ? resolve(process.cwd(), args.root) : SAMPLES_ROOT;
+  const pdfs = await walkPdfs(sampleRoot);
   if (pdfs.length === 0) {
-    console.error("No PDFs found under:", SAMPLES_ROOT);
+    console.error("No PDFs found under:", sampleRoot);
     process.exit(1);
+  }
+  if (args.root) {
+    console.log(`Using --root ${sampleRoot} (${pdfs.length} PDFs)`);
   }
 
   const results = [];
@@ -416,6 +426,59 @@ async function main() {
       .map(([k, v]) => `${k}=${v}`)
       .join(", ")}`
   );
+
+  // ── Per-format breakdown (workplan §12.5) ───────────
+  // Tabulate metadata + impact + by_stage coverage by detected format.
+  // Surfaces which formats are most under-served — informs the §12.3
+  // architectural choice (geometric vs declarative vs HITL).
+  const formatBreakdown = {};
+  for (const r of ok) {
+    if (!formatBreakdown[r.format]) {
+      formatBreakdown[r.format] = { count: 0, meta: 0, metaMax: 0, impact: 0, impactMax: 0, byStage: 0, byStageMax: 0 };
+    }
+    const fb = formatBreakdown[r.format];
+    fb.count++;
+    fb.meta += r.metaHit;
+    fb.metaMax += METADATA_FIELDS.length;
+    fb.impact += r.impactHit;
+    fb.impactMax += IMPACT_KEYS.length;
+    fb.byStage += r.byStageHit || 0;
+    fb.byStageMax += IMPACT_KEYS.length * ALL_STAGES.length;
+  }
+  console.log("");
+  console.log("Per-format breakdown:");
+  for (const fmt of Object.keys(formatBreakdown).sort()) {
+    const fb = formatBreakdown[fmt];
+    const mPct = ((100 * fb.meta) / fb.metaMax).toFixed(1);
+    const iPct = ((100 * fb.impact) / fb.impactMax).toFixed(1);
+    const bPct = ((100 * fb.byStage) / fb.byStageMax).toFixed(1);
+    console.log(`  ${fmt.padEnd(20)} n=${fb.count.toString().padStart(3)}  meta=${mPct}%  impact=${iPct}%  by_stage=${bPct}%`);
+  }
+
+  // ── Per-parameter aggregate hit-rate (workplan §12.5) ───
+  // Surfaces which schema fields have systemic gaps vs sample-
+  // idiosyncratic gaps. A field with low hit-rate across many formats
+  // suggests a generalization opportunity; low hit-rate concentrated
+  // in one format suggests a per-format extractor needs work (or the
+  // EPD genuinely doesn't publish that field).
+  const paramHits = {};
+  for (const f of METADATA_FIELDS) paramHits[f] = 0;
+  for (const k of IMPACT_KEYS) paramHits["impacts." + k + ".total.value"] = 0;
+  for (const r of ok) {
+    for (const f of METADATA_FIELDS) {
+      if (r.meta[f] != null) paramHits[f]++;
+    }
+    for (const k of IMPACT_KEYS) {
+      if (r.impacts[k] != null) paramHits["impacts." + k + ".total.value"]++;
+    }
+  }
+  console.log("");
+  console.log("Per-parameter aggregate hit-rate (across", ok.length, "samples):");
+  const sortedParams = Object.entries(paramHits).sort((a, b) => b[1] - a[1]);
+  for (const [path, hits] of sortedParams) {
+    const pct = ((100 * hits) / ok.length).toFixed(0);
+    console.log(`  ${path.padEnd(50)} ${hits.toString().padStart(3)}/${ok.length}  (${pct}%)`);
+  }
 
   // ── Ground-truth aggregate (workplan §10.3) ─────────
   const annotated = ok.filter((r) => r.expected);


### PR DESCRIPTION
## Summary

- Andy paused mid-implementation of CISC + 2023 BC Wood ASTM per-format extractors with the directive: *"You seem to be in a loop making highly customized readers for a handful of specific EPDs where we need GENERALIZED functionality for ANY EPD the Parser loads."* This PR captures the pause, sets up scaling-test infrastructure, integrates Mélanie's answers on biogenic-calc, and ships one behavioural fix (CISC compact-label extraction) that's also flagged for revisit per the new §12.
- New workplan **§12 Architecture review** documents three options on the table (geometric / declarative / HITL / hybrid) with 5 questions for Andy to resolve before any further per-format extractor work.
- New workplan **§11.8/9/10** integrates Mélanie's 6 answers on biogenic-calc — C-fb6 scope grew from ~3 hrs to ~19 hrs across 7 sub-commits (Material Content table, Phyllis 2 lookup, biogenic inventory, etc.). 6 remaining items for Monday's review with Mélanie.
- Harness `--root <dir>` flag + per-format breakdown + per-parameter aggregate hit-rate — ready for tomorrow's larger sample directory.

## Commits (3 on `EPD-PARSER-4`)

| SHA | Scope |
|---|---|
| `3839b47` | Cradle-to-gate-with-options total recompute (xcarb) + CISC compact-label per-stage extraction. CISC portion is per-format and **flagged in §12.2 as candidate for deprecation** depending on §12.3 architecture choice. |
| `394cbea` | Workplan §12 architecture review chapter (3 options + 5 questions for Andy) + harness `--root` flag + per-format breakdown + per-parameter aggregate hit-rate audit. NO new format-specific extractors. |
| `d73cffe` | Workplan §11 Mélanie's answers integrated. Revised commit plan (§11.9: 7 sub-commits, ~19 hrs). 6 items for Monday review with Mélanie (§11.10). NO code changes. |

## Coverage delta vs PR #17 baseline

| Dimension | PR #17 baseline | This PR |
|---|---|---|
| Metadata | 279/420 (66.4%) | 279/420 (66.4%) — unchanged |
| Impact totals | 162/300 (54.0%) | **180/300 (60.0%)** — +18 from xcarb total recompute (calculated from A1+A2+A3) |
| Per-stage cells | 473/5100 (9.3%) | **494/5100 (9.7%)** — +21 from CISC main indicators + water |
| Ground-truth annotated | 2/30 samples (110 keys) | 2/30 samples (116 keys — xcarb ground truth extended with 6 computed totals) |
| Ground-truth failures | 0 / 0 / 0 | 0 / 0 / 0 |

## Two compound-gating decision points

1. **§11.10** — Monday review with Mélanie on 6 items: schema-field locations, storage_cycle enum values, Phyllis 2 curation, material-content extraction architecture, legacy 821 migration, validation tolerance. Gates C-fb6 implementation.
2. **§12.3 / §12.4** — Andy's choice between Option A (geometric table extraction) / Option B (declarative format library) / Option C (HITL form-pane UX) / hybrid. Gates further per-format extractor work AND the new C-fb6 sub-commits that need material-content + biogenic-inventory table extraction.

## Test plan

- [ ] Harness re-runs cleanly: `node schema/scripts/test-epd-extract.mjs` final summary should read `Samples processed: 30 / 30`, `Metadata coverage: 279 / 420 (66.4%)`, `Impact coverage: 180 / 300 (60.0%)`, `By-stage coverage: 494 / 5100 (9.7%)`, `Ground-truth checks: 2 samples annotated, 0 / 0 / 0 failures`.
- [ ] `--root <dir>` flag works: pass any directory of PDFs and the harness runs against it. Useful for tomorrow's larger sample directory without copying PDFs into the repo.
- [ ] xcarb cold-formed total values are now computed: GWP=1257 (=A1+A2+A3=1230+11.7+15.3) with `source: "calculated"` (was 1230 = A1 only with `source: "epd_direct"`).
- [ ] CISC main indicators + water now extract per-stage. Verify GWP A1=1020 (1.02E+03), water total=9.197 (= A1+A2+A3 from `1 mt 6.27 0.0469 2.88`).
- [ ] No regression on Kalesnikoff GLT (still 14/14 metadata + 10/10 impacts + 30/170 by_stage, GT=✓).
- [ ] Pages-deployed landing page's "EPD-Parser workplan" link resolves to the §11 (with Mélanie's answers) + §12 (architecture review) once this is merged.

## What's deliberately NOT in this PR

- No new per-format extractors (the §12 pause directive).
- No C-fb6 implementation (gated on §11.10 Monday review + §12.3 architecture choice).
- No deprecation of the existing per-format patterns (waiting for §12.3 to land before pruning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
