### PR TITLE
EPD-Parser: density-units fix, metadata field-tuning, CCLIMB scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ data/beam/
 *.docx
 *.xlsx
 *.xls
+
+# Large external EPD sample sets — local only, never committed (BfCA-shared
+# binary dumps). Explicit folder ignore catches .jpg / uppercase .PDF that
+# the extension rules miss.
+docs/PDF References/EPD SAMPLES/BEAM 639 Rows/
+docs/PDF References/EPD-scaling-sets/

--- a/bfcastyles.css
+++ b/bfcastyles.css
@@ -6067,3 +6067,306 @@ details.dep-details pre {
 .app-epdparser .epd-open-db-link:hover {
   text-decoration: underline;
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════ */
+/* §12  APP: CCLIMB — Time-explicit climate response (parallel coords)          */
+/* ═══════════════════════════════════════════════════════════════════════════ */
+/*
+ * Phase 0 — scaffolding. P1 will harmonize palette + per-component shading
+ * + axis banding once the OBJECTIVE parallel-coords source has been ported.
+ *
+ * Visual identity: shares the BfCA dark-theme palette; RT = red (#dc3545,
+ * matches OBJECTIVE convention); PT = blue (#007bff, same convention).
+ * Per-component lines: PT lines use opacity-stack shading; RT lines are
+ * solid red strokes.
+ */
+
+html.app-cclimb {
+  --rt-color: #dc3545;
+  --pt-color: #007bff;
+  --pt-shade: rgba(0, 123, 255, 0.18);
+}
+
+.app-cclimb body {
+  background: var(--bg-base, #1e1e1e);
+  color: var(--text-base, #ddd);
+  margin: 0;
+  font-family: var(--font-body, Helvetica Neue, Arial, sans-serif);
+}
+
+.app-cclimb #cclimb-app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-cclimb .cclimb-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 24px;
+  background: var(--bg-elevated, #252525);
+  border-bottom: 1px solid var(--border-dim, #333);
+}
+
+.app-cclimb .header-logo {
+  height: 32px;
+}
+
+.app-cclimb .cclimb-title-block {
+  flex: 0 0 auto;
+}
+
+.app-cclimb .cclimb-title {
+  font-family: Georgia, serif;
+  font-size: 22px;
+  font-weight: normal;
+  margin: 0;
+}
+
+.app-cclimb .cclimb-subtitle {
+  display: block;
+  font-size: 12px;
+  color: var(--text-dim, #999);
+  margin-top: 2px;
+}
+
+.app-cclimb .cclimb-subtitle a {
+  color: var(--text-dim, #999);
+  text-decoration: underline;
+}
+
+.app-cclimb .cclimb-spacer {
+  flex: 1;
+}
+
+.app-cclimb .cclimb-nav {
+  display: flex;
+  gap: 4px;
+}
+
+.app-cclimb .cclimb-nav .nav-btn {
+  padding: 6px 14px;
+  color: var(--text-dim, #999);
+  text-decoration: none;
+  border: 1px solid var(--border-dim, #333);
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.app-cclimb .cclimb-nav .nav-btn:hover {
+  background: var(--bg-hover, #2a2a2a);
+  color: var(--text-base, #ddd);
+}
+
+.app-cclimb .cclimb-nav .nav-btn.active {
+  background: var(--accent-green, #2a5c3f);
+  color: #fff;
+  border-color: var(--accent-green, #2a5c3f);
+}
+
+.app-cclimb .cclimb-status-bar {
+  padding: 10px 24px;
+  background: var(--bg-warn, rgba(255, 165, 0, 0.08));
+  border-bottom: 1px solid var(--border-dim, #333);
+  font-size: 13px;
+  color: var(--text-base, #ddd);
+}
+
+.app-cclimb .cclimb-status-bar code {
+  background: rgba(0, 0, 0, 0.4);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.app-cclimb .cclimb-status-bar a {
+  color: var(--accent-green-light, #7bbf94);
+}
+
+.app-cclimb .cclimb-main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 420px 1fr;
+  gap: 0;
+}
+
+.app-cclimb .cclimb-form-pane {
+  padding: 20px;
+  background: var(--bg-elevated, #252525);
+  border-right: 1px solid var(--border-dim, #333);
+  overflow-y: auto;
+}
+
+.app-cclimb .cclimb-section-heading {
+  font-family: Georgia, serif;
+  font-size: 14px;
+  font-weight: normal;
+  margin: 18px 0 8px;
+  color: var(--text-dim, #999);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.app-cclimb .cclimb-section-heading:first-child {
+  margin-top: 0;
+}
+
+.app-cclimb .cclimb-form-row {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.app-cclimb .cclimb-form-label {
+  font-size: 12px;
+  color: var(--text-dim, #999);
+}
+
+.app-cclimb .cclimb-form-row input,
+.app-cclimb .cclimb-form-row select {
+  background: var(--bg-base, #1e1e1e);
+  color: var(--text-base, #ddd);
+  border: 1px solid var(--border-dim, #333);
+  border-radius: 3px;
+  padding: 6px 8px;
+  font-size: 13px;
+  font-family: Courier New, monospace;
+}
+
+.app-cclimb .cclimb-compute-btn {
+  margin-top: 24px;
+  width: 100%;
+  padding: 10px;
+  background: var(--accent-green, #2a5c3f);
+  color: #fff;
+  border: 0;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  opacity: 0.5;
+}
+
+.app-cclimb .cclimb-compute-btn:disabled {
+  cursor: not-allowed;
+}
+
+.app-cclimb .cclimb-chart-pane {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  overflow: hidden;
+}
+
+.app-cclimb .cclimb-pcg-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-dim, #333);
+}
+
+.app-cclimb .cclimb-pcg-btn {
+  padding: 6px 12px;
+  background: var(--bg-elevated, #252525);
+  color: var(--text-base, #ddd);
+  border: 1px solid var(--border-dim, #333);
+  border-radius: 3px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.app-cclimb .cclimb-pcg-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.app-cclimb .cclimb-btn-decarb {
+  background: var(--accent-green, #2a5c3f);
+  color: #fff;
+  border-color: var(--accent-green, #2a5c3f);
+}
+
+.app-cclimb .cclimb-pcg-legend {
+  margin-left: auto;
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--text-dim, #999);
+}
+
+.app-cclimb .cclimb-pcg-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.app-cclimb .cclimb-pcg-swatch {
+  width: 16px;
+  height: 3px;
+  border-radius: 2px;
+}
+
+.app-cclimb .cclimb-pcg-swatch-rt {
+  background: var(--rt-color);
+}
+
+.app-cclimb .cclimb-pcg-swatch-pt {
+  background: var(--pt-color);
+  box-shadow: 0 6px 0 -3px var(--pt-shade);
+}
+
+.app-cclimb .parallel-coordinates-container {
+  flex: 1;
+  min-height: 400px;
+  background: var(--bg-base, #1e1e1e);
+  border: 1px dashed var(--border-dim, #333);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-cclimb .cclimb-pcg-placeholder {
+  text-align: center;
+  color: var(--text-dim, #999);
+  font-size: 13px;
+  padding: 20px;
+}
+
+.app-cclimb .cclimb-pcg-placeholder p {
+  margin: 6px 0;
+}
+
+.app-cclimb .cclimb-pcg-placeholder code {
+  background: rgba(0, 0, 0, 0.4);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.app-cclimb .cclimb-summary-table {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-dim, #333);
+  font-size: 12px;
+  color: var(--text-dim, #999);
+}
+
+.app-cclimb .cclimb-footer {
+  padding: 8px 24px;
+  background: var(--bg-elevated, #252525);
+  border-top: 1px solid var(--border-dim, #333);
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-dim, #999);
+}
+
+.app-cclimb .cclimb-footer a {
+  color: var(--text-dim, #999);
+  text-decoration: underline;
+}

--- a/cclimb.html
+++ b/cclimb.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en" class="theme-dark app-cclimb">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CCLIMB — Time-Explicit Climate Response (BfCA)</title>
+    <link rel="icon" type="image/png" href="graphics/BFCA-LOGO-sm.png" />
+    <meta
+      name="description"
+      content="CCLIMB — Carbon & Climate Impact Model for Materials and Buildings. Time-explicit dynamic-LCA interpretation comparing project trajectory (PT) to reference trajectory (RT) via parallel-coordinates visualization across EN 15804+A2 life-cycle modules."
+    />
+
+    <!-- CSS: consolidated bfcastyles.css holds shared + per-app rules scoped by html class. -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+    <link rel="stylesheet" href="bfcastyles.css" />
+
+    <!-- D3 — parallel coordinates rendering. Ported from OBJECTIVE module 18. -->
+    <script src="https://d3js.org/d3.v7.min.js" defer></script>
+  </head>
+  <body>
+    <div id="cclimb-app">
+      <!-- ── Header ───────────────────────────────────────── -->
+      <header class="site-header cclimb-header">
+        <img src="graphics/BFCA-LOGO-sm.png" alt="BfCA" class="header-logo" />
+        <div class="cclimb-title-block">
+          <h1 class="cclimb-title">
+            CCLIMB
+            <span style="font-size: 12px; font-weight: normal; color: var(--text-dim)"
+              >· Carbon &amp; Climate Impact Model — time-explicit climate response for carbon-storing building products</span
+            >
+          </h1>
+          <span class="cclimb-subtitle"
+            >Compares project trajectory (PT) to reference trajectory (RT) across EN 15804+A2 life-cycle modules · methodology
+            <a href="docs/RMI%20Work/CCLIMB-Workplan.md">CCLIMB-Workplan.md</a></span
+          >
+        </div>
+        <div class="cclimb-spacer"></div>
+        <nav class="cclimb-nav">
+          <a href="index.html" class="nav-btn" target="_blank" rel="noopener" title="App directory / home">Home</a>
+          <a href="pdfparser.html" class="nav-btn" target="_blank" rel="noopener" title="PDF takeoff + area extraction"
+            >PDF-Parser</a
+          >
+          <a href="matrix.html" class="nav-btn" target="_blank" rel="noopener" title="EC compliance matrix">Matrix</a>
+          <a href="database.html" class="nav-btn" target="_blank" rel="noopener" title="BfCA material catalogue"
+            >Database</a
+          >
+          <a href="beamweb.html" class="nav-btn" target="_blank" rel="noopener" title="Embodied carbon calculator">BEAM</a>
+          <a href="cclimb.html" class="nav-btn active" aria-current="page" title="Current app">CCLIMB</a>
+        </nav>
+      </header>
+
+      <!-- ── Status / placeholder banner ─────────────────── -->
+      <div class="cclimb-status-bar">
+        <div class="cclimb-status-text">
+          <strong>Phase 0 — scaffolding.</strong> Parallel-coordinates source ported from OBJECTIVE module 18 (reference at
+          <code>js/cclimb/parallel-coordinates.objective-source.js</code>). Climate-model + RT engines stubbed pending P1.
+          Methodology: <a href="docs/RMI%20Work/CCLIMB-Workplan.md">CCLIMB-Workplan.md</a> · Implementation:
+          <a href="docs/RMI%20Work/CCLIMB-Workplan2.md">CCLIMB-Workplan2.md</a>
+        </div>
+      </div>
+
+      <!-- ── Main split: form pane (left) + chart (right) ─ -->
+      <main class="cclimb-main">
+        <!-- Form pane: feedstock category, RT selector, lifespan, EOL mix -->
+        <aside id="cclimb-form-pane" class="cclimb-form-pane">
+          <h3 class="cclimb-section-heading">Product</h3>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Display name</label>
+            <input type="text" id="cclimb-display-name" placeholder="e.g. Glulam beam" />
+          </div>
+
+          <h3 class="cclimb-section-heading">Inventory (carbon flows, kgCO₂e)</h3>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">A1 — feedstock carbon</label>
+            <input type="number" id="cclimb-a1" placeholder="-1000" />
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">A3 — manufacturing</label>
+            <input type="number" id="cclimb-a3" placeholder="50" />
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">A5 — install-waste</label>
+            <input type="number" id="cclimb-a5" placeholder="15" />
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">C4 — end-of-life</label>
+            <input type="number" id="cclimb-c4" placeholder="1000" />
+          </div>
+
+          <h3 class="cclimb-section-heading">Methodology</h3>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Feedstock category</label>
+            <select id="cclimb-feedstock-cat">
+              <option value="A">A — Residues / waste streams</option>
+              <option value="B">B — Short-rotation crops</option>
+              <option value="C">C — Perennial regenerative (bamboo, coppice)</option>
+              <option value="D" disabled>D — Harvest without depletion (cork, rubber) — v2</option>
+              <option value="E">E — Engineered atmospheric uptake</option>
+            </select>
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Reference trajectory</label>
+            <select id="cclimb-rt-type">
+              <option value="RT-A-1">RT-A: −1/+1 default</option>
+              <option value="RT-A-5">RT-A: −5/+5 default</option>
+              <option value="RT-B">RT-B: custom (growth / decay yr)</option>
+            </select>
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Lifespan (years)</label>
+            <input type="number" id="cclimb-lifespan" placeholder="75" />
+          </div>
+
+          <h3 class="cclimb-section-heading">End-of-life mix</h3>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Incineration %</label>
+            <input type="number" id="cclimb-eol-inc" placeholder="10" min="0" max="100" />
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Landfill %</label>
+            <input type="number" id="cclimb-eol-lf" placeholder="60" min="0" max="100" />
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Recycle %</label>
+            <input type="number" id="cclimb-eol-rec" placeholder="20" min="0" max="100" />
+          </div>
+          <div class="cclimb-form-row">
+            <label class="cclimb-form-label">Reuse %</label>
+            <input type="number" id="cclimb-eol-reuse" placeholder="10" min="0" max="100" />
+          </div>
+
+          <button class="cclimb-compute-btn" id="cclimb-compute" disabled>Run climate calc · P1</button>
+        </aside>
+
+        <!-- Chart pane: parallel coordinates RT vs PT, per-component stratification -->
+        <section id="cclimb-chart-pane" class="cclimb-chart-pane">
+          <div id="cclimb-pcg-controls" class="cclimb-pcg-controls">
+            <button class="cclimb-pcg-btn" id="cclimb-refresh" disabled>Refresh</button>
+            <button class="cclimb-pcg-btn" id="cclimb-restore-baseline" disabled>Restore Baseline</button>
+            <button class="cclimb-pcg-btn cclimb-btn-decarb" id="cclimb-decarbonize" disabled>Decarbonize EOL</button>
+            <span class="cclimb-pcg-legend">
+              <span class="cclimb-pcg-legend-item">
+                <span class="cclimb-pcg-swatch cclimb-pcg-swatch-rt"></span>RT — Reference Trajectory
+              </span>
+              <span class="cclimb-pcg-legend-item">
+                <span class="cclimb-pcg-swatch cclimb-pcg-swatch-pt"></span>PT — Project Trajectory
+              </span>
+            </span>
+          </div>
+
+          <div id="cclimb-pcg-container" class="parallel-coordinates-container">
+            <!-- D3 PCG renders here. Empty until P1. -->
+            <div class="cclimb-pcg-placeholder">
+              <p><strong>Parallel-coordinates chart</strong></p>
+              <p>
+                Axes: A1 · A2 · A3 · A4 · A5 · B1 · B2 · B3 · B4 · B5 · B6 · B7 · C1 · C2 · C3 · C4 · D · ΔCRF(100) · ΔT(100) · C(100)
+              </p>
+              <p>Red lines: Reference Trajectory per material component. Blue lines (shaded): Project Trajectory per component.</p>
+              <p>Source ported from <code>OBJECTIVE/src/core/ParallelCoordinates.js</code>. Adaptation in progress.</p>
+            </div>
+          </div>
+
+          <div id="cclimb-summary-table" class="cclimb-summary-table">
+            <!-- Per-component sub-totals + building-level total in °C·year. P1. -->
+          </div>
+        </section>
+      </main>
+
+      <!-- ── Footer ──────────────────────────────────────── -->
+      <footer class="cclimb-footer">
+        <span>CCLIMB · scaffolding · 2026-05-19</span>
+        <span class="cclimb-footer-note">
+          Methodology: <a href="docs/RMI%20Work/CCLIMB-Workplan.md">CCLIMB-Workplan.md</a> · Implementation:
+          <a href="docs/RMI%20Work/CCLIMB-Workplan2.md">CCLIMB-Workplan2.md</a>
+        </span>
+      </footer>
+    </div>
+
+    <!-- ES-module entry point. Loads form bindings, climate model, parallel-coords widget. -->
+    <script type="module" src="js/cclimb.mjs"></script>
+  </body>
+</html>

--- a/docs/RMI Work/CCLIMB-Workplan.md
+++ b/docs/RMI Work/CCLIMB-Workplan.md
@@ -1,0 +1,546 @@
+Carbon & Climate Impact Model for Materials and Buildings (C-CLIMB)
+Methodology for Time-Explicit Climate Interpretation of Carbon Storage and Release from Building Products
+Draft for Working Group Review
+Carbon & Climate Impact Model for Materials and Buildings (C-CLIMB)	1
+1: Orientation	2
+1.1. Rationale	2
+1.2. Scope and Application	5
+2: Methodology Overview	7
+2.1 How This Methodology Works	7
+2.2 Inputs overview	8
+2.3 Outputs overview	8
+2.4 Interpretation overview	9
+3. Inputs	9
+3.1 Inventory Requirements	9
+3.2. Feedstock Categorization Framework	10
+4. Modeling Logic	12
+4.1 Climate Interpretation – Reference Trajectory	12
+4.1.1. Standardized Reference Trajectory Archetypes	13
+4.2 Climate Interpretation – Radiative Forcing, Temperature Change, and Completeness	14
+5. Reporting of results	16
+Critical Note (must accompany table)	17
+6. Minimum Requirements for Climate Calculation Engines	18
+6.1 Scope and Role of the Calculator	18
+6.2 Scientific Basis	18
+6.3 Climate System Parameters	19
+6.4 Gas Coverage	19
+6.5 Input Requirements	19
+6.6 Temporal Treatment	19
+6.7 Output Requirements	20
+6.8 Transparency and Documentation	20
+6.9 Consistency and Completeness	20
+6.10 Scenario Treatment	21
+Section 7. Implementation Guidelines	22
+7.1 Worked Examples	22
+Section 8. Boundaries and Transparency	23
+8.1 Limitations and Assumptions	23
+Section 9. Reference Material	24
+9.1. Definitions	24
+9.2 Appendices	24
+Use in PCRs and EPDs	25
+Appendix	30
+Draft Reference Trajectories for Tier 2	32
+5.2 Tiered Approach for Category D	32
+
+
+1: Orientation[1.1]
+1.1. Rationale
+What is the climate impact of using long-lived, carbon-storing products in the built environment? Even though storing carbon in buildings has the potential to create a significant new, gigatonne-sized planetary carbon sink ,  and provide a major climate mitigation opportunity, this question has not yet been answered in a consistent, consensus-based manner. As a result, the sector has seen divergent claims — ranging from assertions that durable carbon storage is climate-neutral to arguments that it delivers significant mitigation benefits. The methodology presented here applies climate science to clarify this question, not to presume that the mere presence of carbon storage in buildings is inherently beneficial or detrimental to our climate trajectory, but to identify the conditions under which either outcome occurs and to illuminate the product and building characteristics with the strongest climate impact.
+Life cycle assessment (LCA) has become the default approach for measuring the embodied carbon emissions of building products and buildings. The global warming potential (GWP) results for products and buildings are expressed in kilograms of carbon dioxide equivalent (CO2e) over a 100-year period and are the key reporting metric for most embodied carbon standards, incentives and policies.
+Embedded in current LCA standards is the reporting of “negative emissions” for atmospheric carbon uptake during feedstock growth and/or product manufacturing. However, the prevailing –1/+1 approach treats all biogenic carbon removals at the beginning of the life cycle as fully balanced by emissions at end-of-life, without regard to the timing of either flow. This convention preserves carbon mass balance at the inventory level but does not interpret how the timing of removals and emissions affects atmospheric carbon concentrations or related climate impacts such as radiative forcing and temperature change.
+Current LCA standards do not provide a mechanism for interpreting the climate significance of carbon stored in products or buildings over time. By collapsing uptake and release into a single accounting balance, the –1/+1 approach obscures the potential climate value of delayed emissions.
+This simplified treatment contrasts with climate science literature demonstrating that carbon stored for a limited duration can influence peak temperature and cumulative radiative forcing, even if storage is not permanent. Temporary storage alters the atmospheric trajectory of carbon relative to a reference trajectory in which emissions occur earlier. Such temporary storage contributes to climate mitigation at large spatial and temporal scales, because any carbon kept out of the atmosphere for a period contributes to reduced warming during that time. 
+The IPCC acknowledges that this type of “CDR [carbon dioxide removal] is required to achieve global and national targets of net zero CO₂ and greenhouse gas (GHG) emissions… and is part of all modelled scenarios that limit global warming to 2°C or lower by 2100.”  While the IPCC does not prescribe accounting methods for building products, its findings establish that atmospheric removals — including those stored in terrestrial and product reservoirs — play a necessary role in mitigation pathways consistent with temperature targets.
+The Greenhouse Gas Protocol’s Land Sector and Removals Standard (a supplement to the GHG Protocol Corporate Standard and Scope 3 Standard) similarly recognizes that “Products that contain biogenic or TCDR-based carbon can keep carbon out of the atmosphere for the duration of the product's lifetime. Therefore, maintaining storage in product carbon pools and preventing its release can help to reduce GHG emissions, depending on the product’s durability and end-of-life fate.” 
+Dynamic LCA (dLCA) introduces temporal variation into both inventory modeling and impact characterization. Its core insight is that the timing of emissions influences atmospheric concentration pathways and therefore climate impact. However, existing dynamic LCA approaches to measuring carbon storage in building products and buildings vary in scope, assumptions, and treatment of system boundaries, and no single method has achieved consensus adoption or widespread use. These approaches currently require bespoke calculations that are outside of current industry norms and not in clear alignment with accepted LCA standards  and practices.
+The absence of a user-friendly, market-aligned method to dynamically account for and demonstrate the potential climate benefits of carbon stored in buildings hinders product development, industry demand, recognition in green building certification programs, and creation of strong signals from regulators. This slows the development of the carbon-storing building product sector at a time when its benefits could prove critical to meeting broader climate goals.
+The Carbon & Climate Impact Model for Materials and Buildings (CCLIMB) methodology provides a broadly applicable and user-friendly method for defining and calculating the climate benefit of carbon storing products and buildings over time. It aligns with leading approaches to dLCA and has been developed in collaboration with a cohort of industry participants. The methodology focus is identifying and quantifying key temporal aspects of flows of stored carbon, including feedstock characterization, manufacturing and installation, product lifespan, and end-of-life considerations. This approach is not intended to replace conventional LCA but to overlay a time-explicit climate interpretation onto inventory-defined carbon flows and more precisely models product and location-dependent end-of-life scenarios.
+This methodology will help users understand how the inclusion of carbon-storing products in buildings affects the climate over time, by comparing the timing of carbon removals and emissions under clearly defined reference trajectories and providing time-explicit changes to radiative forcing and temperature to enable users to clearly demonstrate the climate impact of products and buildings that store significant amounts of carbon over their intended lifespans.
+By advancing a standardized dynamic LCA method applicable across building LCAs performed under various standards, this work aims to provide clarity, consistency, and rigor to claims regarding biogenic carbon storage in products and buildings. This will support more informed product development, policy, design, and investment decisions in alignment with regional, national and international climate goals.
+1.2. Scope and Application
+The CCLIMB methodology is intended to demonstrate the climate impact of products and buildings that store significant amounts of carbon over their intended lifespans by modeling the timing of carbon removals and emissions and the resulting climate responses: time-dependent impacts to radiative forcing and temperature. These insights are intended to inform the decision-making of a range of building sector stakeholders, including but not limited to:
+	LCA practitioners
+	Product manufacturers
+	Building designers & specifiers
+	Building owners 
+	Carbon reporting & standards regulators
+	Policy analysts
+CCLIMB can be applied to carbon storage in individual products for which a verified LCA or EPD have been produced and buildings containing carbon storing products for which a completed whole building life cycle assessment (WBLCA) exists. 
+Carbon that is present in a biogenic feedstock and/or intentionally incorporated into a product during manufacturing or construction and is quantifiable at the time of installation is considered in scope (referenced as ‘carbon flows’). Gradual atmospheric uptake occurring during the service life of the product/building (e.g., ambient carbonation of concrete) is excluded.
+CCLIMB is not intended to provide dynamic interpretation of non-carbon emissions (such as N2[2.1]O, CFCs, HFCs) from LCAs, EPDs or WBLCAs.
+CCLIMB is not intended to certify products or buildings, perform forestry or agricultural carbon accounting or issue carbon credits.
+ 
+2: Methodology Overview
+2.1 How This Methodology Works
+ Step 1: 
+Collect and input relevant LCA/EPD data (all carbon flows into and out of the product system, including A1, A3, A5 and C4, as per Section 3.
+Note: All flows in B4 may be captured as A and C flows for the replacement product at the appropriate year.
+Step 2:
+Identify the feedstock category(s) for each product as per Section 4. This will associate a default reference trajectory for each feedstock.
+Step 3:
+Identify the Reference Trajectory for each feedstock category(s) as per Section 5.
+Step 4:
+Enter all CO2 withdrawals and emissions in the appropriate year of occurrence into an approved dLCA calculator as per Section 6.
+Note: C-module defaults will be available for dLCA calculator.
+Step 5:
+Run simulation in dLCA calculator and generate results for the complete reference timeline as per Section 8.
+Step 6:
+Create report, including required outputs and any custom outputs as per Section 8.
+2.2 Inputs overview
+Inputs from LCA and EPD: The first step to calculating C-CLIMB is to gather product data from LCAs, EPDs, and/or WBLCAs. This data includes the carbon removals and emissions associated with the product throughout its life cycle, to inform climate interpretation formulas used in the methodology. See section 3.1 for full details of EPD/LCA inventory requirements.
+Feedstock characterization: In addition to gathering product-specific carbon flow data, the carbon-bearing feedstocks in the product must be categorized by typology. Typologies are determined by whether the carbon-bearing feedstock, when processed for product development, changes the timing of atmospheric carbon exchange (Tier 1), or changes the trajectory of an existing carbon stock (Tier 2). The type of climate interpretation calculations performed are reliant on this categorization. See section 3.2 for full details on feedstock categorization and sub-categories for support in identifying appropriate categories.
+Reference trajectories: To accurately assess climate interpretation, the alternative pathway of the carbon-based feedstocks must be determined. This alternative pathway, known as the reference trajectory, defines the carbon flow (delay and emissions) that would have happened if the product(s) were not developed. Comparing the reference trajectory to the product trajectory illuminates the carbon flow and resulting climate impacts that are present due solely to the product(s). 
+Where feedstock delay (e.g. growth) and decay information is known, CCLIMB users may refer to Reference Trajectory B (RT-B), to input specific delay and decay information. Otherwise, the default reference trajectory (RT-A) may be used, inferring feedstocks within Tier 1 to be within a default delay and decay rate timescale. 
+See section 4.1 and 4.2 for full details on reference trajectory computations.
+2.3 Outputs overview
+After inputting relevant carbon flow data across the lifecycle of a product or building, computations are performed [3.1]to determine time-dependent climate impacts from changes to carbon flows associated with the product(s).
+Climate interpretation metrics: The climate impacts of product and building carbon trajectories over time are determined by calculating the change in temperature and change in radiative forcing from the product development, using the reference trajectory as a baseline comparison. See section 4.4 for full details on temperature and radiative forcing metric formulas.
+Completeness: In order to accurately show the full scope of climate impact across time, a completeness metric is derived to be reported alongside any time-specific climate impact metrics. See section 4.4 for full details on completeness metric computation.
+2.4 Interpretation overview
+The time-dependent climate response data reported from CCLIMB includes changes to radiative forcing and temperature. Climate response data must be reported with transparency into the completeness of the data in relation to time. Results may be reported in graph or table form. Radiative forcing response results at 100 years may be compared to GWP100-based reporting. See section 5 for full details on reporting and interpretation of time-dependent climate response. 
+3. Inputs
+3.1 Inventory Requirements[4.1]
+Module-specific carbon flows are required for calculating climate impacts, sourced from product LCAs, Environmental Product Declarations (EPDs), and/or WBLCAs, as per Table XX . Data source(s) shall be declared according to the provisions of Section [reporting specifications section]. 
+CCLIMB interprets carbon removals and emissions as physical events defined by:
+	The life-cycle module in which they occur (LCA/EPD modules A1, A3, A5, C4),
+	The quantity of carbon involved (converted to CO₂ equivalent),
+	The associated end-of-life pathway(s) (reuse, decay, disposal, combustion).
+CCLIMB calculations shall define Year 0 as the actual or intended year of product installation or building construction. All removals and emissions occurring in product modules (A1-3) are modeled as occurring prior to Year 0 and those occurring in the construction, use and end-of-life modules are modeled as occurring in relation to Year 0 (e.g. A product with a declared lifespan of 35 years shall be modeled as reaching end-of-life at Year 35).
+Table XX: Inventory sources
+Inventory Source	LCA module/Year
+LCA/EPD modules	A1 
+Carbon removal (GWPbiogenic or product carbon content)	A3
+Emissions from feedstock / processing waste 	Year 
+
+0	A5
+Emissions from construction waste	B4
+Replacement year	C4
+EoL year, Carbon emission from end of life
+Additional factors from CCLIMB	Feedstock category & Reference trajectory (defaults or custom)			Disposal pathway calculations (defaults or custom)	Repeat A-C modules for timeframe of study	EoL pathway calculations (defaults or custom)
+
+3.2. Feedstock Categorization Framework
+This section defines the classification of carbon-bearing feedstocks used in building products to distinguish between different physical mechanisms governing climate impact (e.g. changes to radiative forcing or temperature) and provide clear guidance on when counterfactual modeling is required.
+This classification only applies to the carbon-bearing feedstock component(s) of a product, not the full product or its non-carbon constituents.
+Feedstocks shall be classified into one of two primary tiers based on their governing climate mechanism: whether the use of the feedstock changes the timing of atmospheric carbon exchange (Tier 1) or alters a standing carbon stock trajectory (Tier 2). These two mechanisms are physically distinct and require different interpretive approaches. 
+Tier 1 — Timing-Driven Systems[5.1][5.2][5.3]
+Timing-driven systems are feedstocks for which climate impact is governed primarily by timing effects rather than changes in standing carbon stocks. For these feedstocks, carbon is part of a short-cycle system or a previously mobilized carbon flow within the technosphere or biosphere, the reference trajectory returns carbon to the atmosphere in the near term, and use of the feedstock does not alter a persistent carbon stock trajectory.
+For Tier 1 feedstocks, climate impact is governed by:
+ΔRF(t) = RF_reference(t) − RF_project(t)
+Where: 
+RF is instantaneous radiative forcing[6.1][6.2]
+t is time
+This includes delayed emissions, and/or atmospheric removal followed by storage and eventual release.
+Tier 1 Sub-Categories [7.1]
+Feedstock sub-categories are intended to provide transparency and interpretive clarity. They do not alter the computational method.
+Sub-category	System	Reference Trajectory
+A — Waste / Secondary Feedstocks 	Carbon circulating within technosphere (e.g. recycled paper, demolition wood)	Near-term emission (decay, incineration)
+B — Short-Rotation By-products and Residues	Agricultural by-products (e.g. straw, hulls, shells)	Near-term emission within annual cycle
+C — Perennial Regrowth Systems	Rapidly regenerating harvests from rhizomes (e.g. bamboo, coppice)	Continuous uptake with minimal stock loss
+D – Harvest without depletion	Harvest occurs without loss of stock (e.g. cork, rubber) 	Continuous harvest without depletion
+E — Engineered Atmospheric Uptake	CO₂ captured through industrial processes (e.g. mineralization)	CO₂ remains in atmosphere
+ 
+Tier 1 feedstocks shall be evaluated using radiative forcing and temperature change data, without explicit modeling of opportunity cost as the carbon flows of these feedstocks are characterized by atmospheric exchange dynamics occurring within approximately 5 years, including near-term emissions from waste or residues, rapid regrowth cycles for short-rotation or perennial systems, and near-term removal or storage dynamics for engineered carbon uptake systems.
+The 5-year horizon shall be interpreted as a practical default for categorization criteria to enable consistent treatment of Tier 1 feedstocks within a simplified modeling framework. This horizon is not intended to define a universal scientific boundary but has been tested to ensure relative accuracy to feedstocks within this category. 
+Feedstocks outside this 10-year horizon may still be valid for analysis but shall require either case-specific justification for inclusion in Tier 1, or classification under Tier 2.
+These sub-category distinctions shall be documented by CCLIMB users to ensure transparency regarding relevant system parameters, including but not limited to emissions arising from land use and land use change (LULUC).
+FOR v2: Tier 2 — Stock-Based Systems
+Reference-driven systems are feedstocks for which carbon is sourced from a standing biological stock, use of the feedstock alters the magnitude and/or trajectory of that stock, and the reference trajectory includes continued storage and/or continued sequestration. The most common example of a reference-driven system is long-rotation woody biomass (timber).
+For Tier 2 feedstocks, climate impact is governed by:
+ΔRF(t) = RF_feedstock trajectory(t) − RF_reference  trajectory(t)
+Where:
+RF =      instantaneous radiative forcing
+t = time
+This method of determining climate impact accounts for forgone carbon storage and forgone future sequestration, due to the use of the feedstock.
+Calculation Requirement: To be determined in v2.
+Combined Feedstocks
+Products containing multiple feedstocks shall classify each feedstock independently and evaluate each according to its assigned tier.
+
+4. Modeling Logic
+4.1 Climate Interpretation – Reference Trajectory
+Climate interpretation under CCLIMB is based on a comparison between the product or building carbon use trajectory (Project Case)[8.1][9.1][9.2] and one or more counterfactual carbon flow trajectories for the carbon-based feedstocks that the product or building is comprised of, defined here as Reference Trajectories (RTs). This trajectory describes the net flux of CO₂ to the atmosphere that would occur in the absence of the project.
+A Reference Trajectory (RT) is defined as a time-explicit counterfactual emissions trajectory:
+E_RT(t)
+Where:
+E_RT(t) = emissions under the Reference Trajectory at time t
+RT = Reference Trajectory
+t = time
+4.1.1. Standardized Reference Trajectory Archetypes
+CCLIMB defines standardized RT archetypes representing common counterfactual pathways.
+Tier 1 Reference Trajectory Archetypes
+RT-A: Near-Term Emission[10.1]
+RT-A is the default reference trajectory for Tier 1 feedstocks, including a default timescale for the delay period (e.g. feedstock growth) and decay rate. Tier 1 feedstocks include waste, by-products, short-rotation crops, perennial systems, and engineered carbon uptake systems where the reference trajectory is near-term return of carbon to the atmosphere.
+E_RT(t) = C₀ · k · e^(−k t)
+Where:
+E_RT(t) = emissions under the Reference Trajectory
+C₀ = initial carbon stock
+k = decay constant
+t = time
+e = base of natural logarithm
+
+k = 1 / τ
+Where:
+k = decay constant
+τ[11.1][12.1] = characteristic decay time (within 5 years)[13.1][14.1]
+RT-B: Custom Scenarios
+RT-B may be applied to any Tier 1 feedstock for which accurate information is available regarding the delay period (e.g. feedstock growth) and decay rate. 
+E_RT(t) = 0    	for t < t_d
+E_RT(t) = C₀ · k · e^(−k (t − t_d))   for t ≥ t_d
+Where:
+E_RT(t) = emissions under the Reference Trajectory
+C₀ = initial carbon stock
+k = decay constant
+t = time
+t_d = delay period
+Tier 2 feedstocks are not included in this version of CCLIMB.
+
+4.2 Climate Interpretation – Radiative Forcing, Temperature Change, and Completeness
+Metrics to determine climate impact under CCLIMB include radiative forcing, temperature change, and completeness[15.1]. Additionally, these metrics are used to inform a result for cumulative[16.1][17.1][18.1][19.1][20.1] radiative forcing at year 100 as a means providing a comparison with product/building GWP100, a metric commonly used in life cycle assessment reporting. 
+Climate impact in CCLIMB is interpreted as the difference in radiative forcing between the Project Case and the Reference Trajectory, with contextual comparison to the difference in temperature change between the Project Case and the Reference Trajectory.
+Detailed below are formulas to derive results for integrated radiative forcing – utilizing radiative forcing response and impulse response formulas – as well as temperature change response and completeness.
+4.2.1 Integrated radiative forcing 
+Integrated radiative forcing represents the cumulative physical climate forcing over the reporting horizon. This metric is directly comparable to the underlying basis of global warming potential (GWP), a common metric used to determine climate impact of greenhouse gas emissions, but is time-explicit and counterfactual-dependent in alignment with CCLIMB. 
+Impulse response
+Radiative forcing is derived from emissions using an impulse response function (IRF):
+RF(t) = ∫₀ᵗ E(τ) · IRF(t − τ) dτ
+Where:
+RF(t) = radiative forcing at time t
+E(τ) = emissions at time τ
+IRF(t − τ) = impulse response function
+t = time
+τ = time of emission
+Radiative Forcing Response
+To calculate the radiative forcing response of a product or building:
+ΔRF(t) = RF_project(t) − RF_RT(t)
+Where:
+ΔRF(t) = difference in radiative forcing at time t
+RF_project(t) = radiative forcing of the Project Case
+RF_RT(t) = radiative forcing of the Reference Trajectory
+t = time
+4.2.2 Temperature change response
+Temperature change response represents the cumulative climate system response of carbon flow associated with a product or building. To calculate the temperature change response of a product or building:
+ΔT(t) = T_project(t) − T_RT(t)
+Where:
+ΔT(t) = difference in temperature change at time t
+T_project(t) = temperature change of the Project Case
+T_RT(t) = temperature change of the Reference Trajectory
+t = time
+4.2.3 Completeness
+Completeness represents the fraction of total modeled climate impact captured within the reporting horizon. Reporting a completeness metric ensures that the reported climate response of a product or building is provided in the context of the timing of emissions trajectories. For instance, reporting on the 50-year impact of a product with a 60-year lifespan will omit the end of life impacts, producing an incomplete insight. 
+5. Reporting of results
+2.3.1 Purpose of Outputs
+Reporting on climate impact of buildings and products with the CCLIMB methodology enables comparison across standard and custom reporting horizons, and explicitly discloses the fraction of total modeled impact captured within any selected time horizon. CCLIMB outputs represent the time-dependent climate response resulting from carbon flows defined in inventory methods, expressed relative to a specified Reference Trajectory (RT). All reported results shall be defined relative to a reference completeness horizon, 𝑇𝑟𝑒𝑓, representing the time period over which climate response is considered substantially complete (provisionally 250 years). 
+These outputs describe how the climate system responds over time to the difference between the two trajectories. They quantify the magnitude of climate response, the timing of that response, and the degree to which it is captured within reporting horizons. 
+2.3.3 Graphical Representation
+Figure X — Time-Explicit Climate Response[21.1] Sample Graph
+[GRAPH HERE]
+Results of temperature change response and radiative forcing response shall be presented graphically, including a reference trajectory line in addition to the response results,[22.1] clearly marked reporting horizons (e.g. 20, 50, 100 years), and indication of warming versus cooling effects. These visualizations communicate the time-dependency of climate impacts, duration of storage effects, and delayed emissions behavior.
+2.3.4 Tabular Reporting of Results
+Results must be summarized using Table X — Time-Dependent Climate Response Summary.
+Table X — Time-Dependent Climate Response Summary
+Metric	Unit	20 years (optional)	50 years (optional)[23.1]	100 years (required)	Full (T_ref)
+Integrated Radiative Forcing ∫₀ᴴ ΔRF(t) dt
+W·m⁻²·year	[ ]	[ ]	[ ]	[reference total]
+Integrated Temperature Response ∫₀ᴴ ΔT(t) dt	°C·year	[ ]	[ ]	[ ]	[reference total]
+Completeness C(H)	–	[ ]	[ ]	[ ]	1.0
+Residual (1 – C(H))	–	[ ]	[ ]	[ ]	0
+Direction of Effect	–	Cooling / Warming	Cooling / Warming	Cooling / Warming	–
+
+Key Definitions
+C(H)=(∫_0^H ΔT(t) dt)/(∫_0^(T_ref) ΔT(t) dt) Cumulative RF(H)=∫_0^H ΔRF(t) dt
+Where:
+	ΔRF(t) = difference in radiative forcing between Project Case and Reference Trajectory 
+	ΔT(t) = difference in temperature response 
+	H = reporting horizon 
+	T_ref= reference completeness horizon (~250 years, provisional) 
+Critical Note (must accompany table)
+“Cumulative radiative forcing values represent integrated climate forcing and are the closest equivalent to conventional GWP-based metrics used in LCA and EPDs. However, they are not CO₂e values and must not be interpreted as carbon quantities or credits.”
+Required Interpretation Statement
+All reported results must include:
+“Results represent the difference in climate response between the Project Case and the specified Reference Trajectory. Values at each time horizon represent partial realizations of the modeled climate response. Completeness indicates the fraction of total impact captured within the reporting horizon relative to T_ref, and residual indicates the proportion occurring beyond the reporting horizon.”
+2.3.7 Use of 100-Year Results
+A 100-year result may be reported for enabling comparison with GWP100-based reporting, aligned with LCA and EPD conventions. However, this 100-year result is a partial representation of climate response and must be interpreted alongside completeness.  
+6. Minimum Requirements for Climate Calculation Engines 
+6.1 Scope and Role of the Calculator
+A climate calculation engine [24.1][25.1][26.1][27.1]shall:
+	Operate as a climate response model only,
+	Accept externally defined carbon inventories, and
+	Produce time-explicit climate impact outputs, including radiative forcing and temperature change.
+The calculator shall not:
+	Define or modify carbon inventories,
+	Implicitly assign climate benefit, or
+	Embed counterfactual assumptions.
+6.2 Scientific Basis
+The calculator shall implement a climate impact formulation consistent with the physical chain:
+Emissions → Atmospheric concentration → Radiative forcing → Temperature 
+This structure shall be consistent with the treatment of emissions metrics and climate impacts described in IPCC AR6 Working Group I (Chapter 7).
+The calculator should:
+	Use a reduced-complexity climate model or equivalent formulation consistent with current scientific understanding (e.g., impulse-response or emulator-based models).
+6.3 Climate System Parameters
+The calculator shall be calibrated to climate system behavior consistent with IPCC AR6 assessed ranges, including:
+	Equilibrium Climate Sensitivity (ECS)
+	Transient Climate Response (TCR)
+The calculator shall document:
+	The ECS and TCR values or distributions used, and
+	The source of calibration (e.g., AR6-consistent parameterization).
+6.4 Gas Coverage
+The calculator shall explicitly model, at minimum:
+	Carbon dioxide (CO₂)
+	Methane (CH₄)
+The calculator may include additional greenhouse gases and forcing agents where supported by the underlying model.
+6.5 Input Requirements
+The calculator shall accept:
+	Time-resolved greenhouse gas flows Fgas(t)
+	With a minimum resolution of one year
+	Including both:
+	positive emissions
+	negative emissions (removals)
+The calculator shall require the definition of a temporal reference point (time zero).
+
+6.6 Temporal Treatment
+The calculator shall:
+	Preserve the timing of emissions and removals without aggregation
+	Apply climate response functions consistently across all time steps
+The calculator shall not:
+	Apply fixed time horizons internally that truncate climate response without disclosure
+The calculator should:
+	Allow evaluation across flexible reporting horizons (e.g., 20, 50, 100 years)
+6.7 Output Requirements
+The calculator shall provide, at minimum:
+	Instantaneous radiative forcing RF(t)
+	Cumulative radiative forcing ∫RF(t)dt
+	Temperature response (e.g., ΔT(t))
+	Optional relative metrics (e.g., CO₂-equivalent values)
+All outputs shall be time-explicit.
+6.8 Transparency and Documentation
+The calculator shall disclose:
+	The underlying climate model or equations used
+	Parameter values and their sources
+	The IPCC assessment basis (e.g., AR6 alignment)
+	Any assumptions related to:
+	atmospheric decay
+	radiative efficiency
+	carbon cycle behavior
+6.9 Consistency and Completeness
+The calculator shall:
+	Apply consistent climate response modeling across all emissions
+	Avoid omission of emissions or impacts within the modeled time domain
+	Enable assessment over extended time horizons sufficient to capture long-term climate response
+6.10 Use of Scenarios in Model CalibrationScenario Treatment
+6.10.1 Use of Scenarios in Model Calibration
+The calculator should:
+	Be calibrated against scenarios or datasets consistent with IPCC AR6 (e.g., SSP-based ensembles).,
+	Use such scenarios only for model validation,  and parameterization, and sensitivity analysis, not for determining results. The calculator may provide scenario-dependent outputs where explicitly requested.
+	Not prescribe a specific global climate scenario (e.g., 1.5°C, SSP2-4.5, or 2.6 W/m²) as a required basis for calculation.
+6.10.2 Prohibition on Fixed Scenario Selection
+CCLIMB shall not prescribe a specific global climate scenario (e.g., 1.5°C, SSP2-4.5, or 2.6 W/m²) as a required basis for calculation.
+The calculator shall:
+	Produce results that are independent of any single assumed future pathway,
+	Reflect the physical response to the input emissions trajectory only.
+6.10.23 Optional Scenario Use
+The calculator may:
+	Allow users to run alternative background scenarios for sensitivity analysis,
+	Provide scenario-dependent outputs where explicitly requested.
+Such scenario-based outputs shall be clearly identified as sensitivity or exploratory results, not primary outputs.
+
+
+ 
+Section 7. Implementation Guidelines
+7.1 Worked Examples
+Include 1-2 products/scenarios from Interface?
+Include bio-based panel or whole building LCA from Meta data center?
+Does Arup have a particular use case to explore/share?[28.1][29.1]
+
+ 
+Section 8. Boundaries and Transparency
+8.1 Limitations[30.1][31.1] and Assumptions
+CCLIMB makes structural assumptions explicit and interprets climate response within defined comparison frameworks. 
+CCLIMB does not:
+	CCLIMB does not guarantee permanence of atmospheric removal nor predict long-term systemic forest equilibrium responses.
+	Eliminate uncertainty associated with reference trajectory selection.
+
+ 
+Section 9. Reference Material
+9.1. Definitions
+Reference trajectory (RT): the net flux of CO₂ to the atmosphere that would occur in the absence of the project (carbon-storing product or building). See Section 5 for full calculation and definition.
+Product [in relation to CCLIMB]: A biogenic feedstock that has carbon present and/or a product with carbon intentionally incorporated during manufacturing or construction, that is quantifiable at the time of building installation.
+Timing-driven systems: feedstocks for which carbon is part of a short-term system, and climate impact is governed primarily by timing effects rather than changes in standing carbon stocks.
+Reference-driven systems: feedstocks for which carbon is sourced from a standing biological stock, and use of the feedstock alters the magnitude and/or trajectory of that stock, and the reference trajectory includes continued storage and/or continued sequestration. 
+Radiative forcing (RF): The quantified energy (W/m2) gained or lost by the Earth system following an imposed atmospheric perturbation. 
+Integrated radiative forcing: The accumulated change in energy from an imposed atmospheric perturbation (carbon emission) within a distinct period of time. Often used as a comparative metric relative to radiative forcing of CO2 (also known as global warming potential or GWP).  
+Instantaneous radiative forcing: The immediate change in energy (W/m2) following an imposed atmospheric perturbation (carbon emission), at a distinct time.  Also called ‘effective radiative forcing.’
+9.2 Appendices
+
+Use in PCRs and EPDs
+(Informative Annex — not part of the declared environmental performance)   A.1 Scope and Purpose
+This annex defines a Carbon & Climate Impact Model for Materials and Buildings (CCLIMB) to supplement Environmental Product Declarations (EPDs) for products containing biogenic carbon.
+The purpose of this annex is to:
+	provide a time-explicit interpretation of climate effects associated with the temporal displacement of biogenic carbon,
+	enable comparison between product systems using cumulative climate metrics consistent in logic with GWP100-based assessments,
+	improve transparency regarding the climate implications of carbon storage and delayed emissions.
+This annex does not modify or replace inventory-based environmental indicators reported in accordance with ISO 14025, EN 15804, or ISO 21930.
+A.2 Normative Position within EPDs
+A.2.1 General
+Results derived using the CCLIMB methodology:
+	shall be reported as supplementary information only,
+	shall not be included within the core environmental impact indicator tables,
+	shall not be used to adjust, offset, or reinterpret declared GWP values.
+A.2.2 Relationship to
+ Declared Indicators
+The Climate Interpretation Overlay:
+	does not alter life cycle inventory results,
+	does not constitute an environmental impact category under existing LCIA methods,
+provides an interpretative layer describing the climate response to inventory-defined carbon flows.
+A.3 Definitions
+For the purposes of this annex:
+A.3.1 Counterfactual trajectory
+ The atmospheric carbon pathway representing the most plausible fate of the same biogenic carbon in the absence of the product system.
+A.3.2 Product trajectory
+ The atmospheric carbon pathway resulting from the production, use, and end-of-life of the declared product.
+A.3.3 ΔCRF (100y)
+ The difference in cumulative radiative forcing over 100 years between the product trajectory and the counterfactual trajectory.
+ΔCRF100=∫0100(RFproduct(t)−RFcounterfactual(t))dt\Delta CRF_{100} = \int_{0}^{100} \left(RF_{product}(t) - RF_{counterfactual}(t)\right) dtΔCRF100=∫0100(RFproduct(t)−RFcounterfactual(t))dt
+A.3.4 Climate response pattern
+ A qualitative classification describing the temporal behavior of climate forcing (e.g., temporary cooling with reversal).
+A.4 Methodological Requirements
+A.4.1 General principle
+Climate benefit or burden shall be interpreted as:
+the difference in climate response between the product trajectory and a defined counterfactual trajectory.
+Carbon storage alone shall not be interpreted as a climate benefit.
+A.4.2 Counterfactual definition
+A counterfactual scenario shall be defined for all products reporting ΔCRF (100y).
+The counterfactual shall:
+	represent the most plausible atmospheric fate of the same biogenic carbon,
+	be consistent with the material category of the product,
+	be transparently documented.
+A.4.3 Default counterfactuals (where applicable)
+Where product category permits, the following default counterfactuals may be used:
+Material category	Default counterfactual
+Residues / waste streams	Near-term atmospheric return via decomposition or conventional use
+Short-rotation crops	Continued short-cycle carbon turnover
+Perennial regenerative systems	Continued standing biomass trajectory
+Long-rotation woody biomass	Explicit forest counterfactual required (no default permitted)
+A.4.4 Time horizon
+ΔCRF shall be calculated over a 100-year time horizon to enable comparability with GWP100-based assessments.
+A.4.5 System boundaries
+The product trajectory shall be based on the life cycle inventory reported in the EPD.
+The counterfactual shall represent the same carbon mass outside the product system boundary.
+A.5 Reporting Requirements
+A.5.1 Mandatory reporting elements
+The following information shall be reported when applying CCLIMB:
+Item	Requirement
+Counterfactual description	Required
+ΔCRF (100y) value	Required
+Climate response pattern	Required
+Statement of interpretation limitations	Required
+
+A.5.2 Recommended reporting format
+CCLIMB results shall be reported in a clearly separated section titled:
+“Climate Interpretation Overlay (CCLIMB) — Informative Results”
+A.5.3 Standard reporting table
+Item	Result
+Counterfactual definition	___
+ΔCRF (100y)	___
+Climate response pattern	___
+Time-dependent graph available	Yes / No
+
+A.5.4 Required interpretative statement
+The following statement shall be included verbatim or with equivalent meaning:
+ΔCRF (100y) represents cumulative radiative forcing relative to a defined counterfactual scenario. It is comparable in logic to GWP100-based cumulative assessment but is not a carbon footprint metric and shall not be used as a substitute for GWP100.
+A.6 Limitations and Conditions of Use
+A.6.1 Non-substitution of GWP
+ΔCRF (100y):
+	shall not replace GWP100,
+	shall not be used as a carbon footprint indicator,
+	shall not be used for regulatory compliance or benchmarking purposes without explicit approval.
+A.6.2 No crediting or neutrality claims
+Results derived under this annex:
+	shall not be used to claim carbon neutrality,
+	shall not be used as offsets or removal credits,
+	shall not be interpreted as permanent carbon sequestration.
+A.6.3 Comparability constraints
+ΔCRF values shall only be compared when:
+	functional units are equivalent,
+	system boundaries are consistent,
+	counterfactual assumptions are materially equivalent.
+A.6.4 Interpretation requirement
+ΔCRF (100y) shall not be reported or interpreted without:
+	an accompanying counterfactual definition, and
+	a qualitative climate response pattern.
+A.7 Optional Supplementary Information
+The following may be provided:
+	time-dependent radiative forcing curves (ΔRF(t)),
+	temperature response curves (ΔT(t)),
+	additional time horizons (e.g., 20y, 50y),
+	impact completeness relative to a long reference horizon.
+A.8 Statement of Role
+The Climate Interpretation Overlay:
+	provides insight into timing-dependent climate response,
+	complements existing LCA results,
+	does not constitute a certification, accounting, or crediting framework.
+
+
+Appendix
+Feedstock categorization table, detailed
+Category	Feedstock source	Feedstock examples	Opportunity cost
+A	Residues, co-products and waste/recycling streams		Agricultural by-products (straw, hulls, shells, chaff, stems, meal)
+	Forestry by-products (slash, bark, root mass, sawdust/chips, trees removed during non-harvest thinning, urban tree removal)
+	Recycling streams (wood, paper, cardboard, textiles)
+	Waste streams (sewage, food waste)	
+Category A includes feedstocks whose reference trajectory is near-term release of stored carbon and whose diversion does not materially reduce ongoing carbon sink capacity at the ecosystem scale. Burden allocation, durability and end-of-life scenarios are to be derived from inventory source data. 	None
+B	Purpose-grown, short-rotation crops		Agricultural crops (hemp, flax, 
+	Perennial crops (switchgrass, 
+	Algae	
+Category B includes purpose-grown crops harvested on annual or near-annual cycles, where carbon uptake and release are part of a short biological turnover and are largely reset each harvest cycle. Burden allocation, durability and end-of-life scenarios are to be derived from inventory source data.	Minimal
+C	Perennial crops - primary products		Bamboo
+	Cork[32.1][33.1]
+	Rubber
+	Coconut (fiber, oil)
+	Fast-growing woody crops (willow, etc)	
+Category C includes feedstocks derived from perennial regenerative systems where harvest does not materially reduce standing carbon stocks (root systems, perennial structures) remain intact and continue net carbon uptake independent of harvest cycles.	Minimal
+D	Timber 		All timber species 	
+Category D includes long-rotation woody biomass harvested from standing forests where removal reduces the existing forest carbon stock and creates an opportunity cost relative to continued forest growth.	Significant
+E	Engineered Atmospheric Carbon Uptake		Carbonated feedstocks from natural sources including algae and microbes
+	Carbonated feedstocks sourced from industrial carbon dioxide removal
+	Polymers	
+Category E includes products in which carbon is intentionally incorporated into material systems during manufacturing or installation through engineered processes, independent of ongoing land-based ecosystem carbon cycling. Does not include gradual atmospheric uptake occurring during the service life of the building (e.g., ambient carbonation of concrete).	None
+
+
+
+Draft Reference Trajectories for Tier 2
+5.1.2 RT-Low (Optimistic Bound)
+Represents a plausible trajectory in which carbon would return to the atmosphere earlier absent building use.
+Purpose:
+	Demonstrate maximum plausible timing benefit from storage.
+5.1.3 RT-High (Conservative Bound)
+Represents a plausible trajectory in which carbon would remain out of the atmosphere longer [34.1][35.1]absent building use.
+Purpose:
+	Expose Provide baseline for opportunity cost of not storing carbon in materials.
+	Prevent automatic overstatement of climate benefit claims.
+Pending decision: The precise structure and parameterization of RT-Low and RT-High remain subject to working group review.
+5.2 Tiered Approach for Category D
+For products utilizing Category D[36.1][37.1] (virgin timber) feedstocks, a tiered approach to selecting reference trajectories is suggested. Virgin timber requires structured reference trajectory governance due to:
+	Significant potential opportunity cost,
+	Scale mismatch between forest carbon systems and product use,
+	Baseline instability,
+	High sensitivity to timing.
+Timber Counterfactual Modeling Tiers (Category D Only)
+Tier	Reference Trajectory (RT)	RT-Low	RT-High	Evidentiary Requirements	Intended Use Context
+Tier 1 – Commodity Timber (Default)	Harvest-occurs / typical product allocation	Fast-return alternative	Delayed harvest (generic conservative bound)	Minimal sourcing detail required	Expected to apply to most projects and users. Designed to lower barriers to implementation while preserving structured interpretation.
+Tier 2 – Managed Regional Context	Business-as-usual (BAU) managed forest trajectory, regionally evidenced	Harvest-occurs fast-return	Regionally parameterized delayed harvest	• Regional forest carbon trend evidence 
+• Identification of sourcing region	Appropriate where regional forest management context is known and defensible but stand-level data are unavailable.
+Tier 3 – Stand-Specific Sourcing	Documented stand- or ownership-level forest trajectory	Required	Required	• Stand-level or ownership-level forest carbon modeling 
+• Explicit documentation of baseline and alternative scenarios	Highest evidentiary rigor. Appropriate where project-level forest data are available and traceable.
+
+
+ 
+Next Steps
+Outstanding decisions for working group:
+	Gross vs net carbon storage treatment (or both),
+	Final material categorization,
+	Reference trajectory governance details,
+	Climate model selection,
+	T-ref calibration,
+	Governance model for companion documents.
+
+
+

--- a/docs/RMI Work/CCLIMB-Workplan2.md
+++ b/docs/RMI Work/CCLIMB-Workplan2.md
@@ -1,0 +1,463 @@
+# CCLIMB — BfCA implementation workplan
+
+> Companion to [`CCLIMB-Workplan.md`](CCLIMB-Workplan.md) (Chris's methodology proposal, translated from Word). This document interprets the proposal as a 6th BfCA module, sleeves it into the existing BEAMweb / PDF-Parser / Matrix / Database / EPD-Parser ecosystem, and sketches the visualization + implementation strategy.
+>
+> **Drafted 2026-05-19 PM in prep for Andy's 3pm working-group call.** Subject to revision as the working-group decisions in §1.5 land.
+
+---
+
+## 1. Summary of the CCLIMB proposal
+
+CCLIMB (Carbon & Climate Impact Model for Materials and Buildings) is a **time-explicit dynamic-LCA (dLCA) methodology** that interprets the climate impact of biogenic-carbon-storing building products *not* as a single CO₂e number, but as a **time-series of radiative forcing and temperature change** over a chosen horizon.
+
+The fundamental claim: GWP100-style accounting collapses uptake and release into a single mass-balance figure, losing the timing information that's load-bearing for atmospheric concentration trajectories. Storing carbon for 50, 100, or 250 years before re-emission is *not* climate-neutral — it shifts the radiative forcing curve, and that shift is measurable.
+
+### 1.1. The math chain
+
+```
+Emissions (per year)  →  Atmospheric concentration  →  Radiative forcing  →  Temperature
+       E(t)                       C(t)                       RF(t)               ΔT(t)
+```
+
+Driven by an **Impulse Response Function (IRF)** convolution:
+
+```
+RF(t) = ∫₀ᵗ E(τ) · IRF(t − τ) dτ
+```
+
+The climate response to a *project* (`PT`) is then compared to a *reference trajectory* (`RT`) representing the counterfactual:
+
+```
+ΔRF(t) = RF_project(t) − RF_RT(t)        [Tier 1, timing-driven]
+ΔRF(t) = RF_RT(t) − RF_project(t)        [Tier 2, stock-based — v2]
+```
+
+### 1.2. Inputs (per product)
+
+| Input | Source | Notes |
+|---|---|---|
+| A1 carbon content / GWP-bio | EPD module A1 | Negative emission at Year 0 |
+| A3 carbon flows | EPD module A3 | Processing-stage emissions |
+| A5 install-waste emissions | EPD module A5 | Routed via Incineration / Landfill (EPA WARM decay rates) |
+| C4 end-of-life carbon | EPD module C4 | At Year = product lifespan |
+| Feedstock category | User-selected (A/B/C/D/E) | Determines RT defaults |
+| Reference trajectory | User-selected (RT-A defaults or RT-B custom) | RT-A: –1/+1, –5/+5, or other defaults. RT-B: custom growth + decay |
+| Product lifespan | EPD or user-supplied | Year of EOL onset |
+| EOL mix | EPD or user-supplied | Incineration % / Landfill % / Recycle % / Reuse % |
+
+### 1.3. Outputs
+
+| Output | Unit | Reporting |
+|---|---|---|
+| Instantaneous radiative forcing `RF(t)` | W/m² | Plot (per gas + total) |
+| Integrated radiative forcing `∫₀ᴴ ΔRF(t)dt` | W·m⁻²·year | Table at 20, 50, 100, T_ref |
+| Temperature response `ΔT(t)` | K | Plot |
+| Integrated temperature response `∫₀ᴴ ΔT(t)dt` | °C·year | Table at horizons |
+| **ΔCRF(100y)** | W·m⁻²·year | **The headline EPD-reportable metric** — comparable in *logic* to GWP100 but explicitly *not* CO₂e |
+| Completeness `C(H)` | dimensionless | Fraction of full impact captured at horizon H, relative to `T_ref` (~250 yr) |
+| Residual `1 – C(H)` | dimensionless | Counterpart |
+| Direction of effect | cooling / warming | Qualitative |
+
+### 1.4. Feedstock categories (Tier 1 — v1 scope)
+
+| Cat | Source | Examples | Opportunity cost |
+|---|---|---|---|
+| A | Residues / waste / recycling streams | Straw, slash, sawdust, recycled wood/paper, sewage | None |
+| B | Purpose-grown short-rotation crops | Hemp, flax, switchgrass, algae | Minimal |
+| C | Perennial regenerative primary products | Bamboo, cork, rubber, coconut, fast-growing wood crops | Minimal |
+| **D** | **Timber (all species)** | **All long-rotation woody biomass** | **Significant → deferred to Tier 2 / v2** |
+| E | Engineered atmospheric uptake | Mineralized feedstocks, captured-CO₂ polymers | None |
+
+Category D is critical because it's *most* of the structural mass-timber market (CLT, GLT, glulam, LVL). v1 defers it pending forest-counterfactual governance.
+
+### 1.5. Working-group decisions still open (per §Next Steps in [CCLIMB-Workplan.md](CCLIMB-Workplan.md))
+
+1. Gross vs. net carbon storage treatment (or both)
+2. Final material categorization (Tier 1 sub-categories)
+3. Reference trajectory governance for Tier 2 (timber)
+4. Climate model selection (which IRF, which carbon-cycle model)
+5. T_ref calibration (~250 yr provisional)
+6. Governance model for companion documents
+
+### 1.6. Inconsistencies / red flags worth flagging at the call
+
+- **5-yr vs 10-yr horizon mention** (lines 143–144 of CCLIMB-Workplan.md): "5-year horizon" used for Tier 1 categorization in one sentence, "10-year horizon" in the immediately following sentence. Working group needs to land on one number.
+- **`[N.1]` reviewer-comment anchors** sprinkled through the Word→MD translation lost their attached comment bodies. If those reviewer notes need to inform the final document, they need to be re-captured.
+- **A.4.4 says ΔCRF computed over 100 years** but elsewhere T_ref is described as ~250 yr. The relationship between "the 100-yr GWP-comparable headline" and the "full T_ref completeness" needs an unambiguous statement.
+
+---
+
+## 2. Why this fits as the 6th BEAM module
+
+### 2.1. Current ecosystem
+
+BfCA OpenBuilding currently ships five apps from one repo, deployed via GitHub Pages:
+
+| URL | Audience | Function |
+|---|---|---|
+| `/` | Anyone | Landing page / app directory |
+| `/pdfparser.html` | Anyone (practitioners) | PDF takeoff |
+| `/matrix.html` | Anyone | Regulatory compliance grid |
+| `/database.html` | Anyone (read-only) | Materials catalogue viewer |
+| `/beamweb.html` | Anyone (practitioners) | Embodied carbon calculator |
+| `/epdparser.html` | **BfCA team only** | Catalogue ingestion (see EPD-Parser.md §14) |
+
+CCLIMB slots in naturally as `/cclimb.html` — a sixth module sharing the same design system, same deployment pipeline, same materials catalogue.
+
+### 2.2. Public-facing positioning
+
+Unlike EPD-Parser (which is back-of-house BfCA tooling per EPD-Parser.md §14), **CCLIMB is public-facing**. The methodology is openly published, the inputs come from any LCA/EPD, and the intended audience is the broad LCA community — practitioners, designers, building owners, policy analysts (per §1.2 of CCLIMB-Workplan.md).
+
+This makes CCLIMB the *third* public-facing analytical tool alongside BEAMweb (carbon calculator) and Matrix (regulatory compliance):
+
+| Module | Audience | Reads from catalogue? | Writes to catalogue? |
+|---|---|---|---|
+| BEAMweb | Public | Yes | No |
+| Matrix | Public | No (uses inline regulatory data) | No |
+| **CCLIMB** | **Public** | **Yes (optional)** | **No** |
+| EPD-Parser | Internal | Yes | Yes (curators only) |
+
+The catalogue read is optional because CCLIMB's standalone mode lets users enter EPD inventory data manually for products *not* in the BfCA catalogue.
+
+### 2.3. Two operating modes
+
+**Standalone mode** (default for non-BfCA users):
+- User enters product carbon inventory directly (A1, A3, A5, C4 carbon flows)
+- User picks feedstock category + RT + lifespan + EOL mix
+- CCLIMB computes climate response, displays parallel-coordinates RT vs PT chart, exports report
+- No catalogue dependency
+
+**BEAM-connected mode** (default for BfCA users + anyone using the catalogue):
+- User picks a product from the materials catalogue (`schema/materials/*.json`)
+- Inventory fields pre-populate from the catalogue's `impacts.*` + `physical.*` + (once Tier-10 lands) `methodology.beam_calc.*`
+- User adjusts service life, RT choice, EOL mix interactively
+- Whole-building roll-up (Step 9 of the flowchart) pulls a BEAMweb-exported product list
+
+These are the same UI; the BEAM-connected mode just pre-fills the form-pane fields.
+
+### 2.4. What CCLIMB depends on / borrows from BfCA
+
+| Dependency | From | Notes |
+|---|---|---|
+| Materials catalogue read | `schema/materials/*.json` via Pages | Already public; no schema change needed for read-only use |
+| `methodology.beam_calc.full_c_kgco2e` per material | EPD-Parser C-fb6 (pending) | Optional input to CCLIMB's PT trajectory. CCLIMB can compute its own if absent. |
+| Design system | `bfcastyles.css` | Add `§N CCLIMB:` banner per the consolidation convention (see CLAUDE.md "Styling") |
+| Landing card | `index.html` | One new card with `Planning` / `Beta` / `Live` badge progression |
+| Schema lookups | `schema/lookups/material-groups.json`, `lifecycle-stages.json` | EN 15804+A2 module enumeration |
+| `js/shared/state-manager.mjs`, `js/shared/file-handler.mjs` | Cross-app utilities | For IndexedDB persistence, drag-drop EPD imports |
+
+CCLIMB does *not* need: format-specific PDF parsers (its inventory comes from already-parsed EPDs or manual entry), browser-side Anthropic API integration (no LLM in scope for v1), or write access to the catalogue.
+
+---
+
+## 3. Visualization — parallel coordinates as the central UI
+
+The OBJECTIVE-tool screenshot is the load-bearing analogy. **The same UX paradigm Andy uses for energy modeling — Reference (red) vs. Target (blue) across many axes — maps directly to CCLIMB's RT vs. PT comparison.**
+
+### 3.1. Why parallel coordinates fit CCLIMB
+
+CCLIMB outputs many time-and-horizon-stratified numbers per product (RF at 20/50/100/T_ref, ΔT at the same, completeness, direction). Comparing PT to RT means comparing two curves through those axes. Single-axis bar charts force users to pick one horizon; multi-panel small-multiples scale poorly. **Parallel coordinates is the natural shape: each axis is an output dimension, each line is a scenario, RT and PT are two lines.**
+
+The OBJECTIVE pattern adds another layer that fits CCLIMB perfectly:
+- **Input axes are draggable sliders** (in OBJECTIVE: SHW%, ACH50, WWR, etc.; in CCLIMB: service lifespan, RT growth/decay, EOL mix %)
+- **Output axes are calculated** (in OBJECTIVE: TEUI, TEDI, GHGI; in CCLIMB: ΔCRF(20/50/100/T_ref), Completeness(100), Direction)
+- **Dragging an input axis recomputes the output curve in real time**
+
+That's the central interaction: practitioner pulls service life from 35 → 100 years, watches the blue (PT) curve shift left of red (RT), watches ΔCRF(100) become more negative (cooling effect), watches completeness rise toward 1.0.
+
+### 3.2. Axis layout for CCLIMB
+
+Draft axis order (left to right; tunable based on what makes the call narrative cleanest):
+
+```
+INPUTS (sliders, blue editable dots)          |  CALCULATED (red & blue lines)
+─────────────────────────────────────────────────────────────────────────────────────
+LIFESPAN     RT_growth   RT_decay   EOL_inc%  EOL_landfill%  ΔCRF(20)  ΔCRF(50)  ΔCRF(100)  ΔCRF(T_ref)  ΔT(100)  C(100)
+   yr           yr           yr        %            %        Wm⁻²·yr   Wm⁻²·yr   Wm⁻²·yr    Wm⁻²·yr      °C·yr    —
+```
+
+For the OBJECTIVE-style "Reference" vs "Target" split:
+- **Red line (RT)** — the reference trajectory through the input axes (RT-A defaults: e.g. lifespan = 0 means immediate release, decay 5y) and the resulting output curve through ΔCRF axes
+- **Blue line (PT)** — the project trajectory: user's actual product lifespan, custom RT-B parameters, real EOL mix, resulting in the project's climate response
+
+When the practitioner drags a blue input slider, the blue output recomputes. The red line stays fixed (it's the counterfactual). **The vertical gap between the two lines at each output axis is the climate benefit (or burden) of the project at that horizon.**
+
+### 3.3. Per-phase axis groups (A1 / A3 / A5 / B / C4)
+
+CCLIMB inputs are stratified by EN 15804+A2 phase. The parallel-coordinates chart can have *banded axes* (visual grouping) to make the phase boundaries explicit:
+
+```
+│  A1   │   A3   │     A5      │    B      │    C4     │  ↓ Climate response (calculated)
+│ C_A1  │  C_A3  │  C_inc  C_lf│  lifespan │  EOL mix  │  ΔCRF(20)  ΔCRF(50)  ΔCRF(100)  ΔCRF(T_ref) ...
+```
+
+Banding could be done via background-color zones behind the axis labels (like the OBJECTIVE Refresh/Decarbonize/Optimize button row, but applied to the axis strip). The user immediately reads "these axes are A1 inputs, these are EOL, these are climate response."
+
+### 3.4. Per-phase axis groups — the A-D scope Andy raised
+
+Andy's framing in the request — "RT/PT comparison could be done in the form of a parallel coordinate graph for each phase of scoped carbon A-D" — implies *separate* parallel-coordinate views per LCA module, or a master view with phase grouping. Two designs to discuss:
+
+**(a) Master chart with phase banding** (described above). One chart, all axes, with visual grouping. Pros: side-by-side comparison across the full life cycle. Cons: lots of axes.
+
+**(b) Per-phase mini-charts + master summary chart.** Four small parallel-coordinate widgets (A, B-use, C-EOL, D-credits/benefits) above one master chart that shows the integrated climate response. Pros: legibility per phase. Cons: more code.
+
+Likely answer is **(a) for v1** — master with banding — because the OBJECTIVE codebase Andy has already does the single-chart form. (b) is a v2 enhancement when we know what practitioners reach for.
+
+### 3.5. Below-the-chart numerical table (OBJECTIVE-style)
+
+OBJECTIVE shows Reference / Target / Δ / %Δ / Ref Cost / Target Cost / Target Savings rows below the chart. CCLIMB's analog:
+
+| Row | Content |
+|---|---|
+| **Reference (RT)** | Per-axis red value |
+| **Project (PT)** | Per-axis blue value |
+| **Δ** | Per-axis numeric difference |
+| **%Δ** | Per-axis percentage |
+| **Direction** | cooling (negative ΔCRF) / warming (positive) per horizon |
+| **Completeness** | Per output horizon (only meaningful on output axes) |
+
+"Cost" doesn't translate to CCLIMB — there's no money axis. But "direction of effect" and "completeness" both fit the same row-summary slot.
+
+---
+
+## 4. Implementation sketch
+
+### 4.1. File map
+
+```
+cclimb.html                                        — entry point
+js/cclimb.mjs                                      — ESM entry, wires the chart + form
+js/cclimb/
+  ├── climate-model.mjs                            — IRF + temperature convolution math
+  ├── reference-trajectories.mjs                   — RT-A defaults, RT-B parameterization
+  ├── feedstock-categories.mjs                     — Tier 1 sub-cat A/B/C/E + Tier 2 stub
+  ├── parallel-coords.mjs                          — Andy's D3 PCG widget (ported from OBJECTIVE)
+  ├── chart-config.mjs                             — axis definitions, scales, banding zones
+  ├── form-bindings.mjs                            — slider ↔ chart sync, debounce
+  └── exporter.mjs                                 — markdown / JSON / image report generation
+js/shared/state-manager.mjs                        — existing; CCLIMB reuses for IndexedDB persistence
+js/shared/file-handler.mjs                         — existing; for drag-drop EPD JSON imports
+bfcastyles.css                                     — append §N CCLIMB section
+schema/lookups/cclimb-rt-defaults.json             — RT-A archetype parameters per feedstock cat
+schema/lookups/ipcc-ar6-irf-params.json            — AR6 IRF parameters (CO₂ Bern coefficients, CH₄ lifetime, etc.)
+docs/workplans/CCLIMB.md                           — workplan (this doc, moved when implementation starts)
+```
+
+### 4.2. Climate model — IRF in JS
+
+CCLIMB requires an impulse-response function for at least CO₂ and CH₄ (per §6.4 of CCLIMB-Workplan.md), calibrated to IPCC AR6 (§6.3). Two viable approaches:
+
+**(a) Implement directly in JS.** The Bern carbon-cycle model is 4 exponentials with documented coefficients. CH₄ is a single perturbation lifetime (~11.8 years). N₂O similar. ~100 lines of JS total. Pros: zero runtime dependency, easy to audit, fits BfCA's "no build tools, no framework" convention. Cons: needs careful citation of AR6 coefficient sources.
+
+**(b) Wrap an external library.** FaIR (Finite Amplitude Impulse-Response) is the academic standard but Python. JS ports exist (e.g., simplified versions in some climate-viz libraries). Pros: pre-validated. Cons: adds dependency, may not be Pages-deployable as ES modules.
+
+**Recommendation: (a) for v1.** Document the AR6 parameter sources in `schema/lookups/ipcc-ar6-irf-params.json` so the climate model is auditable. The math is well-known and the BfCA team can verify it against published tables.
+
+### 4.3. Reusing the OBJECTIVE PCG codebase
+
+Andy has the D3 parallel-coordinates widget ready. Migration plan:
+
+1. **Copy as-is** into `js/cclimb/parallel-coords.mjs`. ES-module wrap if it isn't already.
+2. **Replace axis definitions.** OBJECTIVE's 14 axes (SHW%, DWHR%, etc.) → CCLIMB's input + output axes.
+3. **Hook the value-binding callbacks.** OBJECTIVE recomputes TEUI/GHGI when user drags an input axis; CCLIMB recomputes ΔCRF(t) at each horizon when user drags lifespan / RT / EOL.
+4. **Style harmonization.** Apply BfCA palette + section banner so the chart matches BEAMweb / EPD-Parser visual identity.
+5. **Below-chart table.** OBJECTIVE's Δ / %Δ / Ref Cost / Target Cost rows translate to CCLIMB's RT / PT / Δ / Direction / Completeness rows.
+
+The brushing / selection interactions OBJECTIVE already provides (per the screenshot's "Restore Baseline", "Decarbonize", "Optimize" buttons) map cleanly onto CCLIMB equivalents:
+
+| OBJECTIVE button | CCLIMB equivalent |
+|---|---|
+| Refresh Graph | Recompute (after a non-axis change like switching feedstock category) |
+| Restore Baseline | Reset PT inputs to match RT defaults |
+| **Decarbonize** | Snap EOL mix to 100% Reuse + Recycle (maximally climate-favorable EOL) |
+| **Optimize** | Find the lifespan/EOL combo that maximizes |ΔCRF(100)| |
+| **Super Optimize** | Includes RT-B custom growth + decay tuning |
+| **PassivHaus-ify** | (does not translate — energy-specific) — could be replaced by **Mass-timber-ify** (assume Cat C / D feedstock with conservative RT) |
+
+### 4.4. State management + persistence
+
+Reuse `js/shared/state-manager.mjs` for IndexedDB persistence. Schema:
+
+```js
+// CCLIMB IndexedDB store: "cclimb-scenarios"
+{
+  id: "scenario-uuid",
+  created_at: "2026-05-19T15:00:00Z",
+  product: {
+    catalogue_id: "<beam_id or null if standalone>",
+    display_name: "Glulam beam",
+    inventory: { A1: -1000, A3: 5, A5: 1.5, C4: 1000 },  // kgCO2e
+    feedstock_cat: "D",
+    lifespan_years: 75,
+    eol_mix: { incineration: 0.1, landfill: 0.7, recycle: 0.2, reuse: 0.0 }
+  },
+  reference_trajectory: {
+    type: "RT-A",
+    archetype: "default_5",   // -5/+5
+    growth_years: 5,
+    decay_years: 5
+  },
+  result: {
+    delta_crf_20: -800,    // W·m⁻²·year, computed
+    delta_crf_50: -1100,
+    delta_crf_100: -950,
+    delta_crf_full: -200,
+    completeness_100: 0.78,
+    direction_100: "cooling"
+  }
+}
+```
+
+### 4.5. Whole-building roll-up (Step 9)
+
+The flowchart's Step 9 is the integration point with BEAMweb. Practitioner exports a building's product manifest from BEAMweb (or the materials catalogue), CCLIMB consumes the list, runs the climate calc per product, sums the trajectories, displays a single whole-building parallel-coordinates view.
+
+Implementation: a `import-beam-building.mjs` module that takes a BEAMweb-exported JSON file (product list + quantities) and feeds the per-product CCLIMB calc. Same chart UI, just with the building total as the "Project" line.
+
+### 4.6. Reporting + export
+
+The CCLIMB Annex (Appendix A.5 of CCLIMB-Workplan.md) requires a structured reporting table (Counterfactual definition, ΔCRF(100y), climate response pattern, etc.) accompanied by the required interpretation statement. CCLIMB-app generates this as:
+
+- **Markdown export** — fits into EPD supplementary annex
+- **PDF export** — for client deliverables (uses pdf.js render path, or just the browser print)
+- **JSON export** — for downstream consumers (BEAMweb, future audit tools)
+
+---
+
+## 5. Module integration mechanics — sleeving into BEAM
+
+Following the same pattern as PDF-Parser, Matrix, etc.:
+
+### 5.1. Landing card
+
+Add to `index.html`:
+
+```html
+<a class="app-card" href="cclimb.html">
+  <div class="app-card-icon">📈</div>
+  <h3>CCLIMB</h3>
+  <p>Time-explicit climate impact for carbon-storing building products. Compares project trajectory to reference, reports radiative forcing and temperature change.</p>
+  <span class="app-card-badge badge-planning">Planning</span>
+</a>
+```
+
+Badge progression: `Planning` → `Alpha` → `Beta` → `Live`.
+
+### 5.2. Pages deployment
+
+`.github/workflows/deploy-pages.yml` already stages `*.html` + `js/` + `bfcastyles.css` + schema JSON into `_site/`. CCLIMB inherits the deployment without workflow changes — drop the files in place, push, the next build picks them up.
+
+### 5.3. Styling — append to bfcastyles.css
+
+Per the BfCA convention ([CLAUDE.md "Styling"](../../CLAUDE.md)), all styles consolidate into `bfcastyles.css`. Add a new section banner:
+
+```css
+/* ═══════════════════════════════════════════════════════════════════════ */
+/* §11  APP: CCLIMB                                                       */
+/* ═══════════════════════════════════════════════════════════════════════ */
+
+.app-cclimb .pcg-axis-input { /* draggable input axes */ }
+.app-cclimb .pcg-axis-output { /* calculated output axes */ }
+.app-cclimb .pcg-line-rt { stroke: var(--col-reference, #c0392b); }
+.app-cclimb .pcg-line-pt { stroke: var(--col-target, #2980b9); }
+/* ...phase-banding zones, summary-row table, etc. */
+```
+
+HTML class: `<html class="theme-dark app-cclimb">`.
+
+### 5.4. IP guardrails (forever)
+
+Per [CLAUDE.md](../../CLAUDE.md) IP rules:
+- **No `CSI` / `MasterFormat` / `Division` / `MCE²` / `NRCan` / Crown-copyright tool names** in code, UI strings, fetched JSON, or served doc files.
+- Schema citations (`ISO 14025`, `EN 15804+A2`, `ISO 21930`, IPCC AR6 chapter references) are factual and stay.
+- CCLIMB UI text uses neutral wording — "feedstock category" not "raw-material classification," "reference trajectory" not "counterfactual baseline," etc.
+
+---
+
+## 6. v1 scope (what ships first)
+
+| In v1 | Deferred to v2 |
+|---|---|
+| Tier 1 feedstocks (categories A, B, C, E) | Tier 2 (timber / Category D) with forest counterfactuals |
+| RT-A defaults + RT-B custom (single product) | Multi-product RT governance (mixed feedstock products) |
+| Standalone manual-entry mode | BEAMweb building-manifest import |
+| Parallel-coordinates UI for single product | Whole-building roll-up (Step 9) |
+| ΔCRF at 20/50/100/T_ref + ΔT | Sensitivity / scenario analysis (alternative IPCC SSPs) |
+| AR6-calibrated CO₂ + CH₄ IRF | N₂O, sulphate, CFC-11 (per §6.4 *may* but not *shall*) |
+| Markdown + JSON export | PDF export with embedded plots |
+
+v1 ships the methodology faithfully for the *bulk* of carbon-storing building product types (residues, short-rotation crops, perennials, engineered uptake). Mass timber waits on the working group's Tier 2 decisions.
+
+---
+
+## 7. Open questions for the 3pm call
+
+1. **Working-group adoption of the IRF model.** Is there a preferred climate model (FaIR? OSCAR? Bern reduced-complexity?) the methodology will mandate, or is "AR6-consistent" sufficient and tools choose?
+2. **T_ref calibration.** Is ~250 years the final number, or pending?
+3. **Tier 2 timeline.** Is Category D / timber going to be in v2 of the methodology, and on roughly what horizon?
+4. **EPD requirements.** Does the methodology contemplate eventual mandatory inclusion in EN 15804+A2 / ISO 21930, or remains a supplementary annex forever?
+5. **Calculator certification.** §6 lists Calculator requirements but no certification process. Is there a plan for vetting which engines comply? (Direct relevance to BfCA shipping CCLIMB-app as a public tool.)
+6. **Connection to GWP-bio in EPDs today.** Many EPDs publish `GWP-bio per stage A1/A2/A3...` (workplan §11). How does CCLIMB's `A1 carbon storage` input relate to / replace / augment that? Same number, different framing, or genuinely different?
+7. **Default decay rates.** §3 references "US EPA WARM model" for landfill/incineration. Is that the working-group consensus, or a placeholder for a future Canada-context source?
+
+---
+
+## 8. Connection to BfCA's existing biogenic-carbon work
+
+The EPD-Parser's Tier-10 (C-fb6, pending Mélanie review per [`EPD-Parser.md`](../workplans/EPD-Parser.md) §11) computes `methodology.beam_calc.full_c_kgco2e` — a *static* per-product biogenic carbon value. **CCLIMB consumes that value as its A1 input.** The pipeline:
+
+```
+EPD PDF
+  │
+  ▼  EPD-Parser (regex + LLM Tier 8.5 per §14)
+JSON record in schema/materials/
+  │
+  ▼  Tier 9 — db-fallbacks + Tier 10 — BEAM normalization
+methodology.beam_calc.full_c_kgco2e + methodology.beam_calc.storage_factor
+  │
+  ▼  CCLIMB-app reads from catalogue
+Per-product time-explicit climate response (ΔCRF / ΔT trajectory)
+  │
+  ▼  BEAMweb whole-building integration (v2)
+Building-scale ΔCRF for a project
+```
+
+The `storage_cycle` enum from the §11.10 Mélanie draft (`long_cycle | short_cycle | future medium_cycle`) becomes informational once CCLIMB lands — CCLIMB doesn't need the enum because product lifespan + EOL mix renders a continuous storage curve. Mélanie's discrete categorization stays useful as a *human-readable* summary chip in the Database viewer, but the load-bearing math moves to CCLIMB.
+
+The medium_cycle / pro-rating question Andy raised (building demolished early) is **automatically handled by CCLIMB**: change the lifespan input from 100 years to 10, the climate calc recomputes, the parallel-coordinates chart updates, the new ΔCRF(100) shows the (likely much smaller) climate benefit.
+
+---
+
+## 9. Implementation sequencing
+
+| Phase | Scope | Estimate |
+|---|---|---|
+| **P0 — Shell** | `cclimb.html` + ESM entry, drop-zone for manual EPD input, basic form pane | 1–2 days |
+| **P1 — Climate model** | IRF math (CO₂ Bern + CH₄), JSON parameter table, unit tests against published AR6 values | 2–3 days |
+| **P2 — Reference trajectories** | RT-A defaults (–1/+1, –5/+5, custom growth/decay), RT-B parameterized form | 1 day |
+| **P3 — Parallel-coordinates UI** | Port Andy's D3 widget, axis definitions, RT/PT line binding, slider interactions | 2–3 days |
+| **P4 — Output table + reporting** | Below-chart numerical table, markdown export with required interpretation statement | 1 day |
+| **P5 — Catalogue integration** | "Pick a product from BfCA catalogue" mode pre-fills inventory | 1 day |
+| **P6 — BEAMweb integration (deferred)** | Building-manifest import + whole-building roll-up | v2 |
+
+Estimated 8–11 days for v1 alpha. Most of the cost is climate-model implementation + UI integration. The methodology itself doesn't require new research — the IPCC AR6 parameters are tabulated, the IRF math is well-documented.
+
+---
+
+## 10. Cross-references
+
+- [`CCLIMB-Workplan.md`](CCLIMB-Workplan.md) — Chris's methodology proposal (Word→MD translation). Authoritative on the methodology; this doc is the implementation interpretation.
+- [`Workflow diagram steps.pdf`](Workflow%20diagram%20steps.pdf) + [`Workflow diagram steps-1.pdf`](Workflow%20diagram%20steps-1.pdf) — Chris's flowchart for the 9-step user workflow + PT-minus-RT climate calc visualization.
+- [`../workplans/EPD-Parser.md`](../workplans/EPD-Parser.md) §11 (Biogenic Calculations) + §14 (Internal positioning + Last Mile LLM) — the EPD-Parser pipeline that feeds CCLIMB's inventory input.
+- [`../workplans/Database.md`](../workplans/Database.md) — sibling workplan for the catalogue viewer (CCLIMB's data dependency).
+- [`../../CLAUDE.md`](../../CLAUDE.md) — repo-wide conventions (IP guardrails, styling, ecosystem layout).
+
+---
+
+## 11. Outstanding from Andy before P0 starts
+
+- [ ] **Working-group decisions** from the 3pm call — particularly which IRF model is mandated and whether T_ref locks at 250 yr.
+- [ ] **OBJECTIVE D3 codebase** — Andy's existing parallel-coordinates implementation. Where it lives, what its current axis API looks like, what state-management it expects.
+- [ ] **Climate model source citations** — confirm the AR6 chapter / table numbers we'll cite in `ipcc-ar6-irf-params.json`. Working group input welcome on which AR6 ranges are the "right" baselines.
+- [ ] **First worked example** — §7.1 of CCLIMB-Workplan.md mentions Interface / Meta / Arup contributions. If a specific product is going to be the v1 calibration case, name it now so P1 implementation can ground-truth against it.
+- [ ] **Tier 2 / timber positioning** — does BfCA ship CCLIMB v1 without timber support (clean methodology fit, but excludes ~50% of structural-wood EPDs), or does BfCA propose a *separate* Category D handling that the working group can vet against the eventual v2?

--- a/docs/RMI Work/CCLIMB-Workplan2.md
+++ b/docs/RMI Work/CCLIMB-Workplan2.md
@@ -231,6 +231,51 @@ The lifespan input doesn't deserve its own axis — instead it drives the tempor
 
 Dragging the lifespan number from 75 → 25 re-runs the climate calc: the B4-onwards carbon flows shift to earlier years, the IRF convolution sees the EOL release sooner, ΔCRF(100) becomes less negative, the blue line on the climate-response axes moves toward the red line. **Visible, immediate, intuitive.** This is the "demolished after 10 years" pro-rating question I raised earlier — handled natively by the chart.
 
+### 3.4.5. Multi-component stratification — N red lines + N blue lines
+
+**Refined by Andy 2026-05-19 PM (mid-prep):** the chart isn't *one* red line vs *one* blue line per building. It's **N red lines + N blue lines**, where N = the number of material components in the building (flooring, structural frame, roofing, cladding, surface coatings, insulation, glazing, etc.). Each component gets its own RT/PT pair.
+
+The "game" the practitioner is playing becomes intuitive at a glance:
+
+- **N red lines** trace the Reference Trajectory for each component (what would happen to that material's carbon under its counterfactual)
+- **N blue lines (shaded with semi-transparent fill beneath)** trace the Project Trajectory for each component (what actually happens given the design choices)
+- **Visual goal: pull every blue line below its corresponding red line at every life-cycle module axis.** The shaded fill between blue line and red line is the per-component climate benefit.
+- Components where blue is *above* red are the design problems — the practitioner can immediately see *which* materials are dragging the building's climate response in the wrong direction.
+
+Sample reading: a building with CLT structural frame + cork flooring + spray-foam insulation + steel cladding. The CLT and cork blue lines sit comfortably below their reds (carbon-storing perennials with long lifespans + good EOL). Spray-foam blue sits on top of red (no storage, fossil-derived). Steel cladding blue sits at red (no biogenic component). The chart shows at-a-glance: structural choice is doing the heavy lifting; spray-foam is the design's climate liability; cladding is neutral.
+
+```
+       A1   A2   A3   A4   A5   B4   C1   C2   C3   C4   D    │  ΔCRF(100) ΔT(100) Completeness
+       ───────────────────────────────────────────────────────────────────────────────────────
+      ●╲                                              ╱●     │
+       ╲╲─────────────●────                        ╱╱╱        │   ← CLT structural (red RT)
+        ╲▓●─────●──────▓▓▓▓▓▓▓▓▓▓▓▓▓▓●────●─────●▓▓●          │   ← CLT structural (blue PT, shaded)
+                                                              │
+      ●─────●─────●─────●─────●─────●─────●─────●─────●       │   ← Spray-foam (red RT, flat at zero benefit)
+      ●╱╱╱╱●╱╱╱╱●╱╱╱╱●╱╱╱╱●╱╱╱╱●╱╱╱╱●╱╱╱╱●╱╱╱╱●╱╱╱╱●          │   ← Spray-foam (blue PT, above red = liability)
+                                                              │
+       (etc., one pair per component)                         │
+       ───────────────────────────────────────────────────────────────────────────────────────
+       (summary row: building-level totals at each output axis)
+```
+
+Sub-totals per component live in the row strip beneath the chart, with a final row for the **building-level total ΔT(100) in °C·year** — the headline number for the building, accumulated across all component trajectories.
+
+### 3.4.6. Metric on the building-level total — °C·year vs. W·m⁻²·year
+
+Andy asked: *"total impacts in terms of °C temperature change... unless I am mistaken."* The mapping:
+
+| Metric | Unit | What it represents | When to use as the headline |
+|---|---|---|---|
+| **Cumulative Temperature Response** ∫ΔT(t)dt | **°C·year** | Integral of temperature change vs time. *Intuitive for practitioners* — directly speaks to "how much warming we caused over the period." | **The practitioner-friendly headline.** Recommended as the primary big-number on the bottom summary row. |
+| **Cumulative Radiative Forcing** ∫ΔRF(t)dt | W·m⁻²·year | Integral of radiative forcing vs time. *Rigorous methodology-aligned headline* — what CCLIMB §4.2.1 and Appendix A specify as the GWP100-comparable metric. | The reportable headline in EPDs and methodology-compliant outputs. Used in tables, not the at-a-glance display. |
+
+So **both metrics show up**, but their roles are different:
+- Big bold number at the top right of the chart (°C·year) — what the practitioner *feels*.
+- Small precise number in the export table (W·m⁻²·year as ΔCRF(100y)) — what the EPD annex *requires*.
+
+Both are computed; both are exportable; the dashboard shows °C as the love-at-first-sight metric, W·m⁻²·year as the rigorous companion. Per CCLIMB §4.2.3 + Critical Note in §5.2.4, neither value can be reported in CO₂e terms or used as a carbon credit / offset.
+
 ### 3.5. Per-category input requirements (axis vocabulary)
 
 Folding in **Table from CCOB §6 (p.12–13)** — what each feedstock category requires as input. This drives which axes are *editable* for each feedstock the user selects, and which axes get defaulted from RT-A archetypes.
@@ -454,15 +499,79 @@ v1 ships the methodology faithfully for the *bulk* of carbon-storing building pr
 
 ---
 
-## 7. Open questions for the 3pm call
+## 7. Questions for the working-group call
 
-1. **Working-group adoption of the IRF model.** Is there a preferred climate model (FaIR? OSCAR? Bern reduced-complexity?) the methodology will mandate, or is "AR6-consistent" sufficient and tools choose?
-2. **T_ref calibration.** Is ~250 years the final number, or pending?
-3. **Tier 2 timeline.** Is Category D / timber going to be in v2 of the methodology, and on roughly what horizon?
-4. **EPD requirements.** Does the methodology contemplate eventual mandatory inclusion in EN 15804+A2 / ISO 21930, or remains a supplementary annex forever?
-5. **Calculator certification.** §6 lists Calculator requirements but no certification process. Is there a plan for vetting which engines comply? (Direct relevance to BfCA shipping CCLIMB-app as a public tool.)
-6. **Connection to GWP-bio in EPDs today.** Many EPDs publish `GWP-bio per stage A1/A2/A3...` (workplan §11). How does CCLIMB's `A1 carbon storage` input relate to / replace / augment that? Same number, different framing, or genuinely different?
-7. **Default decay rates.** §3 references "US EPA WARM model" for landfill/incineration. Is that the working-group consensus, or a placeholder for a future Canada-context source?
+These are framed for direct discussion, not just internal flags. Order roughly by how load-bearing the answers are for BfCA's CCLIMB-app implementation.
+
+### 7.1. Climate model — mandated or implementer's choice?
+
+CCLIMB §6.2 specifies "AR6-consistent" impulse-response or emulator-based models, but doesn't mandate a specific one. Different calculators implementing different IRFs (Bern reduced-complexity vs FaIR vs OSCAR vs Joos et al. 2013) will produce *different* ΔCRF and ΔT values for the same input inventory.
+
+**Question for the group:**
+- Will the methodology eventually mandate a specific IRF (which one, and on what timeline)?
+- Or stay implementer-choice but require disclosure (calculator declares which model + parameters)?
+- Without convergence, ΔCRF(100y) values reported across calculators won't be comparable. Is that an acceptable v1 state?
+
+### 7.2. T_ref calibration — 250 years final or pending?
+
+CCLIMB §5 marks T_ref ≈ 250 years as "provisional." Completeness C(H) is computed relative to T_ref, so the number is load-bearing — a different T_ref shifts every reported completeness.
+
+**Question for the group:**
+- What's the path to finalizing T_ref? Working group vote? Literature alignment? Specific scientific reference?
+- Should CCLIMB-app expose T_ref as a configurable parameter pending finalization, or lock it at 250 yr and re-release when the working group settles?
+
+### 7.3. Tier 2 / Category D (timber) timeline
+
+CCLIMB v1 defers timber to v2. But timber (CLT, glulam, LVL, dimension lumber) is *most* of the structural-mass-timber EPD market and one of the biggest carbon-storage stories in modern construction. Without Tier 2 support, CCLIMB v1 covers maybe half the materials practitioners care most about.
+
+**Question for the group:**
+- Is there a target timeline for Tier 2?
+- Is BfCA welcome to propose an interim Tier 2 treatment that the working group can vet against the eventual final spec?
+- For products with *combined* feedstocks (e.g. wood-cement composites — Cat A or C residue + Cat D timber), how does v1 handle them? §4 "Combined Feedstocks" says classify each independently; does that mean the timber portion gets *excluded* from CCLIMB analysis until v2?
+
+### 7.4. Calculator certification process
+
+CCLIMB §6 lists Calculator Requirements (scope, scientific basis, gas coverage, temporal treatment, transparency, etc.) but doesn't specify *how* a calculator's compliance is verified or by *whom*. If BfCA ships CCLIMB-app as a public tool, on what basis does a practitioner trust that it computes correctly?
+
+**Question for the group:**
+- Is there a planned governance / certification body?
+- Will there be a reference test-suite (input → expected output) that calculators can self-verify against?
+- For now, what's the disclosure expectation — "this app implements CCLIMB methodology v1.0 with documented deviations: X, Y, Z"?
+
+### 7.5. EPD-annex normative status
+
+Appendix A defines CCLIMB results as "supplementary information only" — outside the core ISO 14025 / EN 15804+A2 indicator tables. Practitioners reading an EPD might miss it; PCRs may not yet have a slot for it.
+
+**Question for the group:**
+- Is there a path toward CCLIMB ΔCRF(100y) becoming a *normative* indicator in some PCRs (especially for biogenic-carbon-rich product families)?
+- For early adopters (BfCA, Vancouver building requirements, etc.) who want CCLIMB-style time-explicit reporting alongside GWP100, what's the formal sanctioning mechanism short of methodology adoption by an SDO?
+
+### 7.6. Connection to existing GWP-biogenic reporting in EPDs
+
+Many EPDs today already publish per-stage `GWP-bio` (carbon dioxide-equivalent biogenic emissions per LCA module A1, A2, A3, etc. — see [`../workplans/EPD-Parser.md`](../workplans/EPD-Parser.md) §11 and Mélanie's 2026-05-05 answers). This is the inventory data CCLIMB ingests as Step 1 inputs.
+
+**Question for the group:**
+- Is the GWP-bio per-stage already in EPDs *the same number* CCLIMB ingests as A1/A3/etc. carbon flow, or are there definitional differences (BCRP vs GWP-bio vs material-content-derived calculations)?
+- For products with multiple biogenic components, how does CCLIMB handle the per-component allocation? (Tied to the §3.4.5 multi-line stratification question — does the methodology require per-feedstock breakdown, or only per-product aggregate?)
+
+### 7.7. Default decay rates — US EPA WARM or future Canada-context
+
+CCLIMB §3 references "US EPA WARM model" for landfill / incineration decay rates. For Canadian projects (where BfCA operates and where Vancouver's mandatory EC programs apply), is there a planned Canadian-context source?
+
+**Question for the group:**
+- Is WARM the working-group consensus default, or a placeholder?
+- For the BfCA CCLIMB-app shipping to Canadian practitioners, can we configure WARM as a default but allow user-supplied Canadian decay rates (e.g. from CMHC, ECCC, NRCan studies) as overrides?
+
+### 7.8. Multi-component visualization sanction
+
+(BfCA-specific design proposal, not a methodology question — but worth raising for working-group reaction.)
+
+The BfCA CCLIMB-app proposes a **per-component stratified parallel-coordinates chart** — N red lines (one per material component) + N shaded-blue lines (one per material component) — for whole-building analysis (see §3.4.5). This visualizes per-component climate response across all LCA modules, with building-level totals as a summary row.
+
+**Question for the group:**
+- Does the methodology say anything about per-component vs aggregate reporting at the building scale (Step 9 of the workflow)?
+- Is per-component disclosure *required*, *optional*, or *out of scope* at the WBLCA reporting level?
+- Concern with per-component reporting: it could be interpreted as ranking materials ("CLT good, spray-foam bad") which Appendix A §A.6 explicitly prohibits. **But** showing per-component results in a *neutral comparison frame* (every component compared to its own RT) avoids ranking — each line is just "this material's climate response relative to its own counterfactual." Is the working group comfortable with that framing?
 
 ---
 

--- a/docs/RMI Work/CCLIMB-Workplan2.md
+++ b/docs/RMI Work/CCLIMB-Workplan2.md
@@ -165,43 +165,107 @@ The OBJECTIVE pattern adds another layer that fits CCLIMB perfectly:
 
 That's the central interaction: practitioner pulls service life from 35 → 100 years, watches the blue (PT) curve shift left of red (RT), watches ΔCRF(100) become more negative (cooling effect), watches completeness rise toward 1.0.
 
-### 3.2. Axis layout for CCLIMB
+### 3.2. Axis layout for CCLIMB — one axis per LCA module
 
-Draft axis order (left to right; tunable based on what makes the call narrative cleanest):
+**Clarified by Andy 2026-05-19:** *"Each axis on the PC graph would be an ISO scoped carbon division, i.e. A1, A2, A3, etc."*
 
-```
-INPUTS (sliders, blue editable dots)          |  CALCULATED (red & blue lines)
-─────────────────────────────────────────────────────────────────────────────────────
-LIFESPAN     RT_growth   RT_decay   EOL_inc%  EOL_landfill%  ΔCRF(20)  ΔCRF(50)  ΔCRF(100)  ΔCRF(T_ref)  ΔT(100)  C(100)
-   yr           yr           yr        %            %        Wm⁻²·yr   Wm⁻²·yr   Wm⁻²·yr    Wm⁻²·yr      °C·yr    —
-```
+This is the right framing because LCA practitioners already think in module terms. Putting one axis per EN 15804+A2 module aligns the chart directly with the way EPDs are read, and the way BEAMweb / EPD-Parser stratify data internally. The OBJECTIVE pattern (each axis = one engineering metric) maps cleanly: in CCLIMB, each axis = one life-cycle module.
 
-For the OBJECTIVE-style "Reference" vs "Target" split:
-- **Red line (RT)** — the reference trajectory through the input axes (RT-A defaults: e.g. lifespan = 0 means immediate release, decay 5y) and the resulting output curve through ΔCRF axes
-- **Blue line (PT)** — the project trajectory: user's actual product lifespan, custom RT-B parameters, real EOL mix, resulting in the project's climate response
-
-When the practitioner drags a blue input slider, the blue output recomputes. The red line stays fixed (it's the counterfactual). **The vertical gap between the two lines at each output axis is the climate benefit (or burden) of the project at that horizon.**
-
-### 3.3. Per-phase axis groups (A1 / A3 / A5 / B / C4)
-
-CCLIMB inputs are stratified by EN 15804+A2 phase. The parallel-coordinates chart can have *banded axes* (visual grouping) to make the phase boundaries explicit:
+Draft axis order (left to right):
 
 ```
-│  A1   │   A3   │     A5      │    B      │    C4     │  ↓ Climate response (calculated)
-│ C_A1  │  C_A3  │  C_inc  C_lf│  lifespan │  EOL mix  │  ΔCRF(20)  ΔCRF(50)  ΔCRF(100)  ΔCRF(T_ref) ...
+PRODUCT STAGE  │  CONSTRUCTION  │      USE STAGE       │     END OF LIFE     │ BEYOND │ CLIMATE RESPONSE (calculated)
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  A1   A2   A3 │    A4    A5    │ B1 B2 B3 B4 B5 B6 B7 │   C1   C2   C3   C4 │   D    │ ΔCRF(100)  ΔT(100)  C(100)
+ kgCO2e per module                                                              kgCO2e   Wm⁻²·yr      °C·yr   —
 ```
 
-Banding could be done via background-color zones behind the axis labels (like the OBJECTIVE Refresh/Decarbonize/Optimize button row, but applied to the axis strip). The user immediately reads "these axes are A1 inputs, these are EOL, these are climate response."
+Per-axis interpretation:
+- **A1** = raw material extraction (often negative for biogenic — carbon-uptake during feedstock growth)
+- **A2** = transport from extraction to manufacturing
+- **A3** = manufacturing-stage process emissions
+- **A4** = transport to site
+- **A5** = installation-stage emissions (incl. install-waste decay routed via WARM)
+- **B1–B7** = use-stage (operational + maintenance + replacement); typically near-zero for most carbon-storing materials, B4 replacement carries new A+C of the replacement product
+- **C1–C4** = end-of-life (demolition + transport + waste processing + disposal/release)
+- **D** = beyond-system-boundary credits (recycling potential, energy recovery)
+- **Climate response axes** (right side, calculated only) = ΔCRF(100), ΔT(100), Completeness — collapsed time-explicit response
 
-### 3.4. Per-phase axis groups — the A-D scope Andy raised
+Red line (RT) and blue line (PT) trace through every module axis. **The gap between red and blue at each axis = the per-module carbon flow attributable to the project relative to the counterfactual.** That's a far richer comparison than a single GWP100 number can deliver — at a glance the practitioner sees which modules drive the climate benefit.
 
-Andy's framing in the request — "RT/PT comparison could be done in the form of a parallel coordinate graph for each phase of scoped carbon A-D" — implies *separate* parallel-coordinate views per LCA module, or a master view with phase grouping. Two designs to discuss:
+Phase grouping happens via banded backgrounds behind the axes (Product / Construction / Use / EOL / Beyond / Response), so the eye reads the EN 15804 phase boundaries without needing axis-label noise.
 
-**(a) Master chart with phase banding** (described above). One chart, all axes, with visual grouping. Pros: side-by-side comparison across the full life cycle. Cons: lots of axes.
+### 3.3. Inputs vs calculated axes
 
-**(b) Per-phase mini-charts + master summary chart.** Four small parallel-coordinate widgets (A, B-use, C-EOL, D-credits/benefits) above one master chart that shows the integrated climate response. Pros: legibility per phase. Cons: more code.
+OBJECTIVE distinguishes input (editable, blue dot) vs calculated (small dot) per its legend. CCLIMB inherits that convention:
 
-Likely answer is **(a) for v1** — master with banding — because the OBJECTIVE codebase Andy has already does the single-chart form. (b) is a v2 enhancement when we know what practitioners reach for.
+| Axis category | Editable / calculated | Notes |
+|---|---|---|
+| A1, A3, A5 carbon flows | **Editable** for standalone mode; **pre-filled & editable** for catalogue mode | These are the EPD-supplied module inventories |
+| B4 (replacement) | **Editable** | Models a service-life shortfall — user drags B4 up to simulate early replacement |
+| C1–C4 EOL emissions | **Editable** but derived from EOL mix (Incineration / Landfill / Recycle / Reuse %) and decay rates | Sliders for EOL mix sit *under* the axes, drive the C-module values |
+| D credits | **Editable** | Reuse / recycle credit estimates from EPD or user input |
+| ΔCRF(100), ΔT(100), Completeness | **Calculated only** | Output of the IRF convolution; tiny dots, no drag |
+
+**Service life** lives in the form pane *next to* the chart (not as an axis), because it affects WHICH year each module's flow lands in — that's a time-shift parameter rather than a per-module magnitude.
+
+### 3.4. Service life as a chart-driving parameter (separate from axes)
+
+The lifespan input doesn't deserve its own axis — instead it drives the temporal placement of each module's flow in the underlying convolution. UI sketch:
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Product:  [Dropdown: Glulam beam ▼]    Lifespan: [75] yr   T_ref: [250] yr │
+│                                                                              │
+│  Feedstock category: [C — Perennial regenerative ▼]                          │
+│  Reference Trajectory: [RT-A: –5/+5 default ▼]  or [RT-B custom: g=5 d=5 yr] │
+│  End-of-life mix:  Inc [10]%  Landfill [60]%  Recycle [20]%  Reuse [10]%     │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  [Parallel-coordinates chart — one axis per A1..D + climate response]        │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  Reference (RT) / Project (PT) / Δ / Direction / Completeness rows           │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Dragging the lifespan number from 75 → 25 re-runs the climate calc: the B4-onwards carbon flows shift to earlier years, the IRF convolution sees the EOL release sooner, ΔCRF(100) becomes less negative, the blue line on the climate-response axes moves toward the red line. **Visible, immediate, intuitive.** This is the "demolished after 10 years" pro-rating question I raised earlier — handled natively by the chart.
+
+### 3.5. Per-category input requirements (axis vocabulary)
+
+Folding in **Table from CCOB §6 (p.12–13)** — what each feedstock category requires as input. This drives which axes are *editable* for each feedstock the user selects, and which axes get defaulted from RT-A archetypes.
+
+| Cat | Required PT inputs (axis values user enters or pre-fills from EPD) | Required RT inputs (red-line counterfactual) | Documented additionally |
+|---|---|---|---|
+| **A** Residues / Waste | Biogenic carbon entering product (A1); timing of carbon retention (lifespan); EOL release profile (decay / combustion / landfill) | Counterfactual near-term atmospheric release profile absent product use | Decay assumptions; sensitivity analysis if timing materially affects results |
+| **B** Short-rotation crops | Carbon incorporated; product retention duration; EOL release profile | Continued short-cycle biological turnover profile absent product use | Regrowth cycle length; LULUC excluded unless explicitly in inventory |
+| **C** Perennial regenerative | Same as B | Multi-year regrowth trajectory with standing carbon stock maintained | Harvest cycle duration; explicit statement that harvest does not materially reduce standing stocks |
+| **D** Virgin long-rotation timber *(v2)* | Same | Forest counterfactual trajectory per Timber Tier framework (Tier 1 Commodity / Tier 2 Managed Regional / Tier 3 Stand-Specific) | Tier level disclosed; explicit counterfactual documentation |
+| **E** Engineered atmospheric uptake | Atmospheric CO₂ incorporated; timing of incorporation; durability / stability / decay profile | Baseline: CO₂ remains in atmosphere absent engineered incorporation | Permanence + durability assumptions documented; opportunity cost modeled only if land displacement |
+
+UI mapping: when the user picks a feedstock category in the form pane, the chart's editable-axis set updates accordingly. E.g. picking **A — Residues** enables A1 + A5 + C4 (decay timing) axes, defaults the RT line to RT-A's exponential-decay archetype with the documented k constant. Picking **C — Perennial** enables A1 + B (replacement) + harvest cycle, defaults the RT to "continuous uptake with minimal stock loss." This category-driven UI prevents the user from filling in axes that don't apply to their product type and reduces the chance of methodology mis-application.
+
+### 3.6. The CCOB calculation-workflow diagram as a chart precedent
+
+CCOB Workplan p.14 has a horizontal calculation-workflow diagram showing the module flow:
+
+```
+[Photosynthetic CO₂ removal]  [Biogenic harvest residues]  [Biogenic mfg residues]  [Construction residues]  [Waste incineration / other EOL]
+       A1                              A2                          A3                       A5                          C4
+   (negative)                      (positive)                  (positive)                (positive)            (positive or negative for D credit)
+```
+
+with colored arrows (green = removal, red = emission) on each module. **This is essentially the parallel-coordinates axis layout in a static form.** CCLIMB-app's interactive version replaces the static arrow widths with draggable axis points: practitioner sees the same horizontal module flow they already understand from CCOB documentation, but each point is a value they can adjust to test sensitivity. The continuity with the methodology's own diagram is a UX gift — practitioners don't need to learn a new visualization language.
+
+### 3.7. Whole-building roll-up
+
+For Step 9 of Chris's flowchart (whole-building view), the same parallel-coordinates chart aggregates across products. Two presentations to consider:
+
+**(a) Sum-of-products** — one PT line that's the sum of all products' module flows. RT line is the sum of all products' reference trajectories. Same chart, same axis layout, just bigger numbers. Cleanest.
+
+**(b) Stacked-product overlay** — each product gets its own faint line, the bold blue line is the total. Useful for spotting which products contribute most to the climate response.
+
+Likely answer is **(a) for v1** with a sortable per-product table beneath (which product contributes how much to each module). (b) as a v2 toggle if practitioners ask for it.
 
 ### 3.5. Below-the-chart numerical table (OBJECTIVE-style)
 
@@ -454,7 +518,100 @@ Estimated 8–11 days for v1 alpha. Most of the cost is climate-model implementa
 
 ---
 
-## 11. Outstanding from Andy before P0 starts
+## 11. Methodology evolution — CCOB → CCLIMB
+
+The CCOB first draft (Feb 26, 2023) and the CCLIMB second draft (April 26, 2023) share most of the methodology, but several decisions evolved between them. Worth knowing at the working-group call so the conversation distinguishes "what's settled" from "what's still moving."
+
+### 11.1. Document scope expanded
+
+- **CCOB** = *Carbon Climate Overlay for Buildings* — framed as an "overlay" sitting alongside LCA, focused on buildings.
+- **CCLIMB** = *Carbon & Climate Impact Model for Materials and Buildings* — promoted from "overlay" to "model" + explicitly covering both materials and buildings (consistent with EPD-level + WBLCA-level applicability).
+
+The name change signals broader ambition + clearer methodological standing in the LCA community.
+
+### 11.2. Feedstock categorization refined (4 → 5)
+
+CCOB had four Tier 1 sub-categories: A (Waste), B (Short-rotation), C (Perennial), D (Engineered Atmospheric Uptake).
+
+CCLIMB second draft has five: **C "Perennial systems" was split into C (Perennial regenerative — bamboo, coppice) and a new D "Harvest without depletion" (cork, rubber)**, and the original D became **E (Engineered Atmospheric Uptake)**.
+
+The refinement matters because cork and rubber have *different* counterfactuals than bamboo (no harvest-cycle reset; continuous accumulation absent harvest). CCLIMB-app should respect the five-category structure not the original four.
+
+### 11.3. Tier 1 horizon: 10 yr → 5 yr (in flight)
+
+CCOB used a **10-year horizon** consistently as the Tier 1 categorization criterion. CCLIMB second draft has **both 5-year (in some places) and 10-year (in others)** — the working group has been tightening 10 → 5 but didn't fully sweep the doc.
+
+This is a real working-group decision in flight, not a translation typo. CCLIMB-app v1 should support both as a configurable parameter until the working group settles.
+
+### 11.4. Calculator requirements formalized
+
+CCOB §6 was a short bullet list of calculator-model criteria (IPCC alignment, transparency, CO₂ + CH₄ tracking, LCA-scale suitability, open source).
+
+CCLIMB §6 (now spanning ~30 lines and 10 sub-sections) formalizes this into a Calculator Requirements specification covering: scope and role, scientific basis (AR6 chain), climate system parameters (ECS / TCR), gas coverage, input requirements, temporal treatment, output requirements, transparency, consistency, scenario treatment.
+
+**Implication for BfCA's CCLIMB-app:** the app is itself a "climate calculation engine" per CCLIMB §6.1, and the requirements there are not aspirational — they're how the methodology defines a *compliant* calculator. v1 must meet §6.1–§6.9 minimum or the working group won't recognize CCLIMB-app as a valid implementation.
+
+### 11.5. Appendix A — EPD annex framing (CCLIMB-only addition)
+
+CCOB did not have a formal EPD-annex specification. CCLIMB's Appendix A is *the* mechanism by which CCLIMB results live in EPDs without conflicting with declared GWP100 values:
+
+- **Supplementary information only** — never inside the core environmental impact tables.
+- **Shall not** be used to adjust, offset, or reinterpret declared GWP.
+- **ΔCRF(100y)** is the EPD-reportable headline, with the explicit "comparable in logic to GWP100 but NOT a CO₂e value" framing.
+- Required interpretation statement must accompany every reported result.
+
+The CCLIMB-app's export pipeline (§4.6 above) needs to emit reports that conform to Appendix A — the supplementary section title, the required interpretation statement, the counterfactual-definition disclosure, etc.
+
+### 11.6. Climate-response metric split
+
+CCOB had a single `ΔCR(t)` (climate response) metric. CCLIMB split this into:
+
+- `ΔRF(t)` — radiative forcing response (instantaneous)
+- `∫ΔRF(t)dt` — integrated / cumulative radiative forcing (the GWP100-comparable form)
+- `ΔT(t)` — temperature change response
+
+The split gives practitioners more granular reporting + makes the comparison to GWP100 cleaner. Both axes are reportable.
+
+### 11.7. RT-Low / RT-High demoted to appendix
+
+CCOB §5.1.2–§5.1.3 had RT-Low (optimistic bound) and RT-High (conservative bound) as primary RT archetypes alongside RT-A and RT-B.
+
+CCLIMB second draft kept RT-Low / RT-High in the methodology but moved them to "Draft Reference Trajectories for Tier 2" appendix, since Tier 2 (timber) is deferred to v2. RT-A and RT-B are the only Tier 1 archetypes in v1 of the methodology.
+
+CCLIMB-app v1 only needs to ship RT-A + RT-B. When Tier 2 lands, RT-Low / RT-High come back as the bracket pair for timber counterfactuals.
+
+---
+
+## 12. Interpretation neutrality — load-bearing design principle
+
+CCOB §11 (carried forward as CCLIMB's design ethos): *"CCOB does not declare materials 'good' or 'bad.' Instead, it reports whether building use delays or accelerates atmospheric return relative to each reference trajectory, and how that timing translates into radiative forcing and temperature response over time. Climate benefit or disbenefit exists only relative to a defined reference trajectory and is determined solely by the time-explicit comparison of trajectories. (Rationale: Reinforces 'let results speak' neutrality.)"*
+
+This is non-negotiable for the BfCA CCLIMB-app:
+
+- **No ranking** of materials, no "best to worst" lists, no green-checkmark / red-X scoring.
+- **No recommendations** ("you should choose CLT over concrete") — the app only reports the time-explicit comparison.
+- **No defaults that imply judgment** — when the user picks RT-B custom, no auto-fill that biases toward "favorable" counterfactual assumptions.
+- **Three semantic layers in the output panel** (also from CCOB §9 Reporting requirements):
+  - **Carbon storage (state)** — how much carbon is in the product at any given time. *Factual.*
+  - **Delayed emissions (mechanism)** — what's been deferred from atmosphere vs counterfactual. *Mechanistic.*
+  - **Climate benefit or disbenefit (conditional interpretation)** — the ΔCRF(100y) value with the explicit "relative to specified RT" caveat. *Interpretive.*
+
+The output panel should visually separate these three layers so practitioners can't accidentally read the state value as a benefit claim. Likely UI: three rows, three different colors, three explicit labels.
+
+### 12.1. What this rules out for the app
+
+- A "decarbonize my building" optimizer that picks materials. CCLIMB-app does not optimize — it reports.
+- A "score" or "grade" assigned to a product based on its ΔCRF. The methodology is intentionally bound to relative comparison against an explicit RT; an absolute score would force a hidden RT.
+- A leaderboard / catalogue ranking by ΔCRF — same reason.
+
+### 12.2. What this enables
+
+- A practitioner brings their *own* RT-B custom inputs (regional regrowth rates, project-specific lifespans), and the app *shows them the result*. The practitioner — not the app — assigns "benefit" or "disbenefit" meaning.
+- Side-by-side scenario comparison (two PT lines, one RT line) — the practitioner sees how different lifespan assumptions move the climate response, and reports both as alternative scenarios.
+
+---
+
+## 13. Outstanding from Andy before P0 starts
 
 - [ ] **Working-group decisions** from the 3pm call — particularly which IRF model is mandated and whether T_ref locks at 250 yr.
 - [ ] **OBJECTIVE D3 codebase** — Andy's existing parallel-coordinates implementation. Where it lives, what its current axis API looks like, what state-management it expects.

--- a/docs/RMI Work/CCLIMB-Workplan2.md
+++ b/docs/RMI Work/CCLIMB-Workplan2.md
@@ -165,9 +165,107 @@ The OBJECTIVE pattern adds another layer that fits CCLIMB perfectly:
 
 That's the central interaction: practitioner pulls service life from 35 → 100 years, watches the blue (PT) curve shift left of red (RT), watches ΔCRF(100) become more negative (cooling effect), watches completeness rise toward 1.0.
 
-### 3.2. Axis layout for CCLIMB — one axis per LCA module
+### 3.2. Axis layout — CORRECTED 2026-05-19 PM mid-call
 
-**Clarified by Andy 2026-05-19:** *"Each axis on the PC graph would be an ISO scoped carbon division, i.e. A1, A2, A3, etc."*
+> **Important semantic correction from Andy mid-call:** *"The Reference Trajectory is not 'another material' — but what would happen if that feedstock DID NOT flow into a construction material, such as burning sugarcane stock instead of turning it into structural panels. So Reference is unmitigated material flow, and Project Trajectory is what happens when that material becomes a carbon sequestering building material. So scoped phases for vertical axes may not make as much sense."*
+>
+> The earlier draft (LCA modules A1, A2, A3 ... as axes) treated RT and PT as if they could both be stratified by EN 15804 module. But **RT does not have an A1/A3/A5** — RT is an *unbounded counterfactual atmospheric flow over time*, not a module-stratified inventory. PT *is* stratified by EN 15804 module (because the project commits carbon at specific module events: A1 at Year 0, A5 at Year 0, C4 at Year = lifespan). But the comparison RT-vs-PT happens in the **time domain**, not the module domain.
+
+### 3.2.A. Corrected axis layout — TIME HORIZONS as axes
+
+Each axis = a time horizon (Year 0, Year 5, Year 20, Year 50, Year 100, Year T_ref ≈ 250). Each axis value = the **cumulative atmospheric carbon emission** at that horizon (in kgCO₂e or per-functional-unit equivalent).
+
+```
+   Y0     Y5     Y20    Y50    Y100   Y250(Tref)  │  dCRF(100)  dT(100)  Completeness(100)  Direction
+   ───────────────────────────────────────────────────────────────────────────────────────────────────
+   ●──────●──────●──────●──────●──────●           │   value     value    value              cooling
+       (red — Reference Trajectory)              │
+   ●──────●──────●──────●──────●──────●           │   value     value    value              cooling
+       (blue, shaded — Project Trajectory)        │
+```
+
+Per-axis interpretation:
+- **Y0** = cumulative emission to atmosphere *at installation* (negative for RT if feedstock was just harvested but not yet released; negative for PT since A1 deposits carbon into the building)
+- **Y5** = cumulative emission *5 years post-installation*. For RT-A default_5 trajectory, this is roughly where the feedstock would have fully decayed under counterfactual. For PT, this is still mostly storage.
+- **Y20, Y50** = the meaningful storage-benefit horizons (RT has fully released; PT still holds)
+- **Y100** = the GWP100-comparable horizon; ΔCRF(100) is the EPD-reportable headline
+- **Y250 (T_ref)** = full reference completeness — by this year the PT has also fully released its carbon (typically, for non-permanent storage)
+
+Per-line interpretation:
+- **Red line (RT — per material)** traces the counterfactual cumulative emission through time. For an RT-A default_5 archetype, by Year 5 the line crosses the initial carbon stock (full release).
+- **Blue line, shaded (PT — per material)** traces the project's cumulative emission through time. For a glulam beam with 75-year lifespan, the curve stays *much lower* than RT through Year 0–75, then jumps at Year 75 + decay tail.
+
+**The shaded area between blue and red is the climate benefit** at each horizon. Lower blue = more atmospheric carbon avoided at that point in time. The chart at-a-glance shows where the storage benefit is largest and when the post-EOL "catch-up" happens.
+
+### 3.2.B. The output axes (right side, calculated)
+
+After the time-horizon axes, divider, then climate-response output axes:
+
+| Axis | Unit | Computed from |
+|---|---|---|
+| **ΔCRF(100)** | W·m⁻²·year | ∫₀¹⁰⁰ ΔRF(t) dt — the GWP100-comparable EPD-reportable |
+| **ΔT(100)** | °C·year | ∫₀¹⁰⁰ ΔT(t) dt — practitioner-friendly headline |
+| **Completeness(100)** | — | C(100) = ΔT(100) / ΔT(T_ref) |
+| **Direction** | — | cooling (negative ΔCRF) / warming (positive) |
+
+Per-material RT vs PT lines populate the time-horizon axes; the output axes show building-level totals at the rightmost end.
+
+### 3.2.C. What still works from the earlier (rejected) module-based design
+
+- **Multi-component stratification** (N red + N blue lines, one pair per material). Still correct — each material gets its own RT vs PT trajectory pair traced through time. See §3.4.5.
+- **Phase grouping via banded backgrounds**. Still useful, but for the TIME axes now: "First decade" / "20–50 yr" / "Use period" / "Beyond completeness" colored bands behind axis labels.
+- **Per-component summary table beneath the chart**. Unchanged.
+
+### 3.2.D. Where the EN 15804 module structure DOES live in the UI
+
+PT's module-stratified inventory (A1, A3, A5, B4, C4) is still load-bearing — that's the data feeding into the curve. It lives in the **form pane** (left side of the screen):
+
+```
+┌──────────────────────────────────────────────────┐
+│  Product: Glulam beam                            │
+│                                                  │
+│  Inventory (kgCO₂e per declared unit):           │
+│    A1:  -1000   (feedstock carbon)               │
+│    A3:     50   (manufacturing)                  │
+│    A5:     15   (install waste)                  │
+│    B4:      0   (no replacement)                 │
+│    C4:    +1000 (EOL release at Year 75)         │
+│                                                  │
+│  Feedstock:    [C — Perennial regenerative ▼]    │
+│  Lifespan:     [75] years                        │
+│  RT:           [RT-A: −5/+5 ▼]                   │
+│  EOL mix:      Inc[10] LF[60] Rec[20] Reuse[10]  │
+└──────────────────────────────────────────────────┘
+```
+
+The form pane is the *module-domain* input; the chart is the *time-domain* output. They're synchronized — change a module value, the PT curve in the chart updates.
+
+### 3.2.E. Scaffold-code revision needed
+
+The Phase-0 scaffold committed in `7a6ef51` (file `js/cclimb/chart-config.mjs`) defines `LCA_MODULES` as axes. That's the now-superseded design and gets revised in the next commit. The new shape:
+
+```js
+// chart-config.mjs (revised)
+export const TIME_HORIZONS = [
+  { id: "Y0",    label: "Year 0",    years: 0,   phase: "install" },
+  { id: "Y5",    label: "Year 5",    years: 5,   phase: "early" },
+  { id: "Y20",   label: "Year 20",   years: 20,  phase: "service" },
+  { id: "Y50",   label: "Year 50",   years: 50,  phase: "service" },
+  { id: "Y100",  label: "Year 100",  years: 100, phase: "gwp_comparison" },
+  { id: "YTref", label: "Year 250",  years: 250, phase: "full" }
+];
+
+export const OUTPUT_AXES = [
+  { id: "dCRF_100", label: "ΔCRF(100)", unit: "W·m⁻²·yr", calculated: true },
+  { id: "dT_100",   label: "ΔT(100)",   unit: "°C·yr",    calculated: true },
+  { id: "C_100",    label: "Completeness(100)", unit: "—", calculated: true },
+  { id: "direction", label: "Direction", unit: "—", calculated: true }
+];
+```
+
+The PT-inventory form-pane fields (A1, A3, A5, B4, C4, lifespan, EOL mix) move to `js/cclimb/inventory-form.mjs` (NEW, P0.5) where they belong as form bindings rather than chart axes.
+
+### 3.2.F. Original (rejected) module-based axis design — kept for historical reference
 
 This is the right framing because LCA practitioners already think in module terms. Putting one axis per EN 15804+A2 module aligns the chart directly with the way EPDs are read, and the way BEAMweb / EPD-Parser stratify data internally. The OBJECTIVE pattern (each axis = one engineering metric) maps cleanly: in CCLIMB, each axis = one life-cycle module.
 

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -6,152 +6,125 @@
 
 ## Agent handoff (read this first)
 
-**You are picking up at 2026-05-11 evening, with no active branch and TWO decision-points still gating further code work.** PR #18 merged into main on both remotes 2026-05-11 (`dc7040d` on openbuilding, mirrored to origin via realign — both now at `78565a8` after the Pages-workflow guard widening). No active sprint branch. Andy ended the prior session with: *"we will continue EPD parser work tomorrow."*
+**You are picking up at 2026-05-19 evening, end of an extended field-tuning marathon session. Active branch: `EPD-PARSER-5` with 9 commits since main, pushed to both remotes, no PR open yet.** Andy made an important strategic clarification at the end of the day that's now captured in §14 — read it before doing any extraction work. *"This process seems exhausting. Will we get to 90% or 100% coverage at this rate?"* The honest answer was no; the path to 90%+ is LLM-as-parser as an internal back-of-house tool (§14.3).
 
-**Two decisions are gating further code work** (unchanged since 2026-04-30 — both still need human input):
+**Today's session at a glance (2026-05-19):**
 
-1. **§11.10 — Monday review with Mélanie on biogenic-calc.** Mélanie's 2026-05-05 answers (§11.8) significantly expanded C-fb6 scope from ~3 hrs to ~19 hrs across 7 sub-commits (§11.9). Six items still need her sign-off (§11.10): schema-field locations, `storage_cycle` enum values, Phyllis 2 curation, material-content extraction architecture, legacy 821-record migration, validation tolerance. Gates C-fb6 implementation.
+1. Andy cut `EPD-PARSER-5` off `main` (78565a8) for the day's work.
+2. Per-pattern hit-count audit shipped to the harness (§12.5 item 1) — `IMPACT_INDICATORS` / `_BYSTAGE_LABELS` / `_CISC_LABEL_PATTERNS` get DEAD-tagged when 0 hits across the audit set.
+3. Andy resolved the BfCA Drive-share blocker (BfCA had download-disable on the original folder; resolved via a separate share). Two new sample folders staged at `docs/PDF References/EPD-scaling-sets/`:
+   - `EPDs to consider for v1.1 update/` — 116 candidate PDFs for the next catalogue update.
+   - `Existing BEAM Database EPDs/` — 208 PDFs from BfCA's archive (may or may not be currently catalogued; the parity matcher sorts them).
+4. Two scaling-audit snapshots + the §12.3 decision dataset committed (`55247fc`).
+5. Catalogue-parity matcher built and shipped (`bd12ef9`) — for each candidate, scores against the 821 records in `schema/materials/*.json` and emits match category + field diff. Surfaced **~10–20 catalogue rows with unit-misencoded density values** (e.g. `mpa000` aluminum at 2.07 kg/m³, `1f3cc3` fiberglass at 0.488 kg/m³). NOT a parser problem — a catalogue-side data-quality issue that the parser now flags.
+6. Mélanie review draft for §11.10 written at `docs/workplans/melanie-review-draft-2026-05-19.md` (`9303991`). Andy's decisions on Q1 (`methodology.beam_calc.*`), Q2 (`long_cycle | short_cycle`, medium deferred), Q5 (`legacy_unknown` flag), Q6 (two-tier ±0.1% / ±5%) are baked in. Phyllis 2 starter shortlist drafted (20 entries) with `// is this right?` markers on the 5 entries needing Mélanie's review. **Pending Andy's red-line pass before sending.**
+7. Five field-tuning passes shipped (manufacturer/epd.id; dates; type/validation; density; material_type). See "Branch state" below for the SHA chain.
+8. Strategic clarification (`§14`, this session): EPD-Parser is **internal back-of-house BfCA tooling**, not public-facing. The materials catalogue is the same. BEAMweb / PDF-Parser / Matrix / DB-read are public-facing; EPD-Parser + DB curation are not. This unlocks LLM-as-parser as a Tier-8.5 extension (Claude API call on BfCA staff workstations to fill the long-tail fields regex can't reach). See §14 in full.
 
-2. **§12.3 — Andy's choice between Option A (geometric table extraction) / Option B (declarative format library) / Option C (HITL form-pane UX) / hybrid.** Gates any further per-format extractor work. Reminder from §12: *"You seem to be in a loop making highly customized readers for a handful of specific EPDs where we need GENERALIZED functionality for ANY EPD the Parser loads."* — DO NOT add new entries to `IMPACT_INDICATORS`, `_BYSTAGE_LABELS`, `_CISC_LABEL_PATTERNS`, or any analogous list until §12.3 lands. Mélanie's expanded C-fb6 scope (material-content + biogenic-inventory table extraction) is itself a per-format extraction problem — compound-gated on §12.3 too.
+**Decisions still gating downstream work:**
 
-**The larger EPD sample directory exists** (Google Drive folder `1B5ilRZ-exHRZSbqIh3MYNpZFk7KuhBIO` titled "New EPDs for 2022 DUMP- STOP DUMPING!", shared with Andy 2026-05-11). The Drive API can see the folder metadata but couldn't enumerate its contents — either indexing lag on the fresh share OR Drive sharing scope doesn't extend list-children permission to API clients. **Plan:** Andy downloads the folder to local disk (Drive web UI → kebab → Download → unzip), then runs the harness:
-```bash
-node schema/scripts/test-epd-extract.mjs --root /path/to/unzipped/EPDs
-```
-The harness (workplan §12.6) accepts `--root <dir>` to walk any directory of PDFs. The per-format breakdown + per-parameter aggregate hit-rate (workplan §12.5) is the canonical input to §12.3 — surfaces which formats / fields are most under-served at scale.
+1. **Mélanie review of §11.10 (gates C-fb6).** Draft is ready in `docs/workplans/melanie-review-draft-2026-05-19.md` — Andy hasn't sent yet. Once Mélanie signs off Q3 (Phyllis 2 shortlist), C-fb6.1 (schema bump) → C-fb6.7 (validation harness) can start.
 
-**Infrastructure shipped 2026-05-11 (post-PR-#18 merge, commit `78565a8`):** GitHub Pages now auto-deploys on BOTH remotes via the same workflow. Workflow guard widened from `if: github.repository == 'arossti/OpenBuilding'` to also include `bfca-labs/at`. Both sites live: https://arossti.github.io/OpenBuilding/ and https://bfca-labs.github.io/at/ — identical artifacts, separate Pages sites. Going forward: open PR only on **arossti/OpenBuilding** (canonical), then `git push origin main` after merge to keep the bfca-labs mirror in sync. This avoids the dual-merge-commit divergence that happened with PR #18 / PR #3 (resolved 2026-05-11 by force-pushing openbuilding/main → origin/main; trees were identical, only merge-commit SHAs differed).
+2. **§12.3 architecture choice — now with Option D added.** §14.6 reframes the decision: Option D (LLM-as-parser, internal CLI) is the recommended path; Option C (HITL form-pane) is complementary. Options A (geometric) and B (declarative) deprioritized. **Andy hasn't formally answered §12.4's questions; treat §14 as the working answer until he says otherwise.** The §12 pause on `IMPACT_INDICATORS` / `_BYSTAGE_LABELS` / `_CISC_LABEL_PATTERNS` inflation **still stands** — the metadata extractor work today did NOT touch those three arrays.
 
-**Coverage state, end of 2026-04-29 (live numbers from `docs/workplans/EPD-coverage-history/2026-04-29T21-47-50Z.md`):**
-- Metadata: **279/420 (66.4%)** across 30 samples (14 fields each)
-- Impact totals: **162/300 (54.0%)** (10 indicators each)
-- Per-stage matrix: **473/5100 (9.3%)** — NEW dimension as of 2026-04-29 PM (10 indicators × 17 EN 15804+A2 stages × 30 samples = 5100 max). 9.3% sounds low because most samples are cradle-to-gate (only A1/A2/A3 published — that's 3/17 stages × 10 indicators × subset of indicators per sample). Cradle-to-grave samples (xcarb 3×, EU/IBU Wood Fibre) reach significantly higher per-sample density.
-- Format detection: na=18, epd_international=2, nsf=2, eu_ibu=1, unknown=7
-- Ground-truth checks: **2/30 samples annotated** (Kalesnikoff GLT, xcarb cold-formed) with 110 expected keys total. All passing — 0 extraction failures, 0 silent-override violations, 0 defaults-applied failures.
+**Coverage state, end of 2026-05-19:**
 
-**Per-sample by_stage state (snapshot as of 2026-04-29T21-47-50Z):**
+After today's 9 commits, three audit sets snapshot in `docs/workplans/EPD-coverage-history/`:
 
-| Sample group | by_stage / 170 per sample | Notes |
-|---|---|---|
-| Kalesnikoff CLT/GLT (cradle-to-gate, NA long-English) | 30 each | Full A1/A2/A3 — published cells exhausted |
-| 2023 BC Wood ASTM (CLT/GLT/SPF/SPF-Plywood) | 15-26 each | Most A1/A2/A3 captured |
-| **xcarb steel (cold-formed/hollow/deck)** | **48 each** | **Full A1/A2/A3/C1/C2/C3/C4/D — module D recycling-credit signs preserved** |
-| Sopra-XPS / Genyk / EU-IBU Wood Fibre | 18-36 each | Decent — could improve in subsequent rounds |
-| 2017/2020 BC Wood AWC industry-avg | 12-18 each | Partial — older format |
-| Concrete CRMCA / EPD International S-P-10278 (×2) / Fab Steel Plates | 9-19 each | Minimal — distinct format families |
-| 2013 LVL / 2016 WRC (older AWC industry-avg) | 0 | **Correct.** EPDs publish only `Total \| Forestry \| LVL Production` (process breakdown, NOT life-cycle stages) — no per-stage data exists in the source PDF |
-| Lafarge cement (NSF) | 0 | **Correct for now.** Multi-product table (4 cement types in columns), not per-stage. Needs future multi-product UI work to disambiguate |
-| CISC steel | 0 | Not extracted yet — separate "Use of net fresh water 1 mt 2.88E+00" pattern not in regex (see follow-up #2) |
-| 7 unknown-format samples (Sopra Cellulose/ISO, Polyiso, Boreal TDS, etc.) | 0 | Format detection gives up; mostly scanned PDFs / TDS docs / no-EPD references |
+| Set | n | Metadata | Notable |
+|---|---:|---|---|
+| Canonical 30 (regression baseline) | 30 | 69.5% (was 66.4%) | material_type 83%, manufacturer 70%, epd.id 67% |
+| v1.1-candidates | 116 | 65.6% (was 55.9%) | manufacturer 60%, epd.id 65%, pub_date 66% |
+| Existing BEAM | 208 | 66.1% (was 60.4%) | display_name 100%, epd.id 64% (was 23%) |
 
-**What shipped 2026-04-29 (chronological, all on `EPD-PARSER-SPRINT-2` then merged to main as PR #16):**
+Day's net delta: **+3pp canonical, +9.7pp v1.1, +5.7pp Existing BEAM** on metadata aggregate. Impact + by_stage unchanged (no `IMPACT_INDICATORS` / `_BYSTAGE_LABELS` touched).
 
-| SHA       | Scope                                                                                                                                       |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `6347183` | **C-fb1.1** — Wood alias resolution in db-fallbacks (TIMBER → "Wood" canonical + 13 aliases for Glulam / CLT / GLT / LVL / LSL / etc.)      |
-| `44fc4f1` | **§9.5 fix #5** — Kalesnikoff long-English impact extraction + display_name from `Group \| Type` taxonomy + per-glyph header skip + q-optional unit |
-| `28f48d3` | **§9.5 fix #6** — Mass-per-declared-unit density + "produced by/at" manufacturer prose fallback + EPD-ID truncation post-process            |
-| `7176915` | **C-fb5** — harness ground-truth verification (extraction fidelity / defaults applied / no silent overrides; first annotated: Kalesnikoff GLT) |
-| `ca025ee` | archive interim coverage snapshot                                                                                                            |
-| `43f0cf3` | **DB viewer** — duplicate-EPD detection on Trust (over-write prompt) + × remove button on `_fresh` rows (catalogue-immutable) + BEAM ID col 96px → 140px |
-| `ae20837` | **P3.3** — per-stage breakdown extraction (A1/A2/A3/.../D) with nearest-header-by-count selection; 30 by_stage ground-truth keys added       |
-| `9a073cc` | EPD-Parser.md handoff section refresh                                                                                                        |
-
-**What shipped 2026-04-29 evening on `EPD-PARSER-SPRINT-3` (current active branch, +3 since merged main `046108a`):**
-
-| SHA       | Scope                                                                                                                                       |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `607a4ed` | **Shared text-join module** — `js/shared/text-join.mjs` extracts `_itemsToLines` + `_flushLine` so the harness uses identical logic to the browser (without this, the harness was falsely-green for browser-specific pdf.js fragmentation bugs — rev-3's sign-stripping was exactly that). +4 metadata, 1 silent-false-positive removed. |
-| `0c2c70d` | **§11 Biogenic Calculations chapter (review-pending)** — drafts the principle (EPD as single source of truth, BEAM as normalization-only for BEAMweb hybrid components). Six concrete questions for Mélanie's review in §11.8. Once signed off, C-fb6 (Tier 10 implementation) is ~3 hrs of mechanical work. |
-| `34570bc` | **by_stage harness dimension + xcarb per-stage extraction + density thousand-comma fix.** Harness now tabulates per-stage coverage; `_BYSTAGE_LABELS` extended for bracketed-unit short codes (xcarb/IPCC AR5/TRACI 2.1 family); unit-cell-skip in tokenizer prevents misaligned values; density regex now handles "7,800" form (xcarb density bug fixed: 800 → 7800). xcarb cold-formed annotated as ground truth (56 keys, all passing). |
+**Catalogue-parity check on Existing BEAM 208 (after today's lifts):**
+- strong: 33 (16%)
+- strong-multi: 23 (11%)
+- medium: 4 (2%)
+- medium-multi: 42 (20%)
+- weak: 76 (37%) — noisy, threshold tuning deferred
+- **unmatched: 30 (14%)** — the catalogue-update candidates BfCA should review
 
 ### Pickup — what you're doing next
 
-**Do NOT add new format-specific patterns to `IMPACT_INDICATORS`, `_BYSTAGE_LABELS`, or any analogous list until §12.3 is resolved.** This was the explicit reason for today's pause. The audit data the harness now produces (per-format breakdown + per-parameter aggregate hit-rate, §12.5) is the input to that decision.
+The branch is at a clean stopping point. Most likely user-driven next moves:
 
-When Andy returns:
-1. Resolve §12.3 (architecture choice) — answer the 5 questions in §12.4.
-2. If Option A or B chosen: refactor begins. Existing per-format patterns may be deprecated.
-3. If Option C chosen: shift focus to form-pane UX work.
-4. Independently: chase §11.8 with Mélanie to unblock C-fb6.
-5. When Andy supplies the larger sample directory tomorrow:
-   - Run `node schema/scripts/test-epd-extract.mjs --root <dir>`.
-   - Examine per-format breakdown + per-parameter aggregate. This is the canonical scaling test.
-   - Per-pattern hit-count audit (which existing patterns matched 0 samples in the larger set?) drives deprecation candidates.
+1. **Open the PR for `EPD-PARSER-5`.** 9 commits, clean lineage, all pushed. Title suggestion: *"EPD-Parser: per-pattern audit + catalogue parity + 5-pass metadata lift + §14 strategic positioning"*. This is the natural unit of review.
 
-### Open follow-ups (next agent to triage)
+2. **Mélanie draft pending Andy red-line.** Check `docs/workplans/melanie-review-draft-2026-05-19.md`. Has an "Andy's review notes" checklist at the bottom. When Andy says it's ready, send through whatever channel BfCA uses.
 
-Listed with concrete repro / fix sketches so the next agent can pick the highest-leverage one without re-discovering context.
+3. **Prototype LLM-as-parser (§14.5 step 2).** Andy didn't authorize this yet but it's the natural next step. ~30 min to wire a Claude API call against 10 wild v1.1 samples + JSON-Schema-as-system-prompt, compare LLM output vs regex output. Confirms or refutes the 90%+ claim with hard data.
 
-**Follow-up #1 — Mélanie's review of §11 (gates C-fb6).** Send Mélanie the link to §11 of this workplan. The six questions in §11.8 are designed to be answerable with short / yes-no replies. Once back: ~3 hrs of mechanical implementation produces Tier 10 (`applyCalculations(rec)` in `js/epd/extract.mjs`) with 3 new schema fields and the form-pane audit-trail render. Validation harness against `BEAM Database-DUMP.csv` cols 24, 25, 28, 29, 31, 33 (per-row tolerance ±5%).
+4. **More regex fine-tuning.** Andy explicitly said *"we should continue to refine the Regex and parser as much as possible, but I think now I see the limits and extended solutions."* So additional passes are welcome but expected to deliver diminishing returns. Highest-headroom remaining fields: `epd.type` (37%), `epd.expiry_date` (15% on Existing BEAM), `physical.density` (63%), validation.type (24% on Existing BEAM).
 
-**Follow-up #2 — xcarb "total = A1" false positive.** For cradle-to-gate-with-options EPDs (xcarb 3 samples) that publish per-stage A1/A2/A3/C1-C4/D but NO precomputed A1-A3 composite, the IMPACT_INDICATORS regex in `js/epd/extract.mjs` grabs the FIRST numeric value (which is A1) and stores it as `impacts.<key>.total.value`. For xcarb cold-formed GWP that's 1230 (= A1) instead of A1+A2+A3 = ~1257. Choose one of:
-   - **(a)** After `_extractByStage` runs, if `total.value` is null AND `by_stage.A1`, `by_stage.A2`, `by_stage.A3` are all populated, compute `total.value = A1 + A2 + A3` and mark `source: "calculated"`. Most accurate.
-   - **(b)** When stage-header lacks the A1-A3 composite, suppress total-extraction entirely and rely on by_stage. Cleanest semantically.
-   - **(c)** Status quo (currently shipped) but mark with a comment in `methodology.notes` flagging that total = A1 only.
-   
-   See xcarb cold-formed ground truth notes for the documentation. Not currently asserted (so it doesn't fail the harness today).
-
-**Follow-up #3 — CISC water "Use of net fresh water 1 mt 2.88E+00" pattern.** CISC Industry-Avg Steel publishes WDP as `Use of net fresh water    1 mt    2.88E+00` (with the `1 mt` functional-unit prefix between label and value, breaking the existing EU/IBU "fresh water" regex's adjacency). Add a regex variant catching this. Tests: CISC by_stage 0/170 → ≥1/170 (just WDP), and aggregate impact totals 162 → 163.
-
-**Follow-up #4 — Lafarge multi-product disambiguation.** Lafarge cement EPD covers 4 cement types (GU/HS, GUL/HSL, HE, OWG) in COLUMNS of the impact table, not life-cycle stages. The current extractor grabs the first cement-type column as the indicator value. Properly fixing this requires a "pick which product" UI in the EPD-Parser form pane (workplan §0 phases-pending: "Multi-product EPD disambiguation"). Same pattern applies to Genyk (3 SPFs) and AWC/CWC industry-avg (multi-product). Estimated 3-4 hrs of UI + state work.
-
-**Follow-up #5 — Per-stage extension to other formats.** Current per-stage coverage: Kalesnikoff 30/170, xcarb 48/170, Sopra-XPS 36/170, Genyk 31/170. To reach higher density on Sopra/Genyk/EU-IBU/2023 BC Wood, audit which `_BYSTAGE_LABELS` patterns aren't matching and either tighten or add variants. Driven by ground-truth annotation: pick a sample, annotate, run harness, see what fails.
-
-### Branch state (2026-05-11 evening)
+### Branch state (2026-05-19 EOD)
 
 ```
-main   78565a8   ci: enable Pages workflow on bfca-labs/at (2026-05-11)
-        ↑
-       dc7040d   Merge PR #18 from arossti/EPD-PARSER-4 (2026-05-11)
-       d73cffe   §11 Mélanie biogenic answers + revised C-fb6 scope
-       394cbea   §12 architecture review + harness --root + audit
-       3839b47   cradle-to-gate-with-options total recompute + CISC compact-label per-stage
-       3fd57e2   Merge PR #17 (2026-04-30)
+EPD-PARSER-5 (both remotes):
+  1ab6301   Pass 4: material_type vocab + title-picker fixes
+  7b54f2b   Pass 3: density extraction lift (modest)
+  63de94f   Pass 2: epd.type + validation.type extraction lift
+  3429602   Pass 1: date extraction lift (DD.MM.YYYY + new labels)
+  b0bc986   manufacturer + epd.id extraction lift (+20–41pp recall)
+  9303991   Mélanie draft — fold in catalogue-parity findings
+  bd12ef9   Catalogue-parity matcher + 208-sample audit
+  55247fc   §12.3 decision data — scaling audit on 324 PDFs
+  202b5a1   Per-pattern hit-count audit (§12.5 item 1)
+         ↑
+  main 78565a8 (unchanged since 2026-05-11)
 ```
 
-No active sprint branch. Both remotes synced at `78565a8`. Both Pages sites deployed and live. The `3839b47` CISC commit added per-format extraction patterns; flagged in §12.2 as per-EPD baggage, **may be deprecated** depending on §12.3 decision (Option A geometric would replace it; Option B declarative would relocate it; Option C HITL would deprecate it in favour of form-pane UX). No PR open until either §11.10 (Mélanie) or §12.3 (Andy) lands.
+PR not yet opened. When ready: open on `arossti/OpenBuilding` (canonical), then `git push origin main` post-merge to keep `bfca-labs` mirror in sync.
 
 ### Read this order
 
-1. §0 — current state (full SHA log + coverage trail)
-2. **§11 — Biogenic calculations (review-pending)** — read in full before C-fb6; especially §11.1 (EPD as single source of truth) and §11.8 (the six questions for Mélanie's review). The BEAM CSV math is documented; only the schema-field naming + storage-factor convention need sign-off.
-3. **§10 — Fallback database (db-fallbacks.json)** — read in full before C-fb5; especially §10.3 (verification before fallback)
-4. §7.6 — Harness contract (the "no regex change ships unless coverage moves up" rule; C-fb5 extends it)
-5. §5.6 — Hierarchical extraction (shipped 2026-04-28; reference)
-6. §9.5 — calibration findings + remaining fix-list (mostly cleared)
+1. **§14 — Internal positioning + Last Mile (new today)** — load-bearing for any architectural decision going forward. Read in full.
+2. §11 — Biogenic calculations (review-pending) — §11.8 (Mélanie answers) and §11.10 (Monday-review items, with Andy's decisions now in the message draft).
+3. §12 — Architecture review — pause is still active for the three pattern arrays.
+4. §10 — Fallback database (db-fallbacks.json) — Tier-9 layer.
+5. §7.6 — Harness contract.
 
-### File map for C-fb5
+### File map (current)
 
-| File                                                 | What you'll touch                                                                                                                                      |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `schema/scripts/test-epd-extract.mjs`                | Extend `main()` with the three new checks. The existing METADATA_FIELDS + IMPACT_KEYS coverage logic stays as-is alongside the new ground-truth check. |
-| `docs/PDF References/EPD SAMPLES/expected/*.json`    | New directory + per-sample ground-truth files. Start with 1–2 annotated samples to prove the pipeline; empty for the rest is fine.                     |
-| `docs/workplans/EPD-coverage-history/<timestamp>.md` | Auto-snapshotted by the harness as usual. New dimensions tabulate as additional rows or columns.                                                       |
+| File / path | What's there |
+|---|---|
+| `js/epd/extract.mjs` | Main extractor. Tier-by-tier (Type → Group → per-format → Common → DB-fallbacks → BEAM-calc). Today's edits in extractNA + extractCommon for manufacturer/epd.id/dates/type/density/material_type. |
+| `schema/scripts/test-epd-extract.mjs` | Harness. Per-format breakdown, per-parameter aggregate, per-pattern audit (§12.5 item 1), catalogue-parity matcher (today). |
+| `docs/PDF References/EPD SAMPLES/` | Canonical 30 with `expected/*.json` ground truth (2 annotated). Default harness target. |
+| `docs/PDF References/EPD-scaling-sets/` | Two folders dropped today: 116 v1.1-candidates + 208 Existing-BEAM-archive. Harness via `--root <dir>`. |
+| `docs/workplans/EPD-coverage-history/` | Auto-snapshotted runs. ~12 new snapshots from today's marathon. |
+| `docs/workplans/melanie-review-draft-2026-05-19.md` | Mélanie message awaiting Andy's red-line. |
+| `schema/materials/*.json` | 821-record catalogue. Read-only on Pages; write side is internal-only (§14.1). |
 
 **Hard rules — do not violate:**
 
-- **§7.6 + §10.3 harness contract:** every commit that touches `js/epd/extract.mjs` re-runs `node schema/scripts/test-epd-extract.mjs` and commits a fresh snapshot to `docs/workplans/EPD-coverage-history/`. Aggregate coverage must move up; no individual sample may regress; once C-fb5 lands, no `epd_publishes` ground-truth value may be silently overridden by the catalogue.
-- **§5.5 BEAM ID convention:** `beam_id` is BfCA-internal and never extracted from a PDF. P3's `extract.mjs` produces `beam_id: null`. Minting happens on the Database side at commit (wired in `database.mjs` `_mintId6` — 6-char hex matching the existing catalogue convention).
-- **§8 security:** no in-browser Anthropic API integration, ever. Andy ruled this out 2026-04-25.
-- **§9 IP guardrails:** no `CSI` / `MasterFormat` / `Division` / `MCE²` / `NRCan` / Crown-copyright tool names in code, UI strings, or the workplan. Numeric `group_prefix` (`03`/`06`/`07`/etc.) is the only classification convention.
-- **Soft-delete only.** Hard-delete forbidden forever ([`Database.md`](Database.md) §6).
+- **§7.6 + §10.3 harness contract:** every commit that touches `js/epd/extract.mjs` re-runs `node schema/scripts/test-epd-extract.mjs` and commits a fresh snapshot to `docs/workplans/EPD-coverage-history/`. Canonical-30 aggregate coverage must move up or stay equal; no individual canonical sample may regress.
+- **§5.5 BEAM ID convention:** `beam_id` is BfCA-internal and never extracted from a PDF. `extract.mjs` produces `beam_id: null`. Minting happens on the Database side at commit.
+- **§8 security (refined by §14):** no Anthropic API integration on public-facing surfaces (BEAMweb, PDF-Parser, Matrix, Database read view). Internal-only tooling on BfCA staff workstations IS permitted — see §14 for the Last Mile strategy.
+- **§12.3 pause (still active):** no new entries to `IMPACT_INDICATORS`, `_BYSTAGE_LABELS`, `_CISC_LABEL_PATTERNS`. Metadata extractors (manufacturer/dates/type/density/material_type label patterns inside extractNA / extractEuIbu / extractCommon) are NOT covered by this pause — that's where today's work happened.
+- **§9 IP guardrails:** no `CSI` / `MasterFormat` / `Division` / `MCE²` / `NRCan` / Crown-copyright tool names in code, UI strings, or workplan.
+- **Soft-delete only.** Hard-delete forbidden forever.
 
 **Daily-driver commands:**
 
 ```
-node schema/scripts/test-epd-extract.mjs                          # run harness, auto-snapshot
-node schema/scripts/test-epd-extract.mjs --only Lafarge           # filter to one sample (no snapshot)
-node schema/scripts/test-epd-extract.mjs --json /tmp/full.json    # full per-candidate dump
-npm run serve                                                     # local dev server (port 8000)
+node schema/scripts/test-epd-extract.mjs                          # run on canonical 30, auto-snapshot
+node schema/scripts/test-epd-extract.mjs --root "docs/PDF References/EPD-scaling-sets/EPDs to consider for v1.1 update"
+node schema/scripts/test-epd-extract.mjs --root "docs/PDF References/EPD-scaling-sets/Existing BEAM Database EPDs"
+node schema/scripts/test-epd-extract.mjs --only Kalesnikoff       # substring filter (no snapshot)
+node schema/scripts/test-epd-extract.mjs --json /tmp/dump.json    # full per-candidate dump
+npm run serve                                                     # local dev server
 ```
 
 **Cross-references:**
 
-- [`Database.md`](Database.md) — sibling workplan for the Database viewer (commit point, list/hide UX, persistence pipeline).
-- [`docs/PDF References/EPD SAMPLES/`](../PDF%20References/EPD%20SAMPLES/) — 30 calibration PDFs across `03 Concrete / 05 Metals / 06 Wood / 07 Thermal`.
+- [`Database.md`](Database.md) — sibling workplan for the Database viewer.
+- [`docs/PDF References/EPD SAMPLES/`](../PDF%20References/EPD%20SAMPLES/) — canonical 30.
+- [`docs/PDF References/EPD-scaling-sets/`](../PDF%20References/EPD-scaling-sets/) — 324 PDFs added today for scaling tests.
 - [`schema/material.schema.json`](../../schema/material.schema.json) — target shape for emitted records.
-- [`schema/lookups/`](../../schema/lookups/) — `material-type-to-group.json`, `display-name-keywords.json`, `country-codes.json`, `lifecycle-stages.json`, `typical-elements.json`, `material-groups.json`.
+- [`schema/lookups/`](../../schema/lookups/) — lookup tables primed via `Extract.setLookups()`.
 
 ---
 
@@ -1237,10 +1210,116 @@ The `--root` flag is purely additive — running the harness without it falls ba
 - **OCR** (Tesseract.js fallback) — P7 phase. **Real demand confirmed in P1 calibration** (`EPD_Polyiso walls.pdf` is image-only, zero text-layer items). v1 detects this case and surfaces a "needs OCR" banner; the actual OCR pass lands in P7.
 - **Hard delete of database records.** Forever. Soft-delete via `status.visibility = "flagged_for_deletion"` is the only deletion path; flagged records stay in `schema/materials/*.json` for back-office manual review (see [`Database.md`](Database.md) §6).
 - **Direct browser-side writes to `schema/materials/*.json`.** Pages serves source data read-only. Commits flow EPD-Parser → shared IndexedDB → DB viewer → patch JSON download → Node patch script → git.
-- **In-browser Anthropic API integration.** Ruled out for security (§8).
+- **In-browser Anthropic API integration on public-facing surfaces.** Ruled out for security (§8). The deployed Pages site, BEAMweb, and the database viewer must never carry an API key. See §14 for the internal-only LLM extraction path (CLI / IDE on BfCA team workstations), which is a different deployment model and is in scope.
 - **Scraping EPD-program registries** (CSA, ULE, IBU, EPD International). Where they expose public APIs, P7 may wrap them; without an API, the team uses the copy-paste-URL workflow (§8).
 - **Auto-minting BfCA-internal `beam_id` values for new entries from EPD-Parser.** Out of scope here; `beam_id` is `null` on the candidate record P3 produces. Actual minting (the `GG####` convention from §5.5) happens at the Database viewer's commit step. Existing 821 records keep their legacy heterogeneous IDs — do not rewrite. EPD-Parser must never populate `beam_id` from a regex anchor.
 - **Regression test fixtures for the parser.** Defer until calibration samples stabilize. Wood EPDs are now in `docs/PDF References/EPD SAMPLES/`; fixture extraction is a P3 follow-up.
+
+---
+
+## 14. Strategic positioning — internal back-of-house tool + Last Mile LLM extension
+
+> Drafted 2026-05-19 PM after Andy's clarification at the end of today's field-tuning marathon. This section names two things explicitly that had been implicit: (1) EPD-Parser and the materials catalogue are BfCA-internal, not public-facing; (2) regex extraction has a structural ceiling around 82–85% on metadata aggregate, and the path to the remaining 15–18% is LLM-as-parser, deployed as an internal CLI / IDE tool that the BfCA team runs on their own workstations to expand the catalogue.
+
+### 14.1. Public-facing vs. internal-only — the deployment split
+
+| Surface                  | Audience                | Deployment            | API access |
+|--------------------------|-------------------------|------------------------|------------|
+| BEAMweb                  | Anyone (practitioners)  | GitHub Pages, public   | None ever  |
+| PDF-Parser               | Anyone (practitioners)  | GitHub Pages, public   | None ever  |
+| Matrix                   | Anyone                  | GitHub Pages, public   | None ever  |
+| Database viewer (read)   | Anyone                  | GitHub Pages, public   | None ever  |
+| **EPD-Parser**           | **BfCA team only**      | **CLI / local browser** | **Permitted on staff workstations** |
+| **DB curation workflow** | **BfCA team only**      | **Local, behind auth-gate if web** | **Permitted on staff workstations** |
+
+The materials catalogue is the BfCA "secret sauce" — practitioners consume it through BEAMweb, but the curation pipeline (EPD-Parser → review → Trust commit → patch JSON → git) stays inside BfCA. This split was implicit in §7.7 and §8's "back-office tools" line; §14 makes it the load-bearing architectural fact.
+
+This changes what the §8 "no in-browser API integration" rule is protecting against. The rule's intent — *no API keys exposed to anonymous traffic, no Anthropic costs scaling with public usage* — is preserved by the public-facing surfaces remaining API-free. **Internal tooling run on BfCA staff workstations does not share that constraint** (the key is an env var on the curator's laptop, not embedded in a page someone can right-click → View Source on).
+
+### 14.2. Coverage trajectory — why regex caps around 82–85%
+
+Today's marathon (9 commits on `EPD-PARSER-5`) lifted v1.1-candidates metadata coverage from 55.9% → 65.6%, with per-pass lift visibly decelerating:
+
+| Pass                       | v1.1 lift                 |
+|----------------------------|--------------------------|
+| manufacturer + epd.id      | +25pp / +26pp             |
+| Pass 1 — dates             | +22pp / +22pp             |
+| Pass 2 — type/validation   | +18pp / +8pp              |
+| Pass 3 — density           | +3pp                      |
+| Pass 4 — material_type     | +10pp                     |
+
+Three structural floors prevent regex from reaching 90%+ on the 354-sample audit:
+
+1. **The 14% unknown-format bucket** (49 / 354 samples). Format detection itself fails for these, so the per-format extractors never run. They sit at 11–27% metadata coverage. Even if other formats reach 95%, the weighted average is mathematically capped near 86%.
+2. **Truly-missing data.** Many EPDs don't publish density (membranes publish grammage instead). Many don't publish expiry. Many don't publish a typed verification field. Regex can't extract data that isn't in the document.
+3. **Multi-language / multi-region drift.** German `Deklarationsinhaber`, French `FICHE DE DÉCLARATION`, Spanish manufacturer-name conventions — each language family is another N patterns to write. Combinatorial.
+
+Realistic regex-only trajectory: **75–85% on metadata aggregate, plateauing as long-tail patterns become per-EPD specials.**
+
+### 14.3. Last Mile — LLM-as-parser as a back-of-house CLI
+
+For the gap between regex's 82% and the 95%+ BfCA wants for catalogue ingestion, the path is **a Claude API call wired into the parser pipeline, deployed as an internal tool**:
+
+```
+[Tier 1–8 regex extractor]    ← today's parser. ~65% of fields filled. Free, fast, deterministic.
+        │
+        ▼  for fields still null
+[Tier 8.5 LLM extractor]      ← new. Hands joined text + JSON Schema → Claude API → structured record.
+                                Fills the long-tail fields regex couldn't.
+        │
+        ▼
+[Tier 9 db-fallbacks]         ← today's catalogue-default fill (unchanged)
+        │
+        ▼
+[Tier 10 BEAM calc]           ← C-fb6, biogenic-carbon normalization (unchanged)
+        │
+        ▼
+[form pane → Trust commit]    ← curator reviews, hits Trust, record lands in catalogue
+```
+
+**Why this works for the catalogue-ingestion use case:**
+- The model reads multi-language fields natively, interprets context ("Specific gravity 1.08 kg/L" → density 1080 kg/m³), and handles arbitrary layouts without per-format engineering.
+- Costs scale with curation cadence, not user traffic. Re-processing today's 354 samples: ~$5–20 once. Per-EPD going forward: ~$0.02–0.10.
+- Latency is acceptable. EPD-Parser is one-EPD-at-a-time curator-driven; 5–30s per call is fine.
+- Stays §8-compatible. The API key lives in an env var on the BfCA staff workstation, never in a public-facing browser bundle.
+
+**Why regex stays — it's the "leg up":**
+- Free + fast first pass. Reduces LLM token cost ~3×.
+- Deterministic — same input always produces same output. Useful for regression tracking and the harness's per-pattern audit (workplan §12.5).
+- Catches the easy 65% so the LLM only does the long-tail 25–30%.
+- The per-pattern audit becomes a tool for retiring regexes the LLM consistently outperforms — codebase shrinks over time.
+
+**Continued regex refinement is still worthwhile.** Each percentage point regex captures removes some LLM inference cost. Today's marathon delivered real lift even as the per-pass return diminished. The plan is **keep grinding on regex AND prototype the LLM tier**, not choose one over the other.
+
+### 14.4. Deployment shapes — CLI first, then maybe IDE
+
+Three viable shapes for the internal LLM tool:
+
+**(A) CLI** — `npm run epd:extract <pdf>` reads the file, runs both extractors, prints the candidate JSON. Curator can pipe it into a review file or open it in their editor. Zero browser involvement. Easiest to ship.
+
+**(B) Local browser** — same EPD-Parser UI, but the "Capture" button now also hits Claude for null fields before populating the form. API key in an env var loaded at `npm run serve` time, never reaches the rendered HTML. Curator workflow is unchanged from today's experience.
+
+**(C) IDE plugin / Claude Code skill** — extraction wrapped as a Claude Code skill the BfCA team invokes during catalogue review. Highest friction to ship, lowest cost per use, integrates with the team's existing tooling if Claude Code becomes a daily driver.
+
+(A) ships first. (B) follows if curators want the form-pane UX over a JSON dump. (C) is speculative and depends on how the team adopts Claude Code.
+
+### 14.5. Implementation sequencing
+
+1. **Ship today's regex improvements as a PR** (`EPD-PARSER-5`, 9 commits, metadata 60% → 67% average across sets).
+2. **Prototype the LLM extractor** against 10 wild v1.1 samples (~30 minutes — Claude API + JSON Schema + the joined text + a "fill what you can" prompt). Confirm 90%+ on the same 10 samples the regex hits ~65% on.
+3. **If validated:** design the Tier-8.5 wiring. Schema for the Claude request payload, retry/timeout policy, cost budget per session, audit-trail for which fields came from LLM vs regex (extend the source-enum: `epd_direct | epd_inferred | epd_llm | calculated | generic_default | user_edit`).
+4. **Wire results** into the existing form-pane / Trust-commit flow unchanged. The form pane already renders provenance chips; `epd_llm` joins them.
+5. **Future regex work** — focused on fields where the LLM struggles (cross-stage `by_stage` tables, biogenic-inventory format variation), where deterministic extraction is easier to audit than LLM consistency.
+
+### 14.6. What this means for §12.3 (architecture review)
+
+The §12.3 paused decision (Option A geometric / B declarative / C HITL / hybrid) was framed before LLM-as-parser was on the table. Adding it gives a fourth option that subsumes most of A's value (handles arbitrary formats) without the implementation cost. The revised menu:
+
+- **Option D (LLM-as-parser)** — primary new path forward, internal-only deployment.
+- **Option C (HITL form-pane)** — still useful as a last-mile reviewer experience, complementary to D.
+- **Option A (geometric)** and **Option B (declarative)** — deprioritized. Most of the leverage they offered against unknown formats is collapsed by D.
+
+The §12.3 question is no longer "which one architecture do we commit to" — it's "in what order do we ship D and C." See §14.5 for the proposed sequencing.
 
 ---
 

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -1335,6 +1335,61 @@ The §12.3 question is no longer "which one architecture do we commit to" — it
 
 ---
 
+## 15. Catalogue data-quality — density-units import bug + audit (2026-05-19)
+
+> Surfaced by the catalogue-parity matcher (§ catalogue-parity check in the harness). Fixed same day in commit `16d4ebd`. This section records the bug, the fix, and the audit confirming density was the only affected column — so a future agent doesn't re-investigate.
+
+### 15.1. The bug
+
+The BEAM source CSV (`docs/csv files from BEAM/BEAM Database-DUMP.csv`) stores density with its unit in a paired column: col 32 `Density` (value) + col 33 `Density Units`. The JSON importer (`schema/scripts/beam-csv-to-json.mjs`) read col 32 but **dropped col 33**, stamping every value as `kg/m³` regardless of the source unit.
+
+Density-unit distribution in the source CSV (684 density-bearing rows):
+- 502 `kg/m3` (correctly volumetric)
+- 104 `kg/m2` (per-area grammage)
+- 19 `g/m2`, 7 `kg/m` (linear), 5 `kg/m2 at RSI 1`, 4 `g/cm3`, ~20 other variants
+
+So ~180 records had per-area or per-linear values silently stored as volumetric density. Examples: fiberglass batt `1f3cc3` (0.488 kg/m² stored as 0.488 kg/m³), EPDM membrane `676103` (2.07 kg/m²), wood I-joist `9aedf1` (3.9 kg/m linear). The parity matcher flagged these as catalogue-vs-parser divergences; tracing to source revealed Mélanie's spreadsheet was correct all along — the bug was BfCA-side at JSON conversion.
+
+### 15.2. The fix (`16d4ebd`)
+
+Importer now reads both columns and emits:
+
+```json
+"physical": { "density": {
+  "value": 0.488,            // raw from CSV, no conversion
+  "units": "kg/m2 at RSI 1", // verbatim from col 33
+  "value_kg_m3": null,       // populated ONLY when source unit is kg/m3 or g/cm3
+  "value_lb_ft3": null,      // null when value_kg_m3 is null
+  "source": "epd"
+}}
+```
+
+`value_kg_m3` is now null for non-volumetric source units, so consumers (BEAMweb assembly math, CCLIMB, parity matcher) can no longer misread a per-area grammage as a volumetric density. The biogenic carbon-content calc gates on `densityKgM3` (not raw density) to avoid corruption. Catalogue-parity density "differ" count dropped 102 → 36 (−65%).
+
+**Schema convention going forward:** `physical.density` carries `{value, units, value_kg_m3, value_lb_ft3, source}`. The unit string is *data*, not metadata — downstream consumers read both `value` + `units` and convert with their own geometry context when needed.
+
+### 15.3. Audit — density was the only affected column
+
+Scanned all value/unit column pairs in the CSV to check for the same dropped-units pattern. Result: **density was the only genuine bug.** Every other value column anchors to the per-material **"common unit"** (CSV col 19), which the importer *does* read (→ `carbon.common.per_functional_unit`). GWP, biogenic storage, and carbon content are all expressed *per that common unit*, so their unit context flows through correctly.
+
+| CSV cols | Field | Importer reads unit? | Verdict |
+|---|---|---|---|
+| 16/17 | Stated EPD GWP / unit | ✅ (→ `carbon.stated.per_unit`) | OK |
+| 18/19 | GWP / common unit | ✅ (→ `carbon.common.per_functional_unit`) | OK |
+| 20/21 | Metric / Imperial unit labels | ✅ | OK |
+| 25/26 | Biogenic Storage / common unit | ⚠️ col 26 not read, but **verified redundant** with col 19 (always identical) | OK |
+| 28/29 | Carbon content / units | ⚠️ col 29 not read, but **106/111 blank**, implied per-common-unit | OK (low risk) |
+| **32/33** | **Density** | **❌ → FIXED `16d4ebd`** | **was broken** |
+| 34/35 | Additional factors / units | ✅ (→ `physical.additional_factor.units`) | OK |
+
+Verification that col 26 is redundant with col 19 (3 biogenic-storage records): `bbb000` col26=`m2` col19=`m²`; `BAM002` col26=`m2 at 1/2"` col19=`m2 @1/2"`; `BAM003` same. Density was unique because its kg/m³ vs kg/m² distinction is *independent* of the common unit — that's why dropping its unit column genuinely corrupted the value's meaning while the others stayed sound.
+
+### 15.4. Forward-looking pipeline note
+
+The bug was a "column added to the spreadsheet later, paired unit column missed in the importer" pattern. **Checklist item for the spreadsheet → CSV → JSON pipeline:** when the BEAM spreadsheet adds a new value column, wire its paired unit column into the importer at the same time. A units-presence assertion in `validate.mjs` (flag any density/factor value whose unit column exists in CSV but isn't carried to JSON) would catch a recurrence automatically.
+
+---
+
 ## Iteration infrastructure (planned)
 
 - **`npm run serve`** — already in place, no-cache dev server on port 8000. Drop EPD samples into `docs/pdf-samples/epd/` (parallel to `docs/pdf-samples/sample-metric.pdf` already used by PDF-Parser) for repeatable testing.

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -6,20 +6,42 @@
 
 ## Agent handoff (read this first)
 
-**You are picking up at 2026-05-19 evening, end of an extended field-tuning marathon session. Active branch: `EPD-PARSER-5` with 9 commits since main, pushed to both remotes, no PR open yet.** Andy made an important strategic clarification at the end of the day that's now captured in §14 — read it before doing any extraction work. *"This process seems exhausting. Will we get to 90% or 100% coverage at this rate?"* The honest answer was no; the path to 90%+ is LLM-as-parser as an internal back-of-house tool (§14.3).
+**You are picking up after a long 2026-05-19 session. Active branch: `EPD-PARSER-5`, ~18 commits since main (`78565a8`), all pushed to both remotes, no PR open yet.** The day covered four workstreams: (a) EPD-extraction field-tuning, (b) catalogue data-quality fixes, (c) the CCLIMB methodology + 6th-module scaffold, (d) parity-validation planning.
 
-**Today's session at a glance (2026-05-19):**
+### ⭐ NEXT SESSION — START HERE
 
-1. Andy cut `EPD-PARSER-5` off `main` (78565a8) for the day's work.
-2. Per-pattern hit-count audit shipped to the harness (§12.5 item 1) — `IMPACT_INDICATORS` / `_BYSTAGE_LABELS` / `_CISC_LABEL_PATTERNS` get DEAD-tagged when 0 hits across the audit set.
-3. Andy resolved the BfCA Drive-share blocker (BfCA had download-disable on the original folder; resolved via a separate share). Two new sample folders staged at `docs/PDF References/EPD-scaling-sets/`:
-   - `EPDs to consider for v1.1 update/` — 116 candidate PDFs for the next catalogue update.
-   - `Existing BEAM Database EPDs/` — 208 PDFs from BfCA's archive (may or may not be currently catalogued; the parity matcher sorts them).
-4. Two scaling-audit snapshots + the §12.3 decision dataset committed (`55247fc`).
-5. Catalogue-parity matcher built and shipped (`bd12ef9`) — for each candidate, scores against the 821 records in `schema/materials/*.json` and emits match category + field diff. Surfaced **~10–20 catalogue rows with unit-misencoded density values** (e.g. `mpa000` aluminum at 2.07 kg/m³, `1f3cc3` fiberglass at 0.488 kg/m³). NOT a parser problem — a catalogue-side data-quality issue that the parser now flags.
-6. Mélanie review draft for §11.10 written at `docs/workplans/melanie-review-draft-2026-05-19.md` (`9303991`). Andy's decisions on Q1 (`methodology.beam_calc.*`), Q2 (`long_cycle | short_cycle`, medium deferred), Q5 (`legacy_unknown` flag), Q6 (two-tier ±0.1% / ±5%) are baked in. Phyllis 2 starter shortlist drafted (20 entries) with `// is this right?` markers on the 5 entries needing Mélanie's review. **Pending Andy's red-line pass before sending.**
-7. Five field-tuning passes shipped (manufacturer/epd.id; dates; type/validation; density; material_type). See "Branch state" below for the SHA chain.
-8. Strategic clarification (`§14`, this session): EPD-Parser is **internal back-of-house BfCA tooling**, not public-facing. The materials catalogue is the same. BEAMweb / PDF-Parser / Matrix / DB-read are public-facing; EPD-Parser + DB curation are not. This unlocks LLM-as-parser as a Tier-8.5 extension (Claude API call on BfCA staff workstations to fill the long-tail fields regex can't reach). See §14 in full.
+1. **Build the Parity-A harness** (`schema/scripts/csv-json-parity.mjs`) — fully spec'd in **§16**. Diffs 639 JSON catalogue records ↔ 639 BEAM CSV rows field-by-field, emits BfCA's requested **3-sheet workbook** (Sheet 1 = CSV values, Sheet 2 = JSON values same order, Sheet 3 = per-cell MATCH/MISMATCH for GREEN/RED conditional formatting). This is BfCA's top ask — "prove the BEAMweb database matches the spreadsheet." Regex-independent, deterministic, high-assurance-per-hour. Density-units bug already fixed (§15) so most fields should come back green.
+2. **Finish the CCLIMB chart-config correction** — `js/cclimb/chart-config.mjs` still defines `LCA_MODULES` as axes; the corrected design (TIME_HORIZONS, per §3.2.E of `docs/RMI Work/CCLIMB-Workplan2.md`) needs to replace it. Workplan2 §3.2 is already corrected; only the scaffold code lags.
+3. **Open the PR** for `EPD-PARSER-5` when ready — it's a big, coherent branch (field-tuning + catalogue fix + parity planning + CCLIMB scaffold). Title suggestion: *"EPD-Parser: scaling audit + catalogue-parity + metadata field-tuning + density-units fix + CCLIMB scaffold"*.
+
+### Pending on Andy (not blocking the above)
+
+- **Mélanie review** — materials at `docs/workplans/melanie-review-2026-05-19.{html,rtf,docx}` (the RTF/DOCX are gitignored as `*.rtf`/`*.docx`; the `.html` source + the original markdown draft are tracked). Gating C-fb6 (Tier-10 biogenic). Andy was meeting her 4:15pm 2026-05-19.
+- **§12.3 architecture** — treat §14 (Option D = LLM-as-parser, internal) as the working answer. The pause on `IMPACT_INDICATORS` / `_BYSTAGE_LABELS` / `_CISC_LABEL_PATTERNS` inflation **still stands**.
+- **Pass 1+2 metadata-extractor bug** (flagged in "Known issue" below) — date/type/validation patterns landed in `extractNA` not `extractCommon`, so NSF/EPD-Intl/unknown formats skip them. ~26% of samples affected. Clean follow-up: move 5 blocks from `extractNA` → real `extractCommon`.
+
+### What shipped 2026-05-19 (full session)
+
+**(a) EPD-extraction field-tuning** (metadata recall, all canonical-30-regression-clean):
+- Per-pattern hit-count audit added to harness (§12.5 item 1).
+- Six field-tuning passes: manufacturer + epd.id (+20–41pp), dates (+22pp v1.1), epd.type/validation (+18pp), density (+3pp), material_type (+10pp). Canonical 30 metadata 66.4 → 69.5%.
+- ⚠️ **Bug:** dates/type/validation passes edited `extractNA` not `extractCommon` (see "Known issue").
+
+**(b) Catalogue data-quality:**
+- **Density-units import bug FOUND + FIXED** (`16d4ebd`, documented §15). The BEAM CSV stores density with correct units in col 33 (`kg/m2`, `kg/m`, `g/cm3`, etc.); the importer dropped the unit column and stamped all as `kg/m³` — corrupting ~180 of 684 density records. Fix: importer reads col 33, emits `{value, units, value_kg_m3 (null unless volumetric), value_lb_ft3, source}`. Parity "differ" count dropped 102 → 36. **Mélanie's source data was correct; the bug was BfCA-side.**
+- **Full CSV units audit** (§15.3): density was the ONLY affected column — every other value column anchors to the per-material "common unit" (col 19) which the importer reads correctly.
+
+**(c) CCLIMB — RMI methodology + 6th BfCA module:**
+- Read CCLIMB methodology (`docs/RMI Work/CCLIMB-Workplan.md` = Chris's proposal) + CCOB earlier draft + Chris's flowchart PDFs.
+- Wrote `docs/RMI Work/CCLIMB-Workplan2.md` — implementation interpretation (~730 lines): summary, 6th-module fit, parallel-coordinates UX (per Andy: axes = TIME HORIZONS, RT vs PT per-material multi-line, RT = unbounded counterfactual not module-stratified), climate-model sketch, v1/v2 scope, working-group questions.
+- Scaffolded the module (`7a6ef51`): `cclimb.html` + `js/cclimb.mjs` + `js/cclimb/*.mjs` (chart-config, climate-model, reference-trajectories, feedstock-categories, parallel-coords stubs) + `js/cclimb/parallel-coordinates.objective-source.js` (verbatim port-reference from OBJECTIVE module 18 via gh CLI) + §12 CCLIMB CSS + landing card.
+- ⚠️ chart-config.mjs axes need the TIME_HORIZONS correction (see NEXT SESSION #2).
+
+**(d) Parity-validation planning** (§16): A (CSV↔JSON, do-first) vs B (EPD↔CSV/JSON, needs multi-product extraction, deferred). Multi-product = the parser emits 1 record/PDF today but 280 EPDs → 639 BEAM rows (EPDs cover 2–8 products each); Follow-up #4 gap, gates Parity B, strongest argument for LLM-as-parser.
+
+**Strategic (§14):** EPD-Parser + materials catalogue are **internal back-of-house** (the catalogue is BfCA's "secret sauce"); BEAMweb/PDF-Parser/Matrix/DB-read are public. Internal tools can use the Claude API on staff workstations → LLM-as-parser is the path to 90%+ extraction. §8 in-browser-API ban applies to public surfaces only.
+
+**Large sample sets (gitignored, local-only):** `docs/PDF References/EPD-scaling-sets/` (116 v1.1-candidates + 208 existing-BEAM) and `docs/PDF References/EPD SAMPLES/BEAM 639 Rows/` (280 PDFs → 639 BEAM rows, the parity validation set). All gitignore-protected — never commit.
 
 **Decisions still gating downstream work:**
 

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -1390,6 +1390,65 @@ The bug was a "column added to the spreadsheet later, paired unit column missed 
 
 ---
 
+## 16. Parity validation — CSV ↔ JSON database (planned, next session)
+
+> Drafted 2026-05-19 PM. BfCA's goal: assurance that the BEAMweb JSON database aligns with the original BEAM spreadsheet, validated against the EPDs now in hand. Two distinct parity questions; this section defines both and specifies the deliverable BfCA requested.
+
+### 16.1. Two parity questions — A and B
+
+| | Parity A | Parity B |
+|---|---|---|
+| **Compares** | BEAM CSV ↔ JSON database | Source EPDs ↔ CSV / JSON |
+| **Checks** | Is the `beam-csv-to-json.mjs` import faithful? | Did the EPDs get transcribed into the catalogue correctly? |
+| **Regex involved?** | **No** — deterministic transform check | Yes — needs EPD extraction |
+| **Multi-product needed?** | **No** | **Yes** (280 EPDs → 639 rows; many EPDs cover 2–8 products) |
+| **Cost** | Low — re-run importer + field diff | High — gated on multi-product extraction |
+| **Status** | **Do first (next session)** | Deferred — tied to LLM-as-parser (§14) for multi-product |
+
+**Parity A is the high-assurance-per-hour move and directly answers BfCA's "values align" question.** The JSON database was *generated from* the CSV, so it should be 1:1 — 639 JSON records ↔ 639 CSV rows. Any mismatch is an import bug (the density-units bug in §15 was exactly this class). Re-run the importer, diff every field against the source CSV, surface mismatches. Target stat: "N of 639 catalogue rows match their CSV source row, field-by-field, at 100% parity."
+
+**Parity B (EPD-sourced validation)** requires the parser to extract *all* products from multi-product EPDs (Follow-up #4 / §0 "Multi-product EPD disambiguation"). Today the parser emits one record per PDF and grabs the first product column on multi-product EPDs. Since 280 EPDs map to 639 rows, multi-product is the norm — Parity B can't be complete without it. This is the strongest argument for the §14 LLM-as-parser path: "list every product variant in this EPD with its per-stage impacts" is trivial for an LLM and a per-format slog with column-walking regex. **Defer B until multi-product extraction lands.**
+
+### 16.2. BfCA's requested deliverable — 3-sheet parity workbook
+
+BfCA asked for a 3-worksheet summary (CSV-format sheets, or one XLSX) for human-in-the-loop review:
+
+| Sheet | Content | Source |
+|---|---|---|
+| **1 — BEAM CSV** | Original `BEAM Database-DUMP.csv` materials values, selected columns, sorted by BEAM ID | the CSV |
+| **2 — BEAMweb DB** | Same columns, same row order (sorted by BEAM ID), values read from `schema/materials/*.json` | the JSON catalogue |
+| **3 — Diff** | Per-cell `MATCH` / `MISMATCH` (+ numeric delta where applicable), same row order | computed A↔B |
+
+Sheet 3 is structured so BfCA applies Excel conditional formatting → GREEN = match, RED = mismatch. We supply the data + the per-cell verdict; they apply (or we pre-apply if shipping XLSX) the colour.
+
+**Column set to compare** (the load-bearing fields, sorted by BEAM ID):
+- Identity: `ID`, `Display Name`
+- Carbon: Stated EPD GWP + unit (CSV 16/17), GWP per common unit + unit (18/19), GWP-bio (22)
+- Biogenic: Biogenic Storage (25), Carbon content kgC/unit (28), Full C value (30), Storage % reduction (31)
+- Physical: Density value + units (32/33 — now correctly split post-§15 fix), Additional factors + units (34/35)
+- Provenance: EPD ID (50), EPD Type (51), Program Operator (54), Service Life (62)
+
+Tolerance: numeric fields match within ±0.5% (rounding in the CSV → JSON transform); strings match on normalized comparison (trim + case-insensitive); units match exact.
+
+### 16.3. Implementation sketch (next session)
+
+New script `schema/scripts/csv-json-parity.mjs`:
+
+1. Parse `BEAM Database-DUMP.csv` → keyed by BEAM ID
+2. Load all `schema/materials/*.json` → keyed by `id`
+3. For each of the 639 IDs, align CSV row ↔ JSON record
+4. Field-by-field compare per the column set + tolerance above
+5. Emit three CSVs: `parity-sheet1-csv.csv`, `parity-sheet2-json.csv`, `parity-sheet3-diff.csv` (or one XLSX with 3 sheets + conditional formatting via a lib)
+6. Console summary: "X/639 rows 100%-parity, Y rows with ≥1 mismatch, top mismatched fields: …"
+
+This harness is **independent of the EPD-extraction harness** (`test-epd-extract.mjs`) — different inputs (CSV+JSON vs PDFs), different question (import faithfulness vs extraction accuracy). Keep them separate.
+
+### 16.4. Expected outcome
+
+After the §15 density fix, Parity A should be high already. The harness will quantify it: most fields likely 100%, density now correct, and any residual mismatches (value rounding, null handling, field-mapping edge cases) surfaced for a targeted second importer fix. The 3-sheet workbook is the artifact BfCA reviews to sign off "the BEAMweb database matches the spreadsheet."
+
+---
+
 ## Iteration infrastructure (planned)
 
 - **`npm run serve`** — already in place, no-cache dev server on port 8000. Drop EPD samples into `docs/pdf-samples/epd/` (parallel to `docs/pdf-samples/sample-metric.pdf` already used by PDF-Parser) for repeatable testing.

--- a/docs/workplans/EPD-Parser.md
+++ b/docs/workplans/EPD-Parser.md
@@ -47,6 +47,18 @@ Day's net delta: **+3pp canonical, +9.7pp v1.1, +5.7pp Existing BEAM** on metada
 - weak: 76 (37%) — noisy, threshold tuning deferred
 - **unmatched: 30 (14%)** — the catalogue-update candidates BfCA should review
 
+### Known issue discovered EOD 2026-05-19 — Pass 1+2 patches in wrong function
+
+Late in the marathon (after the strategic-§14 commit) a debug-trace on 810.CRMCA_EPD_BC.pdf (NSF format) revealed that the new date / EPD-type / validation patterns added in Pass 1 + Pass 2 are inside `extractNA` (line 1163+), not the actual `extractCommon` (line 412+) as the commit messages claimed. The functions are ~700 lines apart and the visual context was easy to mistake.
+
+**Impact:** NSF (30 Existing-BEAM samples), EPD-International (14), and unknown-format (49) samples never see the Pass 1+2 improvements — about 26% of the 354-sample audit. This explains why Pass 1's pub_date lift on Existing BEAM was only +6pp instead of the +22pp v1.1 saw.
+
+**Fix (single follow-up commit):** Move three blocks from inside `extractNA` (lines 1319–1411) up into the real `extractCommon` (line 412+). The blocks: pub_date chain, expiry chain, EPD-type label+prose, markets, validation-type. NSF / EPD-Intl / unknown samples should see immediate coverage lift; canonical 30 should be unchanged (NA samples still get the same patterns since extractCommon runs after the per-format extractors); v1.1 should see another +5-10pp metadata.
+
+**Verification:** After moving the blocks, re-run all 3 audits. The 810.CRMCA-class test case is: `Period of Validity 5 Years – Valid until July 27, 2027` should set `epd.expiry_date: 2027-07-27`.
+
+This is the cleanest first-thing-tomorrow task. Independent of any §14 / LLM-as-parser work.
+
 ### Pickup — what you're doing next
 
 The branch is at a clean stopping point. Most likely user-driven next moves:

--- a/docs/workplans/EPD-coverage-history/2026-05-19T14-42-56Z.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19T14-42-56Z.md
@@ -1,0 +1,163 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T14:42:56.687Z
+Samples: 30 · metadata: 279/420 (66.4%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 13/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 10/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 7/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 10/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 11/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 13/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 13/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 13/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 13/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 11/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 14/30 | 47% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 6/30 | 20% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 13/30 | 43% |  |
+| 3 | `acidification_kgso2eq` — AP | 11/30 | 37% |  |
+| 4 | `eutrophication_kgneq` — EP | 13/30 | 43% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 11/30 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 11/30 | 37% |  |
+| 7 | `water_consumption_m3` — WDP | 2/30 | 7% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 4/30 | 13% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 7/30 | 23% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 6/30 | 20% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/30 | 7% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 3/30 | 10% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 5/30 | 17% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 6/30 | 20% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/30 | 7% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 4/30 | 13% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/30 | 10% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/30 | 7% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/30 | 7% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 2/30 | 7% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 2/30 | 7% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 17/30 | 57% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 11/30 | 37% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 14/30 | 47% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 1/30 | 3% | thin |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 2/30 | 7% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 10/30 | 33% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 10/30 | 33% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 13/30 | 43% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 23/30 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 2/30 | 7% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 21/30 | 70% |  |
+| 3 | `acidification_kgso2eq` | 24/30 | 80% |  |
+| 4 | `eutrophication_kgneq` | 22/30 | 73% |  |
+| 5 | `smog_kgo3eq` | 14/30 | 47% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 10/30 | 33% |  |
+| 7 | `water_consumption_m3` | 14/30 | 47% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/30 | 7% |  |
+| 9 | `primary_energy_renewable_mj` | 2/30 | 7% |  |
+| 10 | `gwp_kgco2e` | 5/30 | 17% |  |
+| 11 | `gwp_bio_kgco2e` | 0/30 | 0% | DEAD |
+| 12 | `acidification_kgso2eq` | 5/30 | 17% |  |
+| 13 | `eutrophication_kgneq` | 5/30 | 17% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 5/30 | 17% |  |
+| 15 | `smog_kgo3eq` | 5/30 | 17% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 5/30 | 17% |  |
+| 17 | `water_consumption_m3` | 0/30 | 0% | DEAD |
+| 18 | `primary_energy_nonrenewable_mj` | 0/30 | 0% | DEAD |
+| 19 | `primary_energy_renewable_mj` | 0/30 | 0% | DEAD |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 3/30 | 10% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 2/30 | 7% |  |
+| 2 | `acidification_kgso2eq` | 1/30 | 3% | thin |
+| 3 | `eutrophication_kgneq` | 2/30 | 7% |  |
+| 4 | `smog_kgo3eq` | 1/30 | 3% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 1/30 | 3% | thin |
+| 6 | `water_consumption_m3` | 1/30 | 3% | thin |
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-dates.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-dates.md
@@ -1,0 +1,307 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:43:37.271Z
+Samples: 30 · metadata: 290/420 (69.0%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 14/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 11/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 8/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 14/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 14/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 12/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 14/30 | 47% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 6/30 | 20% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 13/30 | 43% |  |
+| 3 | `acidification_kgso2eq` — AP | 11/30 | 37% |  |
+| 4 | `eutrophication_kgneq` — EP | 13/30 | 43% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 11/30 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 11/30 | 37% |  |
+| 7 | `water_consumption_m3` — WDP | 2/30 | 7% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 4/30 | 13% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 7/30 | 23% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 6/30 | 20% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/30 | 7% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 3/30 | 10% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 5/30 | 17% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 6/30 | 20% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/30 | 7% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 4/30 | 13% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/30 | 10% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/30 | 7% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/30 | 7% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 2/30 | 7% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 2/30 | 7% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 17/30 | 57% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 11/30 | 37% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 14/30 | 47% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 1/30 | 3% | thin |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 2/30 | 7% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 10/30 | 33% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 10/30 | 33% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 13/30 | 43% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 23/30 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 2/30 | 7% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 21/30 | 70% |  |
+| 3 | `acidification_kgso2eq` | 24/30 | 80% |  |
+| 4 | `eutrophication_kgneq` | 22/30 | 73% |  |
+| 5 | `smog_kgo3eq` | 14/30 | 47% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 10/30 | 33% |  |
+| 7 | `water_consumption_m3` | 14/30 | 47% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/30 | 7% |  |
+| 9 | `primary_energy_renewable_mj` | 2/30 | 7% |  |
+| 10 | `gwp_kgco2e` | 5/30 | 17% |  |
+| 11 | `gwp_bio_kgco2e` | 0/30 | 0% | DEAD |
+| 12 | `acidification_kgso2eq` | 5/30 | 17% |  |
+| 13 | `eutrophication_kgneq` | 5/30 | 17% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 5/30 | 17% |  |
+| 15 | `smog_kgo3eq` | 5/30 | 17% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 5/30 | 17% |  |
+| 17 | `water_consumption_m3` | 0/30 | 0% | DEAD |
+| 18 | `primary_energy_nonrenewable_mj` | 0/30 | 0% | DEAD |
+| 19 | `primary_energy_renewable_mj` | 0/30 | 0% | DEAD |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 3/30 | 10% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 2/30 | 7% |  |
+| 2 | `acidification_kgso2eq` | 1/30 | 3% | thin |
+| 3 | `eutrophication_kgneq` | 2/30 | 7% |  |
+| 4 | `smog_kgo3eq` | 1/30 | 3% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 1/30 | 3% | thin |
+| 6 | `water_consumption_m3` | 1/30 | 3% | thin |
+
+## Catalogue parity check
+
+30 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 5/30 | 17% |
+| strong-multi | 2/30 | 7% |
+| medium | 0/30 | 0% |
+| medium-multi | 10/30 | 33% |
+| weak | 8/30 | 27% |
+| unmatched | 5/30 | 17% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 24 | 0 | 1 | 0 | 96% |
+| `classification.material_type` | 13 | 3 | 8 | 1 | 54% |
+| `manufacturer.name` | 7 | 12 | 5 | 1 | 29% |
+| `physical.density.value_kg_m3` | 7 | 12 | 4 | 2 | 30% |
+| `epd.id` | 4 | 14 | 6 | 1 | 17% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2015 LSL Summary.pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | strong-multi | 110 | `10d47f` (+4 more) | Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg \| US & CA] | epd.id, disp(1/2), group |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | strong-multi | 130 | `f0c8ce` (+4 more) | OSB sheathing / 7/16" / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-ISO.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-XPS.pdf | strong | 127 | `3kglse` | XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch | epd.id, disp(2/3), group, mat |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD_Polyiso walls.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Lafarge Canada"` vs catalogue `"Portland Cement Association"`
+
+**05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Canadian Institute of Steel Construction"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"1905-5299 Declaration product"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/EPD_document_S-P-10278_en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"SDI"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"341 Declaration Number"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"8705-0201 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3079-2583 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3688-5839 Declaration product"` vs catalogue `"7740-1109"`
+
+**06 Wood/2013 BC Wood LVL EPD.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"American Wood Council and Canadian Wood Council"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `7.05`
+- `epd.id` — candidate `"13CA24184.105.1"` vs catalogue `"SCS-EPD-07526"`
+
+**06 Wood/2016 BC Wood LSL AWC.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"American Wood Council"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787193543.101.1"` vs catalogue `"EPD-117"`
+
+**06 Wood/2017 BC Wood WRC AWC EPD.pdf** (top: `10d47f` — Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"the United States of America"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `456`
+
+**06 Wood/2020 BC Wood OSB EPD.pdf** (top: `f0c8ce` — OSB sheathing / 7/16" / AWC & CWC [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `620`
+
+**06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**06 Wood/2023 BC Wood CLT EPD ASTM.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 395"` vs catalogue `"6742-7944"`
+
+**06 Wood/2023 BC Wood GLT EPD ASTM.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 396"` vs catalogue `"EPD296"`
+
+**07 Thermal/Boreal_Nature_Elite_TDS.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**07 Thermal/EPD Sopra-XPS.pdf** (top: `3kglse` — XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch):
+- `manufacturer.name` — candidate `"Canada J2C 8E9"` vs catalogue `"Soprema"`
+
+**07 Thermal/EPD_Genyk_EN-FINAL.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `manufacturer.name` — candidate `"the exposure of nitrogen oxides"` vs catalogue `"Carlisle"`
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `32`
+- `epd.id` — candidate `"EPD 503 Genyk e 1701 3 Avenue Shawinigan"` vs catalogue `"4790550934-101.1"`
+
+**07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-density.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-density.md
@@ -1,0 +1,307 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T17:05:06.158Z
+Samples: 30 · metadata: 290/420 (69.0%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 14/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 11/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 8/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 14/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 14/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 12/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 14/30 | 47% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 6/30 | 20% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 13/30 | 43% |  |
+| 3 | `acidification_kgso2eq` — AP | 11/30 | 37% |  |
+| 4 | `eutrophication_kgneq` — EP | 13/30 | 43% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 11/30 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 11/30 | 37% |  |
+| 7 | `water_consumption_m3` — WDP | 2/30 | 7% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 4/30 | 13% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 7/30 | 23% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 6/30 | 20% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/30 | 7% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 3/30 | 10% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 5/30 | 17% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 6/30 | 20% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/30 | 7% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 4/30 | 13% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/30 | 10% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/30 | 7% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/30 | 7% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 2/30 | 7% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 2/30 | 7% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 17/30 | 57% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 11/30 | 37% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 14/30 | 47% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 1/30 | 3% | thin |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 2/30 | 7% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 10/30 | 33% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 10/30 | 33% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 13/30 | 43% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 23/30 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 2/30 | 7% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 21/30 | 70% |  |
+| 3 | `acidification_kgso2eq` | 24/30 | 80% |  |
+| 4 | `eutrophication_kgneq` | 22/30 | 73% |  |
+| 5 | `smog_kgo3eq` | 14/30 | 47% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 10/30 | 33% |  |
+| 7 | `water_consumption_m3` | 14/30 | 47% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/30 | 7% |  |
+| 9 | `primary_energy_renewable_mj` | 2/30 | 7% |  |
+| 10 | `gwp_kgco2e` | 5/30 | 17% |  |
+| 11 | `gwp_bio_kgco2e` | 0/30 | 0% | DEAD |
+| 12 | `acidification_kgso2eq` | 5/30 | 17% |  |
+| 13 | `eutrophication_kgneq` | 5/30 | 17% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 5/30 | 17% |  |
+| 15 | `smog_kgo3eq` | 5/30 | 17% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 5/30 | 17% |  |
+| 17 | `water_consumption_m3` | 0/30 | 0% | DEAD |
+| 18 | `primary_energy_nonrenewable_mj` | 0/30 | 0% | DEAD |
+| 19 | `primary_energy_renewable_mj` | 0/30 | 0% | DEAD |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 3/30 | 10% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 2/30 | 7% |  |
+| 2 | `acidification_kgso2eq` | 1/30 | 3% | thin |
+| 3 | `eutrophication_kgneq` | 2/30 | 7% |  |
+| 4 | `smog_kgo3eq` | 1/30 | 3% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 1/30 | 3% | thin |
+| 6 | `water_consumption_m3` | 1/30 | 3% | thin |
+
+## Catalogue parity check
+
+30 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 5/30 | 17% |
+| strong-multi | 2/30 | 7% |
+| medium | 0/30 | 0% |
+| medium-multi | 10/30 | 33% |
+| weak | 8/30 | 27% |
+| unmatched | 5/30 | 17% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 24 | 0 | 1 | 0 | 96% |
+| `classification.material_type` | 13 | 3 | 8 | 1 | 54% |
+| `manufacturer.name` | 7 | 12 | 5 | 1 | 29% |
+| `physical.density.value_kg_m3` | 7 | 12 | 4 | 2 | 30% |
+| `epd.id` | 4 | 14 | 6 | 1 | 17% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2015 LSL Summary.pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | strong-multi | 110 | `10d47f` (+4 more) | Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg \| US & CA] | epd.id, disp(1/2), group |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | strong-multi | 130 | `f0c8ce` (+4 more) | OSB sheathing / 7/16" / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-ISO.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-XPS.pdf | strong | 127 | `3kglse` | XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch | epd.id, disp(2/3), group, mat |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD_Polyiso walls.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Lafarge Canada"` vs catalogue `"Portland Cement Association"`
+
+**05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Canadian Institute of Steel Construction"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"1905-5299 Declaration product"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/EPD_document_S-P-10278_en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"SDI"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"341 Declaration Number"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"8705-0201 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3079-2583 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3688-5839 Declaration product"` vs catalogue `"7740-1109"`
+
+**06 Wood/2013 BC Wood LVL EPD.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"American Wood Council and Canadian Wood Council"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `7.05`
+- `epd.id` — candidate `"13CA24184.105.1"` vs catalogue `"SCS-EPD-07526"`
+
+**06 Wood/2016 BC Wood LSL AWC.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"American Wood Council"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787193543.101.1"` vs catalogue `"EPD-117"`
+
+**06 Wood/2017 BC Wood WRC AWC EPD.pdf** (top: `10d47f` — Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"the United States of America"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `456`
+
+**06 Wood/2020 BC Wood OSB EPD.pdf** (top: `f0c8ce` — OSB sheathing / 7/16" / AWC & CWC [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `620`
+
+**06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**06 Wood/2023 BC Wood CLT EPD ASTM.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 395"` vs catalogue `"6742-7944"`
+
+**06 Wood/2023 BC Wood GLT EPD ASTM.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 396"` vs catalogue `"EPD296"`
+
+**07 Thermal/Boreal_Nature_Elite_TDS.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**07 Thermal/EPD Sopra-XPS.pdf** (top: `3kglse` — XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch):
+- `manufacturer.name` — candidate `"Canada J2C 8E9"` vs catalogue `"Soprema"`
+
+**07 Thermal/EPD_Genyk_EN-FINAL.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `manufacturer.name` — candidate `"the exposure of nitrogen oxides"` vs catalogue `"Carlisle"`
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `32`
+- `epd.id` — candidate `"EPD 503 Genyk e 1701 3 Avenue Shawinigan"` vs catalogue `"4790550934-101.1"`
+
+**07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-mattype.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-mattype.md
@@ -1,0 +1,308 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T17:09:48.048Z
+Samples: 30 · metadata: 292/420 (69.5%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 14/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 11/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 9/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 14/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 14/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 12/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 13/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 14/30 | 47% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 6/30 | 20% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 13/30 | 43% |  |
+| 3 | `acidification_kgso2eq` — AP | 11/30 | 37% |  |
+| 4 | `eutrophication_kgneq` — EP | 13/30 | 43% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 11/30 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 11/30 | 37% |  |
+| 7 | `water_consumption_m3` — WDP | 2/30 | 7% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 4/30 | 13% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 7/30 | 23% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 6/30 | 20% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/30 | 7% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 3/30 | 10% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 5/30 | 17% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 6/30 | 20% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/30 | 7% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 4/30 | 13% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/30 | 10% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/30 | 7% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/30 | 7% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 2/30 | 7% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 2/30 | 7% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 17/30 | 57% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 11/30 | 37% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 14/30 | 47% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 1/30 | 3% | thin |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 2/30 | 7% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 10/30 | 33% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 10/30 | 33% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 13/30 | 43% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 23/30 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 2/30 | 7% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 21/30 | 70% |  |
+| 3 | `acidification_kgso2eq` | 24/30 | 80% |  |
+| 4 | `eutrophication_kgneq` | 22/30 | 73% |  |
+| 5 | `smog_kgo3eq` | 14/30 | 47% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 10/30 | 33% |  |
+| 7 | `water_consumption_m3` | 14/30 | 47% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/30 | 7% |  |
+| 9 | `primary_energy_renewable_mj` | 2/30 | 7% |  |
+| 10 | `gwp_kgco2e` | 5/30 | 17% |  |
+| 11 | `gwp_bio_kgco2e` | 0/30 | 0% | DEAD |
+| 12 | `acidification_kgso2eq` | 5/30 | 17% |  |
+| 13 | `eutrophication_kgneq` | 5/30 | 17% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 5/30 | 17% |  |
+| 15 | `smog_kgo3eq` | 5/30 | 17% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 5/30 | 17% |  |
+| 17 | `water_consumption_m3` | 0/30 | 0% | DEAD |
+| 18 | `primary_energy_nonrenewable_mj` | 0/30 | 0% | DEAD |
+| 19 | `primary_energy_renewable_mj` | 0/30 | 0% | DEAD |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 3/30 | 10% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 2/30 | 7% |  |
+| 2 | `acidification_kgso2eq` | 1/30 | 3% | thin |
+| 3 | `eutrophication_kgneq` | 2/30 | 7% |  |
+| 4 | `smog_kgo3eq` | 1/30 | 3% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 1/30 | 3% | thin |
+| 6 | `water_consumption_m3` | 1/30 | 3% | thin |
+
+## Catalogue parity check
+
+30 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 5/30 | 17% |
+| strong-multi | 2/30 | 7% |
+| medium | 0/30 | 0% |
+| medium-multi | 10/30 | 33% |
+| weak | 8/30 | 27% |
+| unmatched | 5/30 | 17% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 24 | 0 | 1 | 0 | 96% |
+| `classification.material_type` | 13 | 4 | 8 | 0 | 52% |
+| `manufacturer.name` | 7 | 12 | 5 | 1 | 29% |
+| `physical.density.value_kg_m3` | 7 | 12 | 4 | 2 | 30% |
+| `epd.id` | 4 | 14 | 6 | 1 | 17% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2015 LSL Summary.pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | strong-multi | 110 | `10d47f` (+4 more) | Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg \| US & CA] | epd.id, disp(1/2), group |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | strong-multi | 130 | `f0c8ce` (+4 more) | OSB sheathing / 7/16" / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-ISO.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-XPS.pdf | strong | 127 | `3kglse` | XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch | epd.id, disp(2/3), group, mat |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD_Polyiso walls.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | strong | 160 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, disp(3/4), group |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Lafarge Canada"` vs catalogue `"Portland Cement Association"`
+
+**05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Canadian Institute of Steel Construction"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"1905-5299 Declaration product"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/EPD_document_S-P-10278_en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"SDI"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"341 Declaration Number"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"8705-0201 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3079-2583 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3688-5839 Declaration product"` vs catalogue `"7740-1109"`
+
+**06 Wood/2013 BC Wood LVL EPD.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"American Wood Council and Canadian Wood Council"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `7.05`
+- `epd.id` — candidate `"13CA24184.105.1"` vs catalogue `"SCS-EPD-07526"`
+
+**06 Wood/2016 BC Wood LSL AWC.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"American Wood Council"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787193543.101.1"` vs catalogue `"EPD-117"`
+
+**06 Wood/2017 BC Wood WRC AWC EPD.pdf** (top: `10d47f` — Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"the United States of America"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `456`
+
+**06 Wood/2020 BC Wood OSB EPD.pdf** (top: `f0c8ce` — OSB sheathing / 7/16" / AWC & CWC [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `620`
+
+**06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**06 Wood/2023 BC Wood CLT EPD ASTM.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 395"` vs catalogue `"6742-7944"`
+
+**06 Wood/2023 BC Wood GLT EPD ASTM.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 396"` vs catalogue `"EPD296"`
+
+**07 Thermal/Boreal_Nature_Elite_TDS.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**07 Thermal/EPD Sopra-XPS.pdf** (top: `3kglse` — XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch):
+- `manufacturer.name` — candidate `"Canada J2C 8E9"` vs catalogue `"Soprema"`
+
+**07 Thermal/EPD_Genyk_EN-FINAL.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `manufacturer.name` — candidate `"the exposure of nitrogen oxides"` vs catalogue `"Carlisle"`
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `32`
+- `epd.id` — candidate `"EPD 503 Genyk e 1701 3 Avenue Shawinigan"` vs catalogue `"4790550934-101.1"`
+
+**07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `classification.material_type` — candidate `"Wood fiber insulation"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-mfr-fixes.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-mfr-fixes.md
@@ -1,0 +1,307 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:36:58.382Z
+Samples: 30 · metadata: 290/420 (69.0%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 14/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 11/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 8/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 14/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 14/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 12/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 14/30 | 47% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 6/30 | 20% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 13/30 | 43% |  |
+| 3 | `acidification_kgso2eq` — AP | 11/30 | 37% |  |
+| 4 | `eutrophication_kgneq` — EP | 13/30 | 43% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 11/30 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 11/30 | 37% |  |
+| 7 | `water_consumption_m3` — WDP | 2/30 | 7% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 4/30 | 13% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 7/30 | 23% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 6/30 | 20% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/30 | 7% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 3/30 | 10% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 5/30 | 17% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 6/30 | 20% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/30 | 7% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 4/30 | 13% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/30 | 10% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/30 | 7% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/30 | 7% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 2/30 | 7% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 2/30 | 7% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 17/30 | 57% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 11/30 | 37% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 14/30 | 47% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 1/30 | 3% | thin |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 2/30 | 7% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 10/30 | 33% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 10/30 | 33% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 13/30 | 43% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 23/30 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 2/30 | 7% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 21/30 | 70% |  |
+| 3 | `acidification_kgso2eq` | 24/30 | 80% |  |
+| 4 | `eutrophication_kgneq` | 22/30 | 73% |  |
+| 5 | `smog_kgo3eq` | 14/30 | 47% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 10/30 | 33% |  |
+| 7 | `water_consumption_m3` | 14/30 | 47% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/30 | 7% |  |
+| 9 | `primary_energy_renewable_mj` | 2/30 | 7% |  |
+| 10 | `gwp_kgco2e` | 5/30 | 17% |  |
+| 11 | `gwp_bio_kgco2e` | 0/30 | 0% | DEAD |
+| 12 | `acidification_kgso2eq` | 5/30 | 17% |  |
+| 13 | `eutrophication_kgneq` | 5/30 | 17% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 5/30 | 17% |  |
+| 15 | `smog_kgo3eq` | 5/30 | 17% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 5/30 | 17% |  |
+| 17 | `water_consumption_m3` | 0/30 | 0% | DEAD |
+| 18 | `primary_energy_nonrenewable_mj` | 0/30 | 0% | DEAD |
+| 19 | `primary_energy_renewable_mj` | 0/30 | 0% | DEAD |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 3/30 | 10% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 2/30 | 7% |  |
+| 2 | `acidification_kgso2eq` | 1/30 | 3% | thin |
+| 3 | `eutrophication_kgneq` | 2/30 | 7% |  |
+| 4 | `smog_kgo3eq` | 1/30 | 3% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 1/30 | 3% | thin |
+| 6 | `water_consumption_m3` | 1/30 | 3% | thin |
+
+## Catalogue parity check
+
+30 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 5/30 | 17% |
+| strong-multi | 2/30 | 7% |
+| medium | 0/30 | 0% |
+| medium-multi | 10/30 | 33% |
+| weak | 8/30 | 27% |
+| unmatched | 5/30 | 17% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 24 | 0 | 1 | 0 | 96% |
+| `classification.material_type` | 13 | 3 | 8 | 1 | 54% |
+| `manufacturer.name` | 7 | 12 | 5 | 1 | 29% |
+| `physical.density.value_kg_m3` | 7 | 12 | 4 | 2 | 30% |
+| `epd.id` | 4 | 14 | 6 | 1 | 17% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2015 LSL Summary.pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | strong-multi | 110 | `10d47f` (+4 more) | Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg \| US & CA] | epd.id, disp(1/2), group |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | strong-multi | 130 | `f0c8ce` (+4 more) | OSB sheathing / 7/16" / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-ISO.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-XPS.pdf | strong | 127 | `3kglse` | XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch | epd.id, disp(2/3), group, mat |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD_Polyiso walls.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Lafarge Canada"` vs catalogue `"Portland Cement Association"`
+
+**05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Canadian Institute of Steel Construction"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"1905-5299 Declaration product"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/EPD_document_S-P-10278_en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"SDI"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"341 Declaration Number"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"8705-0201 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3079-2583 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3688-5839 Declaration product"` vs catalogue `"7740-1109"`
+
+**06 Wood/2013 BC Wood LVL EPD.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"American Wood Council and Canadian Wood Council"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `7.05`
+- `epd.id` — candidate `"13CA24184.105.1"` vs catalogue `"SCS-EPD-07526"`
+
+**06 Wood/2016 BC Wood LSL AWC.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"American Wood Council"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787193543.101.1"` vs catalogue `"EPD-117"`
+
+**06 Wood/2017 BC Wood WRC AWC EPD.pdf** (top: `10d47f` — Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"the United States of America"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `456`
+
+**06 Wood/2020 BC Wood OSB EPD.pdf** (top: `f0c8ce` — OSB sheathing / 7/16" / AWC & CWC [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `620`
+
+**06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**06 Wood/2023 BC Wood CLT EPD ASTM.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 395"` vs catalogue `"6742-7944"`
+
+**06 Wood/2023 BC Wood GLT EPD ASTM.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 396"` vs catalogue `"EPD296"`
+
+**07 Thermal/Boreal_Nature_Elite_TDS.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**07 Thermal/EPD Sopra-XPS.pdf** (top: `3kglse` — XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch):
+- `manufacturer.name` — candidate `"Canada J2C 8E9"` vs catalogue `"Soprema"`
+
+**07 Thermal/EPD_Genyk_EN-FINAL.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `manufacturer.name` — candidate `"the exposure of nitrogen oxides"` vs catalogue `"Carlisle"`
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `32`
+- `epd.id` — candidate `"EPD 503 Genyk e 1701 3 Avenue Shawinigan"` vs catalogue `"4790550934-101.1"`
+
+**07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-type.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_canonical_post-type.md
@@ -1,0 +1,307 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:57:03.993Z
+Samples: 30 · metadata: 290/420 (69.0%) · impacts: 180/300 (60.0%) · by_stage: 494/5100 (9.7%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | nsf | 10 | 9/14 | 6/10 | 0/170 | 838 | 2.81e-5 | 2.89 | 0.832 | 36 | · | 0.985 | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | na | 23 | 14/14 | 7/10 | 21/170 | 1190 | 3.39e-5 | 3.05 | 0.207 | 43.9 | 14400 | 9.1969 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | epd_international | 17 | 12/14 | 7/10 | 10/170 | 8.47 | 8.08e-10 | 7.69e-5 | 7.99e-3 | · | 120 | 2.89 | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | na | 14 | 12/14 | 5/10 | 19/170 | 1.1400000000000001 | 1.61e-12 | 6.05e-3 | 1.36e-4 | · | · | 4.563000000000001 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 16.3 | 18200 | 2020 |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | na | 20 | 14/14 | 9/10 | 48/170 | 1067.4 | 8.12e-10 | 1.9852 | 0.09068 | 35.529 | 1087.1000000000001 | 3.28 | 14500 | 1180 |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | na | 19 | 14/14 | 9/10 | 48/170 | 1257 | 8.50e-10 | 2.6046 | 0.11893000000000001 | 49.516 | 1398.3999999999999 | 6.19 | 18200 | 2020 |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | na | 16 | 11/14 | 6/10 | 0/170 | 201.8 | 0.00e+0 | · | 0.0855 | 26.95 | · | · | 3338.45 | 3329.08 |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | unknown | 4 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | na | 17 | 8/14 | 7/10 | 15/170 | 620.56 | 0.00e+0 | 4.82 | 0.1418 | 68.1 | · | · | 4810.87 | 7574.23 |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | na | 8 | 6/14 | 5/10 | 0/170 | 19.87 | 4.36e-6 | 16.25 | 0.63 | 0.06 | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.120000000269 | 3.16 | 3.12 | 4.27 | 296.46 | 0.16 | 576.04 | 1354.71 |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000290000003 | 3.21 | 3.13 | 5.5 | 459.9 | 1.05 | 4206.41 | 3490.16 |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unknown | 2 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | na | 12 | 14/14 | 10/10 | 15/170 | 100.57 | 2.52e-6 | 1.1 | 0.13 | 23.25 | 1462.67 | 0.17 | 182 | 4538.05 |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 164.52999999999997 | 0.00e+0 | 2.19 | 0.21 | 47.35 | 1569.54 | 0.76 | 1991.34 | 4984.39 |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | na | 11 | 14/14 | 10/10 | 18/170 | 45.86 | 1.40e-6 | 0.58 | 0.06 | 11.93 | 698.93 | 0.03 | 760.87 | 3381.89 |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | na | 11 | 14/14 | 10/10 | 26/170 | 221.94 | 2.77e-6 | 2.4 | 0.22000000000000003 | 27.27 | 2672.52 | 0.4 | 290 | 1205.02 |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | unknown | 2 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | unknown | 34 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | na | 33 | 12/14 | 4/10 | 36/170 | 2 | 3.43e-7 | 0.015960000000000002 | 5.31e-3 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | na | 40 | 12/14 | 4/10 | 31/170 | 4.04 | 5.09e-7 | 2.0999999999999996 | 0.02474 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | unknown | 23 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | 5 | · | · | · | 5 | · | · | · | · | · |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2015 LSL Summary.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | · | · | · | · | · | · | · | · | · | · |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | 3 | · | · | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | 5 | · | 4 | 4 | 4 | 4 | 1 | 4 | · | · |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-ISO.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD Sopra-XPS.pdf | · | · | 12 | 12 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | 2 | · | 12 | 5 | 12 | · | · | · | · | · |
+| 07 Thermal/EPD_Polyiso walls.pdf | · | · | · | · | · | · | · | · | · | · |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 14/30 | 47% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 6/30 | 20% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 13/30 | 43% |  |
+| 3 | `acidification_kgso2eq` — AP | 11/30 | 37% |  |
+| 4 | `eutrophication_kgneq` — EP | 13/30 | 43% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 11/30 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 11/30 | 37% |  |
+| 7 | `water_consumption_m3` — WDP | 2/30 | 7% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 4/30 | 13% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 7/30 | 23% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 6/30 | 20% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/30 | 7% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 3/30 | 10% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 5/30 | 17% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 6/30 | 20% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/30 | 7% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 4/30 | 13% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/30 | 10% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/30 | 7% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/30 | 7% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 2/30 | 7% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 2/30 | 7% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 17/30 | 57% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 11/30 | 37% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 14/30 | 47% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 1/30 | 3% | thin |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 2/30 | 7% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 10/30 | 33% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 10/30 | 33% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 13/30 | 43% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 23/30 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 2/30 | 7% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 21/30 | 70% |  |
+| 3 | `acidification_kgso2eq` | 24/30 | 80% |  |
+| 4 | `eutrophication_kgneq` | 22/30 | 73% |  |
+| 5 | `smog_kgo3eq` | 14/30 | 47% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 10/30 | 33% |  |
+| 7 | `water_consumption_m3` | 14/30 | 47% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/30 | 7% |  |
+| 9 | `primary_energy_renewable_mj` | 2/30 | 7% |  |
+| 10 | `gwp_kgco2e` | 5/30 | 17% |  |
+| 11 | `gwp_bio_kgco2e` | 0/30 | 0% | DEAD |
+| 12 | `acidification_kgso2eq` | 5/30 | 17% |  |
+| 13 | `eutrophication_kgneq` | 5/30 | 17% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 5/30 | 17% |  |
+| 15 | `smog_kgo3eq` | 5/30 | 17% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 5/30 | 17% |  |
+| 17 | `water_consumption_m3` | 0/30 | 0% | DEAD |
+| 18 | `primary_energy_nonrenewable_mj` | 0/30 | 0% | DEAD |
+| 19 | `primary_energy_renewable_mj` | 0/30 | 0% | DEAD |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 30 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 3/30 | 10% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 2/30 | 7% |  |
+| 2 | `acidification_kgso2eq` | 1/30 | 3% | thin |
+| 3 | `eutrophication_kgneq` | 2/30 | 7% |  |
+| 4 | `smog_kgo3eq` | 1/30 | 3% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 1/30 | 3% | thin |
+| 6 | `water_consumption_m3` | 1/30 | 3% | thin |
+
+## Catalogue parity check
+
+30 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 5/30 | 17% |
+| strong-multi | 2/30 | 7% |
+| medium | 0/30 | 0% |
+| medium-multi | 10/30 | 33% |
+| weak | 8/30 | 27% |
+| unmatched | 5/30 | 17% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 24 | 0 | 1 | 0 | 96% |
+| `classification.material_type` | 13 | 3 | 8 | 1 | 54% |
+| `manufacturer.name` | 7 | 12 | 5 | 1 | 29% |
+| `physical.density.value_kg_m3` | 7 | 12 | 4 | 2 | 30% |
+| `epd.id` | 4 | 14 | 6 | 1 | 17% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| 03 Concrete/CRMCA Ontario Regional Industry-Avg Concrete EPD 2022.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| 05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/EPD_document_S-P-10278_en.pdf | medium-multi | 50 | `mps003` (+4 more) | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, group |
+| 05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf | strong | 80 | `mps003` | Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge | mfr, disp(1/2), group, mat |
+| 06 Wood/2013 BC Wood LVL EPD.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| 06 Wood/2015 BC Wood DF Density (No EPD).pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2015 LSL Summary.pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2016 BC Wood LSL AWC.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| 06 Wood/2016 BC Wood WRC EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| 06 Wood/2017 BC Wood WRC AWC EPD.pdf | strong-multi | 110 | `10d47f` (+4 more) | Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg \| US & CA] | epd.id, disp(1/2), group |
+| 06 Wood/2020 BC Wood OSB EPD.pdf | strong-multi | 130 | `f0c8ce` (+4 more) | OSB sheathing / 7/16" / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| 06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2022 BC Wood Hemlock Density (No EPD).pdf | unmatched | 0 | — | — | — |
+| 06 Wood/2023 BC Wood CLT EPD ASTM.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| 06 Wood/2023 BC Wood GLT EPD ASTM.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| 06 Wood/2023 BC Wood SPF EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 06 Wood/2023 BC Wood SPF Plywood EPD ASTM.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| 07 Thermal/Boreal_Nature_Elite_TDS.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD Sopra-Cellullose.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-ISO.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD Sopra-XPS.pdf | strong | 127 | `3kglse` | XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch | epd.id, disp(2/3), group, mat |
+| 07 Thermal/EPD_Genyk_EN-FINAL.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| 07 Thermal/EPD_Polyiso walls.pdf | unmatched | 0 | — | — | — |
+| 07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**03 Concrete/Lafarge Exshaw Cement Plant EPD.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Lafarge Canada"` vs catalogue `"Portland Cement Association"`
+
+**05 Metals/CISC Industry-Avg Fabricated Hot-Rolled Structural Sections EPD 2021.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Canadian Institute of Steel Construction"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"1905-5299 Declaration product"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/EPD_document_EPD-IES-0010278_002__S-P-10278__en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/EPD_document_S-P-10278_en.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `7800`
+- `epd.id` — candidate `"S-P-10278"` vs catalogue `"7740-1109"`
+
+**05 Metals/Fabricated Structural Steel Plates EPD 2019.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"SDI"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"341 Declaration Number"` vs catalogue `"4789365778.101.1"`
+
+**05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"8705-0201 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-hollow-structural-sections-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3079-2583 Declaration product"` vs catalogue `"7740-1109"`
+
+**05 Metals/xcarb-epd-for-steel-deck-final_v3_updated.pdf** (top: `mps003` — Metal panels - steel / ArcelorMittal / XCarb RRP / 24 gauge):
+- `epd.id` — candidate `"3688-5839 Declaration product"` vs catalogue `"7740-1109"`
+
+**06 Wood/2013 BC Wood LVL EPD.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"American Wood Council and Canadian Wood Council"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `7.05`
+- `epd.id` — candidate `"13CA24184.105.1"` vs catalogue `"SCS-EPD-07526"`
+
+**06 Wood/2016 BC Wood LSL AWC.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"American Wood Council"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787193543.101.1"` vs catalogue `"EPD-117"`
+
+**06 Wood/2017 BC Wood WRC AWC EPD.pdf** (top: `10d47f` — Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"the United States of America"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `456`
+
+**06 Wood/2020 BC Wood OSB EPD.pdf** (top: `f0c8ce` — OSB sheathing / 7/16" / AWC & CWC [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `620`
+
+**06 Wood/2022 BC Wood CLT Kalesnikoff EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**06 Wood/2023 BC Wood CLT EPD ASTM.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 395"` vs catalogue `"6742-7944"`
+
+**06 Wood/2023 BC Wood GLT EPD ASTM.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"British Columbia According to EN"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 396"` vs catalogue `"EPD296"`
+
+**07 Thermal/Boreal_Nature_Elite_TDS.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**07 Thermal/EPD Sopra-XPS.pdf** (top: `3kglse` — XPS foam board / SOPREMA / SOPRA-XPS (entire product line) / R 5.0-inch):
+- `manufacturer.name` — candidate `"Canada J2C 8E9"` vs catalogue `"Soprema"`
+
+**07 Thermal/EPD_Genyk_EN-FINAL.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `manufacturer.name` — candidate `"the exposure of nitrogen oxides"` vs catalogue `"Carlisle"`
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `32`
+- `epd.id` — candidate `"EPD 503 Genyk e 1701 3 Avenue Shawinigan"` vs catalogue `"4790550934-101.1"`
+
+**07 Thermal/EPD_Wood Fibre Insulating Boards Environmental Product Declaration_3_13-02-2020.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+
+## Ground-truth checks (workplan §10.3)
+
+2 samples annotated · 0 extraction failures · 0 silent-override violations · 0 defaults-applied failures
+
+| Sample | Published keys | Omitted keys | Extraction ✗ | Silent overrides ✗ | Defaults applied ✗ |
+|---|---:|---:|---:|---:|---:|
+| 05 Metals/xcarb-epd-for-cold-formed-sections-final_v3_updated.pdf | 64 | 0 | 0 | 0 | 0 |
+| 06 Wood/2022 BC Wood GLT Kalesnikoff EPD.pdf | 54 | 0 | 0 | 0 | 0 |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam.md
@@ -1,0 +1,510 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T15:50:57.956Z
+Samples: 208 · metadata: 1758/2912 (60.4%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 10/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 7/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 7/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 10/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 11/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 8/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 10/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 11/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 9/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 10/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 10/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 9/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 11/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 11/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 11/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 10/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 11/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 10/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 9/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 11/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 8/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 10/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 10/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 9/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 7/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 9/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 8/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 10/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 10/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 10/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 11/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 5/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 10/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 11/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 11/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 10/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 9/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 8/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 11/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 8/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 10/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 7/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 11/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 10/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 7/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 7/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 10/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 10/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 8/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 10/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 10/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 10/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 10/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 11/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 10/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 10/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 6/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 10/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 10/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 10/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 10/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 10/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 7/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 10/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 8/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 10/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 8/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 10/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 10/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 8/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 10/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 10/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 10/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 11/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 10/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 9/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 9/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 9/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 10/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 10/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 10/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 8/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_parity.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_parity.md
@@ -1,0 +1,1216 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:11:03.908Z
+Samples: 208 · metadata: 1758/2912 (60.4%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 10/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 7/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 7/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 10/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 11/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 8/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 10/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 11/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 9/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 10/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 10/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 9/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 11/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 11/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 11/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 10/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 11/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 10/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 9/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 11/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 8/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 10/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 10/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 9/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 7/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 9/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 8/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 10/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 10/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 10/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 11/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 5/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 10/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 11/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 11/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 10/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 9/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 8/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 11/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 8/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 10/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 7/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 11/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 10/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 7/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 7/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 10/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 10/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 8/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 10/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 10/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 10/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 10/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 11/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 10/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 10/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 10/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 6/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 10/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 10/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 10/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 10/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 10/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 7/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 10/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 8/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 10/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 8/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 10/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 10/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 8/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 11/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 10/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 10/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 10/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 11/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 10/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 9/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 9/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 9/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 10/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 10/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 10/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 8/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |
+
+## Catalogue parity check
+
+208 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 16/208 | 8% |
+| strong-multi | 19/208 | 9% |
+| medium | 2/208 | 1% |
+| medium-multi | 47/208 | 23% |
+| weak | 94/208 | 45% |
+| unmatched | 30/208 | 14% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 153 | 17 | 8 | 0 | 86% |
+| `classification.material_type` | 94 | 29 | 49 | 6 | 55% |
+| `manufacturer.name` | 36 | 45 | 86 | 11 | 22% |
+| `physical.density.value_kg_m3` | 13 | 98 | 51 | 16 | 8% |
+| `epd.id` | 28 | 14 | 119 | 17 | 17% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | unmatched | 27 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | medium-multi | 50 | `xsp4tl` (+4 more) | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(2/2), group |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unmatched | 0 | — | — | — |
+| April 2022/EPD Durabella.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | strong-multi | 127 | `c9a7f3` (+1 more) | Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | strong | 170 | `vin001` | Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] | epd.id, mfr, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | strong-multi | 160 | `bri005` (+1 more) | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | strong-multi | 157 | `84c2b6` (+1 more) | Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg \| US-Canada] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | weak | 47 | `eps003` | EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg \| US & CA] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | medium-multi | 70 | `10d47f` (+4 more) | Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg \| US & CA] | mfr, disp(1/2), group |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | medium-multi | 70 | `ebd574` (+4 more) | Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg \| US & CA] | mfr, disp(1/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/EPD - Pac-Clad.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs DONE/Straw EPD UK.pdf | strong | 95 | `b4t02m` | Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg \| EU] | epd.id, disp(1/2) |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unmatched | 27 | — | — | — |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | strong-multi | 90 | `d0rk2l` (+1 more) | Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm) | epd.id, group |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | medium-multi | 55 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(1/2) |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | weak | 30 | `lvt001` | Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg \| US & CA] | disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | strong | 80 | `lin003` | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(3/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | strong | 110 | `cer002` | Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade / | epd.id, disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | strong | 120 | `cer001` | Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade / | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | weak | 37 | `4dadb7` | Ceramic tile / Crossville / Porcelain / Standard grade (mortar included) | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | medium-multi | 77 | `ins035` (+2 more) | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | strong | 80 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | strong-multi | 120 | `ins040` (+2 more) | Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg \| US & CA] | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | medium | 75 | `poly10` | Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | medium | 75 | `lec000` | Light expanded clay aggregate (LECA) / Leca Int'l / Leca Arlita 10-20 / R 1.3-inch, 10-20 mm [EU] | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | strong | 120 | `poly06` | Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | strong | 120 | `poly02` | Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | strong-multi | 120 | `poly05` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | strong | 120 | `poly01` | Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | strong-multi | 120 | `poly04` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | medium-multi | 50 | `1f3cc3` (+4 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | strong-multi | 80 | `ins006` (+1 more) | Fiberglass batt / Johns Manville / Unfaced, ComfortTherm, Cavity-SHIELD, FSK-25 / R 3.4-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | strong | 80 | `lam000` | Laminated Veneer Lumber (LVL) / Boise Cascade / Versa-Lam | mfr, disp(1/2), group, mat |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | medium-multi | 50 | `p8c2la` (+4 more) | Linoleum flooring / 2.5 mm [BEAM Avg] | disp(2/2), group |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | weak | 40 | `e075b4` | Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum | disp(1/1) |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | strong | 130 | `lam012` | Mass ply panels (MPP) / Freres Lumber | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | strong-multi | 80 | `ply003` (+4 more) | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | strong-multi | 80 | `ply003` (+4 more) | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | strong-multi | 120 | `int000` (+1 more) | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | weak | 35 | `l2jfis` | Rebar / Nucor Corporation / 10M | mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | medium-multi | 50 | `p8c2la` (+4 more) | Linoleum flooring / 2.5 mm [BEAM Avg] | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | medium-multi | 60 | `osb000` (+4 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | mfr, disp(1/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/DVP-window-EPD-mexico.pdf | unmatched | 0 | — | — | — |
+| Windows/EPD - Product Specific (32).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (33).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (34).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (37).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Italy-window.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Pursoy-Window -EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/SvenskaWindows.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Window-Finstral-EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/kawneer_window_epd.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | unmatched | 20 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"Composite Panel Association"` vs catalogue `"CPCI - PCI"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Concrete"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"Nov 2020 to"` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"S-P-06876"` vs catalogue `"01-004"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"CCMPA"` vs catalogue `"Portland Cement Association"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Boehmers"` vs catalogue `"Portland Cement Association"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf** (top: `c9a7f3` — Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `2060` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf** (top: `84c2b6` — Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg | US-Canada]):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `2120`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf** (top: `eps003` — EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `14.4`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf** (top: `10d47f` — Wood / Redwood / Lumber by volume / AWC & CWC [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `456`
+
+**EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Nucor Steel Auburn"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf** (top: `ebd574` — Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `548`
+
+**EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `manufacturer.name` — candidate `"TM"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/EPD - Pac-Clad.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `manufacturer.name` — candidate `"HBS"` vs catalogue `"Carlisle"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**EPDs DONE/EPD_-_RFPIJoist-2.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/EPD_-_RigidLam_LVL-1.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/Straw EPD UK.pdf** (top: `b4t02m` — Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+
+**EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf** (top: `d0rk2l` — Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm)):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Bamboo"`
+- `manufacturer.name` — candidate `"Zhejiang Daocheng Bamboo Industry Co., Ltd"` vs catalogue `"Dasso"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `1150`
+
+**EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered Wood siding"`
+
+**EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"North American Fiberboard Association"` vs catalogue `"CPCI - PCI"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf** (top: `lvt001` — Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"EGE SERAM"` vs catalogue `"Resilient Floor Covering Institute"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"ASSA ABLOY Door Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"James"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"S-P-01432"` vs catalogue `"EPD 034"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf** (top: `4dadb7` — Ceramic tile / Crossville / Porcelain / Standard grade (mortar included)):
+- `manufacturer.name` — candidate `"RAK Ceramics"` vs catalogue `"Crossville"`
+- `epd.id` — candidate `"EPD 165"` vs catalogue `"4788863727.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `35`
+- `epd.id` — candidate `"EPD-GTX-20180071-IBA1-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 247"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 246"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf** (top: `ins040` — Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Hemp fiber"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf** (top: `poly10` — Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Polyisocyanurate"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `33.73`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf** (top: `lec000` — Light expanded clay aggregate (LECA) / Leca Int'l / Leca Arlita 10-20 / R 1.3-inch, 10-20 mm [EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"04"`
+- `classification.material_type` — candidate `"Polyisocyanurate"` vs catalogue `"Leca"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Leca International"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf** (top: `poly06` — Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Carlisle"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD 273"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf** (top: `poly02` — Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf** (top: `poly05` — Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf** (top: `poly01` — Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf** (top: `poly04` — Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Fiberglass"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `0.488`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `manufacturer.name` — candidate `"TM"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf** (top: `e075b4` — Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Forbo"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"LONGi Solar PV"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Tecnoglass, Inc."` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf** (top: `lam012` — Mass ply panels (MPP) / Freres Lumber):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `546`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"Factory of USG Middle East Ltd. Co."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `753` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf** (top: `ply003` — Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `8.9`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf** (top: `ply003` — Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `8.9`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Schluter Systems"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"USG"` vs catalogue `"DATABASE AVERAGE"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"YKK AP America"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/EPD - Product Specific (32).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/EPD - Product Specific (33).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/EPD - Product Specific (34).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/EPD - Product Specific (37).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"ES Windows by Tecnoglass"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20150313-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Italy-window.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-00514"` vs catalogue `"4789365778.101.1"`
+
+**Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/Pursoy-Window -EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Purso Oy"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-03838"` vs catalogue `"4789365778.101.1"`
+
+**Windows/SvenskaWindows.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Svenska F"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-01969"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Window-Finstral-EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-05676"` vs catalogue `"4789365778.101.1"`
+
+**Windows/kawneer_window_epd.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/scs-epd-07201_andersencorp_e-series_092721.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"IBU - Institut Bauen und Umwelt e.V. Fermacell GmbH"` vs catalogue `"CMS"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-dates.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-dates.md
@@ -1,0 +1,1338 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:49:54.859Z
+Samples: 208 · metadata: 1902/2912 (65.3%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 11/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 8/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 12/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 11/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 12/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 9/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 11/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 11/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 12/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 9/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 11/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 11/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 12/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 12/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 11/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 12/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 9/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 11/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 8/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 9/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 12/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 13/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 8/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 11/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 12/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 11/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 10/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 10/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 12/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 11/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 8/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 12/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 11/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 8/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 11/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 9/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 12/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 12/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 11/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 11/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 8/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 12/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 11/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 8/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 11/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 9/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 12/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 12/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 9/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 11/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 12/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 11/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 12/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 11/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 11/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 11/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 11/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 11/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 12/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 12/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 8/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |
+
+## Catalogue parity check
+
+208 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 33/208 | 16% |
+| strong-multi | 26/208 | 13% |
+| medium | 4/208 | 2% |
+| medium-multi | 39/208 | 19% |
+| weak | 76/208 | 37% |
+| unmatched | 30/208 | 14% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 143 | 27 | 8 | 0 | 80% |
+| `classification.material_type` | 84 | 35 | 54 | 5 | 49% |
+| `manufacturer.name` | 36 | 78 | 60 | 4 | 21% |
+| `physical.density.value_kg_m3` | 10 | 102 | 54 | 12 | 6% |
+| `epd.id` | 68 | 51 | 54 | 5 | 39% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | unmatched | 27 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | medium-multi | 50 | `xsp4tl` (+4 more) | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(2/2), group |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unmatched | 0 | — | — | — |
+| April 2022/EPD Durabella.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | medium-multi | 50 | `cmu000` (+3 more) | CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg \| CA] | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | strong-multi | 115 | `cmu004` (+1 more) | CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16 | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | strong | 160 | `f33e5e` | Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | strong-multi | 127 | `c9a7f3` (+1 more) | Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | strong | 170 | `vin001` | Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] | epd.id, mfr, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | strong-multi | 160 | `bri005` (+1 more) | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | strong-multi | 157 | `84c2b6` (+1 more) | Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg \| US-Canada] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | weak | 47 | `eps003` | EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg \| US & CA] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | medium-multi | 75 | `mpa001` (+1 more) | Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060" | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | strong | 130 | `4k2v0s` | Laminated strand lumber (LSL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | medium-multi | 75 | `l2jfis` (+4 more) | Rebar / Nucor Corporation / 10M | epd.id |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | strong | 150 | `ebd574` | Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | strong | 127 | `175f1a` | XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - Pac-Clad.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | strong | 120 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | strong | 120 | `rnd601` | Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch | epd.id, disp(3/4), group |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | strong | 150 | `9aedf1` | Wood I joist / Roseburg / RFPI Joist / | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs DONE/Straw EPD UK.pdf | strong | 95 | `b4t02m` | Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg \| EU] | epd.id, disp(1/2) |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unmatched | 27 | — | — | — |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | strong-multi | 90 | `d0rk2l` (+1 more) | Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm) | epd.id, group |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | strong | 120 | `f4l2kx` | Wood fiber board / R 2.7-inch / NAFA [Industry Avg \| US & CA] | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | weak | 30 | `lvt001` | Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg \| US & CA] | disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | strong | 80 | `lin003` | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(3/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | strong | 120 | `lvt007` | Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | medium-multi | 75 | `car003` (+1 more) | Carpet / Shaw / Strataworx / Carpet tile | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | strong | 110 | `cer002` | Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade / | epd.id, disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | strong | 120 | `cer001` | Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade / | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | weak | 37 | `4dadb7` | Ceramic tile / Crossville / Porcelain / Standard grade (mortar included) | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | medium-multi | 77 | `ins035` (+2 more) | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | medium-multi | 50 | `hwf000` (+4 more) | HempWood / Fibonacci / Natural Laminate Flooring / 16 mm | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | strong-multi | 120 | `ins040` (+2 more) | Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg \| US & CA] | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | medium | 75 | `poly10` | Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | strong | 120 | `poly06` | Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | strong | 120 | `poly02` | Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | strong-multi | 120 | `poly05` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | strong | 120 | `poly01` | Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | strong-multi | 120 | `poly04` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | medium-multi | 50 | `1f3cc3` (+4 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | strong | 160 | `ins009` | Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | weak | 40 | `e075b4` | Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum | disp(1/1) |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | strong | 90 | `lam012` | Mass ply panels (MPP) / Freres Lumber | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | medium-multi | 70 | `f14060` (+1 more) | Wood framing - Softwood / Roseburg / | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | strong | 160 | `ply003` | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | strong-multi | 160 | `ply004` (+1 more) | Plywood / 1/2" / Roseburg softwood plywood / | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | medium | 75 | `car001` | Carpet / Shaw / Residential Broadloom | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | strong-multi | 120 | `int000` (+1 more) | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | weak | 35 | `l2jfis` | Rebar / Nucor Corporation / 10M | mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | medium-multi | 75 | `mwb012` (+4 more) | Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | medium-multi | 60 | `osb000` (+4 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | mfr, disp(1/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/DVP-window-EPD-mexico.pdf | unmatched | 0 | — | — | — |
+| Windows/EPD - Product Specific (32).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (33).pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| Windows/EPD - Product Specific (34).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (37).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Italy-window.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Pursoy-Window -EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/SvenskaWindows.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Window-Finstral-EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/kawneer_window_epd.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | strong-multi | 90 | `2fg4um` (+4 more) | OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8" | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | unmatched | 20 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.101.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"Composite Panel Association"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787549627.101.1"` vs catalogue `"EPD-117"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Concrete"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"Nov 2020 to"` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"S-P-06876"` vs catalogue `"01-004"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4790057043.103.1 2"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf** (top: `cmu000` — CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg | CA]):
+- `classification.material_type` — candidate `"Portland Cement"` vs catalogue `"Concrete"`
+- `epd.id` — candidate `"1 m3 of concrete formed into manufactured"` vs catalogue `"EPD-338"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf** (top: `cmu004` — CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16):
+- `classification.group_prefix` — candidate `"03"` vs catalogue `"04"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf** (top: `f33e5e` — Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.574`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf** (top: `c9a7f3` — Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties):
+- `manufacturer.name` — candidate `"Climate Earth, Inc"` vs catalogue `"Interstate"`
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `2060` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf** (top: `84c2b6` — Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg | US-Canada]):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `2120`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf** (top: `eps003` — EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `14.4`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf** (top: `mpa001` — Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060"):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Aluminum"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `10.49`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Long Products Canada"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf** (top: `4k2v0s` — Laminated strand lumber (LSL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Framing"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `570.22`
+
+**EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `manufacturer.name` — candidate `"Nucor Steel Auburn"` vs catalogue `"Nucor Corporation"`
+
+**EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf** (top: `ebd574` — Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `548`
+
+**EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf** (top: `175f1a` — XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi):
+- `manufacturer.name` — candidate `"the facilities TM TM located"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - Pac-Clad.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `manufacturer.name` — candidate `"the Pennsauken"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf** (top: `rnd601` — Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"HBS during the year. The"` vs catalogue `"Huntsman Building Solutions"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `38.4`
+
+**EPDs DONE/EPD_-_RFPIJoist-2.pdf** (top: `9aedf1` — Wood I joist / Roseburg / RFPI Joist /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `3.9`
+
+**EPDs DONE/EPD_-_RigidLam_LVL-1.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/Straw EPD UK.pdf** (top: `b4t02m` — Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+
+**EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf** (top: `d0rk2l` — Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm)):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Bamboo"`
+- `manufacturer.name` — candidate `"Zhejiang Daocheng Bamboo Industry Co., Ltd"` vs catalogue `"Dasso"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `1150`
+
+**EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD192"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf** (top: `lvt001` — Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"EGE SERAM"` vs catalogue `"Resilient Floor Covering Institute"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"ASSA ABLOY Door Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789049516.178.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"James"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"S-P-01432"` vs catalogue `"EPD 034"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf** (top: `lvt007` — Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"several stages beginning with the"` vs catalogue `"Shaw - Patcraft"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `0.00576`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf** (top: `car003` — Carpet / Shaw / Strataworx / Carpet tile):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Nylon"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf** (top: `cer002` — Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Aromas"` vs catalogue `"Fireclay Tile"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf** (top: `cer001` — Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Lebanon"` vs catalogue `"American Wonder Porcelain"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf** (top: `4dadb7` — Ceramic tile / Crossville / Porcelain / Standard grade (mortar included)):
+- `manufacturer.name` — candidate `"RAK Ceramics. Since tiles are"` vs catalogue `"Crossville"`
+- `epd.id` — candidate `"EPD 165"` vs catalogue `"4788863727.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `35`
+- `epd.id` — candidate `"EPD-GTX-20180071-IBA1-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Edmonton"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 247"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Boissevain"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 246"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf** (top: `hwf000` — HempWood / Fibonacci / Natural Laminate Flooring / 16 mm):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `1063` vs catalogue `10.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf** (top: `ins040` — Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"each member"` vs catalogue `"SPFA"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Hemp fiber"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf** (top: `poly10` — Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Polyisocyanurate"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `33.73`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf** (top: `d0rm3c` — Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"PIMA"`
+- `epd.id` — candidate `"EPD 254 Product Polyisocyanurate High-Density"` vs catalogue `"EPD10465"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf** (top: `poly06` — Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Carlisle"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD 273 Product Polyisocyanurate Wall Insulation"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf** (top: `poly02` — Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf** (top: `poly05` — Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf** (top: `poly01` — Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf** (top: `poly04` — Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Fiberglass"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `0.488`
+- `epd.id` — candidate `"4787358620.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf** (top: `ins009` — Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.46`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"Boise Cascade in White City"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `483.4` vs catalogue `7.05`
+- `epd.id` — candidate `"Veneer Laminated Timber"` vs catalogue `"SCS-EPD-07526"`
+
+**Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Linoleum flooring EPD/EPD - Tarket Linoleum.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789275679.141.1"` vs catalogue `"4789365778.101.1"`
+
+**Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf** (top: `e075b4` — Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Forbo"`
+- `epd.id` — candidate `"12CA64879.101.1"` vs catalogue `"4790690881.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. LONGi solar monocrystalline"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4790285205.101.1 LR4-72HBD"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Tecnoglass, Inc."` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf** (top: `lam012` — Mass ply panels (MPP) / Freres Lumber):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `manufacturer.name` — candidate `"Freres Lumber in Lyons"` vs catalogue `"Freres Lumber Company Inc."`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `546`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789198858.107.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Manufacturer VP-001 O.C.O Technology Ltd"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"Factory of USG Middle East Ltd. Co."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Joplin"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.103.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf** (top: `f14060` — Wood framing - Softwood / Roseburg /):
+- `physical.density.value_kg_m3` — candidate `753` vs catalogue `456`
+- `epd.id` — candidate `"4789110727.101"` vs catalogue `"4786969381.105.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf** (top: `ply003` — Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `8.9`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+- `epd.id` — candidate `"4786969381.101.1"` vs catalogue `"4786969381.104.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf** (top: `ply004` — Plywood / 1/2" / Roseburg softwood plywood /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `4.38`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.103.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Schluter Systems"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4787455040.102.1"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. JA Solar mono-crystalline"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790076867.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf** (top: `car001` — Carpet / Shaw / Residential Broadloom):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.145.1"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"the facilities shown in the"` vs catalogue `"National Gypsum"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `epd.id` — candidate `"4789971341.101.1"` vs catalogue `"4789793365.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Wabash"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.102.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf** (top: `mwb012` — Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Mineral wool"`
+- `manufacturer.name` — candidate `"the locations listed below. Wabash"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `epd.id` — candidate `"4789103593.103.1"` vs catalogue `"4789103593.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"USG"` vs catalogue `"DATABASE AVERAGE"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"YKK AP America"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4786832322.107.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/EPD - Product Specific (32).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.103.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (33).pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**Windows/EPD - Product Specific (34).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.101.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (37).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"ES Windows by Tecnoglass"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.104.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20150313-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Italy-window.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-00514"` vs catalogue `"4789365778.101.1"`
+
+**Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/Pursoy-Window -EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Purso Oy"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-03838"` vs catalogue `"4789365778.101.1"`
+
+**Windows/SvenskaWindows.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Svenska F"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-01969"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Window-Finstral-EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-05676"` vs catalogue `"4789365778.101.1"`
+
+**Windows/kawneer_window_epd.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/scs-epd-07201_andersencorp_e-series_092721.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf** (top: `2fg4um` — OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8"):
+- `manufacturer.name` — candidate `"five different thicknesses"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `660`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"IBU - Institut Bauen und Umwelt e.V. Fermacell GmbH"` vs catalogue `"CMS"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-density-importer-fix.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-density-importer-fix.md
@@ -1,0 +1,1233 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T21:47:03.563Z
+Samples: 208 · metadata: 1925/2912 (66.1%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 10/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 9/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 9/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 12/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 10/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 12/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 9/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 9/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 11/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 13/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 13/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 11/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 11/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 11/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 12/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 12/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 11/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 12/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 10/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 11/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 10/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 10/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 13/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 12/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 14/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 9/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 11/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 12/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 12/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 10/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 10/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 12/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 11/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 8/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 12/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 11/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 9/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 8/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 11/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 9/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 12/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 12/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 11/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 10/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 9/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 9/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 12/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 11/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 8/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 11/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 9/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 12/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 12/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 9/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 11/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 12/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 12/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 12/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 12/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 12/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 11/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 12/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 12/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 9/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |
+
+## Catalogue parity check
+
+208 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 33/208 | 16% |
+| strong-multi | 23/208 | 11% |
+| medium | 4/208 | 2% |
+| medium-multi | 42/208 | 20% |
+| weak | 76/208 | 37% |
+| unmatched | 30/208 | 14% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 143 | 27 | 8 | 0 | 80% |
+| `classification.material_type` | 81 | 40 | 53 | 4 | 47% |
+| `manufacturer.name` | 36 | 78 | 60 | 4 | 21% |
+| `physical.density.value_kg_m3` | 7 | 36 | 99 | 36 | 5% |
+| `epd.id` | 68 | 51 | 54 | 5 | 39% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | medium-multi | 50 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | unmatched | 27 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | medium-multi | 50 | `xsp4tl` (+4 more) | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(2/2), group |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unmatched | 0 | — | — | — |
+| April 2022/EPD Durabella.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | medium-multi | 50 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | medium-multi | 50 | `cmu000` (+3 more) | CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg \| CA] | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | strong-multi | 115 | `cmu004` (+1 more) | CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16 | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | strong | 160 | `f33e5e` | Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | strong-multi | 127 | `c9a7f3` (+1 more) | Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | strong | 170 | `vin001` | Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] | epd.id, mfr, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | strong-multi | 160 | `bri005` (+1 more) | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | strong-multi | 157 | `84c2b6` (+1 more) | Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg \| US-Canada] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | weak | 47 | `eps003` | EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg \| US & CA] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | medium-multi | 75 | `mpa001` (+1 more) | Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060" | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | strong | 130 | `4k2v0s` | Laminated strand lumber (LSL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | medium-multi | 75 | `l2jfis` (+4 more) | Rebar / Nucor Corporation / 10M | epd.id |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | strong | 150 | `ebd574` | Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | strong | 127 | `175f1a` | XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - Pac-Clad.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | strong | 120 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | strong | 120 | `rnd601` | Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch | epd.id, disp(3/4), group |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | strong | 150 | `9aedf1` | Wood I joist / Roseburg / RFPI Joist / | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs DONE/Straw EPD UK.pdf | strong | 95 | `b4t02m` | Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg \| EU] | epd.id, disp(1/2) |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | strong-multi | 90 | `d0rk2l` (+1 more) | Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm) | epd.id, group |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | strong | 120 | `f4l2kx` | Wood fiber board / R 2.7-inch / NAFA [Industry Avg \| US & CA] | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | weak | 30 | `lvt001` | Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg \| US & CA] | disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | strong | 80 | `lin003` | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(3/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | strong | 120 | `lvt007` | Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | medium-multi | 75 | `car003` (+1 more) | Carpet / Shaw / Strataworx / Carpet tile | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | strong | 110 | `cer002` | Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade / | epd.id, disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | strong | 120 | `cer001` | Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade / | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | weak | 37 | `4dadb7` | Ceramic tile / Crossville / Porcelain / Standard grade (mortar included) | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | strong | 160 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | medium-multi | 77 | `ins035` (+2 more) | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | medium-multi | 50 | `hwf000` (+4 more) | HempWood / Fibonacci / Natural Laminate Flooring / 16 mm | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | strong-multi | 120 | `ins040` (+2 more) | Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg \| US & CA] | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | medium | 75 | `poly10` | Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | strong | 120 | `poly06` | Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | strong | 120 | `poly02` | Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | strong-multi | 120 | `poly05` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | strong | 120 | `poly01` | Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | strong-multi | 120 | `poly04` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | medium-multi | 50 | `1f3cc3` (+4 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | strong | 160 | `ins009` | Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | weak | 40 | `e075b4` | Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum | disp(1/1) |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | strong | 90 | `lam012` | Mass ply panels (MPP) / Freres Lumber | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | medium-multi | 70 | `f14060` (+1 more) | Wood framing - Softwood / Roseburg / | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | strong | 160 | `ply003` | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | strong-multi | 160 | `ply004` (+1 more) | Plywood / 1/2" / Roseburg softwood plywood / | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | medium-multi | 50 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | medium | 75 | `car001` | Carpet / Shaw / Residential Broadloom | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | strong-multi | 120 | `int000` (+1 more) | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | weak | 35 | `l2jfis` | Rebar / Nucor Corporation / 10M | mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | medium-multi | 75 | `mwb012` (+4 more) | Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | medium-multi | 60 | `osb000` (+4 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | mfr, disp(1/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/DVP-window-EPD-mexico.pdf | unmatched | 0 | — | — | — |
+| Windows/EPD - Product Specific (32).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (33).pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| Windows/EPD - Product Specific (34).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (37).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Italy-window.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Pursoy-Window -EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/SvenskaWindows.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Window-Finstral-EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/kawneer_window_epd.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | strong-multi | 90 | `2fg4um` (+4 more) | OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8" | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | unmatched | 20 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Bituminous membrane"` vs catalogue `"Fiberglass"`
+- `epd.id` — candidate `"4789064623.101.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"Composite Panel Association"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787549627.101.1"` vs catalogue `"EPD-117"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Concrete"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"Nov 2020 to"` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"S-P-06876"` vs catalogue `"01-004"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4790057043.103.1 2"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Bituminous membrane"` vs catalogue `"Fiberglass"`
+- `epd.id` — candidate `"4789064623.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf** (top: `cmu000` — CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg | CA]):
+- `classification.material_type` — candidate `"Portland Cement"` vs catalogue `"Concrete"`
+- `epd.id` — candidate `"1 m3 of concrete formed into manufactured"` vs catalogue `"EPD-338"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf** (top: `cmu004` — CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16):
+- `classification.group_prefix` — candidate `"03"` vs catalogue `"04"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf** (top: `c9a7f3` — Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties):
+- `manufacturer.name` — candidate `"Climate Earth, Inc"` vs catalogue `"Interstate"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf** (top: `84c2b6` — Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg | US-Canada]):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `2120`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf** (top: `eps003` — EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `14.4`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf** (top: `mpa001` — Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060"):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Aluminum"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Long Products Canada"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf** (top: `4k2v0s` — Laminated strand lumber (LSL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Framing"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `570.22`
+
+**EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `manufacturer.name` — candidate `"Nucor Steel Auburn"` vs catalogue `"Nucor Corporation"`
+
+**EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf** (top: `ebd574` — Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `548`
+
+**EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf** (top: `175f1a` — XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi):
+- `manufacturer.name` — candidate `"the facilities TM TM located"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - Pac-Clad.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+
+**EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `manufacturer.name` — candidate `"the Pennsauken"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf** (top: `rnd601` — Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"HBS during the year. The"` vs catalogue `"Huntsman Building Solutions"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `38.4`
+
+**EPDs DONE/EPD_-_RigidLam_LVL-1.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/Straw EPD UK.pdf** (top: `b4t02m` — Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+
+**EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf** (top: `d0rk2l` — Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm)):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Bamboo"`
+- `manufacturer.name` — candidate `"Zhejiang Daocheng Bamboo Industry Co., Ltd"` vs catalogue `"Dasso"`
+
+**EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD192"` vs catalogue `"6742-7944"`
+
+**EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf** (top: `f4l2kx` — Wood fiber board / R 2.7-inch / NAFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Wood fiber insulation"` vs catalogue `"Wood fibre"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf** (top: `lvt001` — Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"EGE SERAM"` vs catalogue `"Resilient Floor Covering Institute"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"ASSA ABLOY Door Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4789049516.178.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"James"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"S-P-01432"` vs catalogue `"EPD 034"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf** (top: `lvt007` — Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"several stages beginning with the"` vs catalogue `"Shaw - Patcraft"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf** (top: `car003` — Carpet / Shaw / Strataworx / Carpet tile):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Nylon"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf** (top: `cer002` — Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Aromas"` vs catalogue `"Fireclay Tile"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf** (top: `cer001` — Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Lebanon"` vs catalogue `"American Wonder Porcelain"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf** (top: `4dadb7` — Ceramic tile / Crossville / Porcelain / Standard grade (mortar included)):
+- `manufacturer.name` — candidate `"RAK Ceramics. Since tiles are"` vs catalogue `"Crossville"`
+- `epd.id` — candidate `"EPD 165"` vs catalogue `"4788863727.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `classification.material_type` — candidate `"Wood fiber insulation"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `35`
+- `epd.id` — candidate `"EPD-GTX-20180071-IBA1-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Edmonton"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD 247"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Boissevain"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD 246"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf** (top: `hwf000` — HempWood / Fibonacci / Natural Laminate Flooring / 16 mm):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Wood"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf** (top: `ins040` — Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"each member"` vs catalogue `"SPFA"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Hemp fiber"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf** (top: `poly10` — Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Polyisocyanurate"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `33.73`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf** (top: `d0rm3c` — Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"PIMA"`
+- `epd.id` — candidate `"EPD 254 Product Polyisocyanurate High-Density"` vs catalogue `"EPD10465"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf** (top: `poly06` — Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Carlisle"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"EPD 273 Product Polyisocyanurate Wall Insulation"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf** (top: `poly02` — Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf** (top: `poly05` — Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf** (top: `poly01` — Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf** (top: `poly04` — Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Fiberglass"`
+- `epd.id` — candidate `"4787358620.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"Boise Cascade in White City"` vs catalogue `"RedBuilt"`
+- `epd.id` — candidate `"Veneer Laminated Timber"` vs catalogue `"SCS-EPD-07526"`
+
+**Linoleum flooring EPD/EPD - Tarket Linoleum.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4789275679.141.1"` vs catalogue `"4789365778.101.1"`
+
+**Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf** (top: `e075b4` — Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Forbo"`
+- `epd.id` — candidate `"12CA64879.101.1"` vs catalogue `"4790690881.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. LONGi solar monocrystalline"` vs catalogue `"SHAW"`
+- `epd.id` — candidate `"4790285205.101.1 LR4-72HBD"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Tecnoglass, Inc."` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4789316837.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf** (top: `lam012` — Mass ply panels (MPP) / Freres Lumber):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `manufacturer.name` — candidate `"Freres Lumber in Lyons"` vs catalogue `"Freres Lumber Company Inc."`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `546`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `epd.id` — candidate `"4789198858.107.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Manufacturer VP-001 O.C.O Technology Ltd"` vs catalogue `"Petersen Aluminum Corp"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"Factory of USG Middle East Ltd. Co."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Joplin"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.103.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf** (top: `f14060` — Wood framing - Softwood / Roseburg /):
+- `physical.density.value_kg_m3` — candidate `753` vs catalogue `456`
+- `epd.id` — candidate `"4789110727.101"` vs catalogue `"4786969381.105.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+- `epd.id` — candidate `"4786969381.101.1"` vs catalogue `"4786969381.104.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Bituminous membrane"` vs catalogue `"Fiberglass"`
+- `epd.id` — candidate `"4789064623.103.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Schluter Systems"` vs catalogue `"SHAW"`
+- `epd.id` — candidate `"4787455040.102.1"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. JA Solar mono-crystalline"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4790076867.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf** (top: `car001` — Carpet / Shaw / Residential Broadloom):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.145.1"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"the facilities shown in the"` vs catalogue `"National Gypsum"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `epd.id` — candidate `"4789971341.101.1"` vs catalogue `"4789793365.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Wabash"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.102.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf** (top: `mwb012` — Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Mineral wool"`
+- `manufacturer.name` — candidate `"the locations listed below. Wabash"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `epd.id` — candidate `"4789103593.103.1"` vs catalogue `"4789103593.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"USG"` vs catalogue `"DATABASE AVERAGE"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"YKK AP America"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4786832322.107.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/EPD - Product Specific (32).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4789733794.103.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (33).pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**Windows/EPD - Product Specific (34).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4789733794.101.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (37).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"ES Windows by Tecnoglass"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"4789316837.104.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"EPD-QKE-20150313-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Italy-window.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `epd.id` — candidate `"S-P-00514"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Pursoy-Window -EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Purso Oy"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"S-P-03838"` vs catalogue `"4789365778.101.1"`
+
+**Windows/SvenskaWindows.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Svenska F"` vs catalogue `"Petersen Aluminum Corp"`
+- `epd.id` — candidate `"S-P-01969"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Window-Finstral-EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `epd.id` — candidate `"S-P-05676"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf** (top: `2fg4um` — OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8"):
+- `manufacturer.name` — candidate `"five different thicknesses"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `660`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"IBU - Institut Bauen und Umwelt e.V. Fermacell GmbH"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `1180` vs catalogue `40`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-density.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-density.md
@@ -1,0 +1,1338 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T17:06:24.294Z
+Samples: 208 · metadata: 1921/2912 (66.0%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 11/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 8/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 12/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 11/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 12/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 9/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 11/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 13/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 13/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 11/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 11/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 11/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 12/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 12/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 11/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 12/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 9/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 11/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 9/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 10/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 12/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 14/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 9/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 11/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 12/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 12/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 10/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 10/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 12/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 11/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 8/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 12/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 11/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 8/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 11/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 9/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 12/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 12/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 11/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 11/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 9/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 9/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 12/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 11/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 8/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 11/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 9/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 12/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 12/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 9/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 11/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 12/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 12/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 12/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 12/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 12/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 11/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 12/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 12/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 9/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |
+
+## Catalogue parity check
+
+208 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 33/208 | 16% |
+| strong-multi | 26/208 | 13% |
+| medium | 4/208 | 2% |
+| medium-multi | 39/208 | 19% |
+| weak | 76/208 | 37% |
+| unmatched | 30/208 | 14% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 143 | 27 | 8 | 0 | 80% |
+| `classification.material_type` | 84 | 35 | 54 | 5 | 49% |
+| `manufacturer.name` | 36 | 78 | 60 | 4 | 21% |
+| `physical.density.value_kg_m3` | 11 | 102 | 53 | 12 | 7% |
+| `epd.id` | 68 | 51 | 54 | 5 | 39% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | unmatched | 27 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | medium-multi | 50 | `xsp4tl` (+4 more) | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(2/2), group |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unmatched | 0 | — | — | — |
+| April 2022/EPD Durabella.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | medium-multi | 50 | `cmu000` (+3 more) | CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg \| CA] | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | strong-multi | 115 | `cmu004` (+1 more) | CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16 | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | strong | 160 | `f33e5e` | Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | strong-multi | 127 | `c9a7f3` (+1 more) | Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | strong | 170 | `vin001` | Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] | epd.id, mfr, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | strong-multi | 160 | `bri005` (+1 more) | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | strong-multi | 157 | `84c2b6` (+1 more) | Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg \| US-Canada] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | weak | 47 | `eps003` | EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg \| US & CA] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | medium-multi | 75 | `mpa001` (+1 more) | Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060" | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | strong | 130 | `4k2v0s` | Laminated strand lumber (LSL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | medium-multi | 75 | `l2jfis` (+4 more) | Rebar / Nucor Corporation / 10M | epd.id |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | strong | 150 | `ebd574` | Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | strong | 127 | `175f1a` | XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - Pac-Clad.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | strong | 120 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | strong | 120 | `rnd601` | Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch | epd.id, disp(3/4), group |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | strong | 150 | `9aedf1` | Wood I joist / Roseburg / RFPI Joist / | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs DONE/Straw EPD UK.pdf | strong | 95 | `b4t02m` | Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg \| EU] | epd.id, disp(1/2) |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unmatched | 27 | — | — | — |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | strong-multi | 90 | `d0rk2l` (+1 more) | Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm) | epd.id, group |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | strong | 120 | `f4l2kx` | Wood fiber board / R 2.7-inch / NAFA [Industry Avg \| US & CA] | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | weak | 30 | `lvt001` | Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg \| US & CA] | disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | strong | 80 | `lin003` | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(3/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | strong | 120 | `lvt007` | Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | medium-multi | 75 | `car003` (+1 more) | Carpet / Shaw / Strataworx / Carpet tile | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | strong | 110 | `cer002` | Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade / | epd.id, disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | strong | 120 | `cer001` | Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade / | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | weak | 37 | `4dadb7` | Ceramic tile / Crossville / Porcelain / Standard grade (mortar included) | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | medium-multi | 77 | `ins035` (+2 more) | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | medium-multi | 50 | `hwf000` (+4 more) | HempWood / Fibonacci / Natural Laminate Flooring / 16 mm | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | strong-multi | 120 | `ins040` (+2 more) | Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg \| US & CA] | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | medium | 75 | `poly10` | Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | strong | 120 | `poly06` | Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | strong | 120 | `poly02` | Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | strong-multi | 120 | `poly05` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | strong | 120 | `poly01` | Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | strong-multi | 120 | `poly04` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | medium-multi | 50 | `1f3cc3` (+4 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | strong | 160 | `ins009` | Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | weak | 40 | `e075b4` | Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum | disp(1/1) |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | strong | 90 | `lam012` | Mass ply panels (MPP) / Freres Lumber | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | medium-multi | 70 | `f14060` (+1 more) | Wood framing - Softwood / Roseburg / | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | strong | 160 | `ply003` | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | strong-multi | 160 | `ply004` (+1 more) | Plywood / 1/2" / Roseburg softwood plywood / | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | medium | 75 | `car001` | Carpet / Shaw / Residential Broadloom | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | strong-multi | 120 | `int000` (+1 more) | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | weak | 35 | `l2jfis` | Rebar / Nucor Corporation / 10M | mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | medium-multi | 75 | `mwb012` (+4 more) | Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | medium-multi | 60 | `osb000` (+4 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | mfr, disp(1/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/DVP-window-EPD-mexico.pdf | unmatched | 0 | — | — | — |
+| Windows/EPD - Product Specific (32).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (33).pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| Windows/EPD - Product Specific (34).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (37).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Italy-window.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Pursoy-Window -EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/SvenskaWindows.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Window-Finstral-EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/kawneer_window_epd.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | strong-multi | 90 | `2fg4um` (+4 more) | OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8" | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | unmatched | 20 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.101.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"Composite Panel Association"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787549627.101.1"` vs catalogue `"EPD-117"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Concrete"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"Nov 2020 to"` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"S-P-06876"` vs catalogue `"01-004"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4790057043.103.1 2"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf** (top: `cmu000` — CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg | CA]):
+- `classification.material_type` — candidate `"Portland Cement"` vs catalogue `"Concrete"`
+- `epd.id` — candidate `"1 m3 of concrete formed into manufactured"` vs catalogue `"EPD-338"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf** (top: `cmu004` — CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16):
+- `classification.group_prefix` — candidate `"03"` vs catalogue `"04"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf** (top: `f33e5e` — Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.574`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf** (top: `c9a7f3` — Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties):
+- `manufacturer.name` — candidate `"Climate Earth, Inc"` vs catalogue `"Interstate"`
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `2060` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf** (top: `84c2b6` — Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg | US-Canada]):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `2120`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf** (top: `eps003` — EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `14.4`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf** (top: `mpa001` — Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060"):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Aluminum"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `10.49`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Long Products Canada"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf** (top: `4k2v0s` — Laminated strand lumber (LSL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Framing"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `570.22`
+
+**EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `manufacturer.name` — candidate `"Nucor Steel Auburn"` vs catalogue `"Nucor Corporation"`
+
+**EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf** (top: `ebd574` — Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `548`
+
+**EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf** (top: `175f1a` — XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi):
+- `manufacturer.name` — candidate `"the facilities TM TM located"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - Pac-Clad.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `manufacturer.name` — candidate `"the Pennsauken"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf** (top: `rnd601` — Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"HBS during the year. The"` vs catalogue `"Huntsman Building Solutions"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `38.4`
+
+**EPDs DONE/EPD_-_RFPIJoist-2.pdf** (top: `9aedf1` — Wood I joist / Roseburg / RFPI Joist /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `3.9`
+
+**EPDs DONE/EPD_-_RigidLam_LVL-1.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/Straw EPD UK.pdf** (top: `b4t02m` — Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+
+**EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf** (top: `d0rk2l` — Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm)):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Bamboo"`
+- `manufacturer.name` — candidate `"Zhejiang Daocheng Bamboo Industry Co., Ltd"` vs catalogue `"Dasso"`
+
+**EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD192"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf** (top: `lvt001` — Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"EGE SERAM"` vs catalogue `"Resilient Floor Covering Institute"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"ASSA ABLOY Door Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789049516.178.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"James"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"S-P-01432"` vs catalogue `"EPD 034"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf** (top: `lvt007` — Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"several stages beginning with the"` vs catalogue `"Shaw - Patcraft"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `0.00576`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf** (top: `car003` — Carpet / Shaw / Strataworx / Carpet tile):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Nylon"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf** (top: `cer002` — Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Aromas"` vs catalogue `"Fireclay Tile"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf** (top: `cer001` — Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Lebanon"` vs catalogue `"American Wonder Porcelain"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf** (top: `4dadb7` — Ceramic tile / Crossville / Porcelain / Standard grade (mortar included)):
+- `manufacturer.name` — candidate `"RAK Ceramics. Since tiles are"` vs catalogue `"Crossville"`
+- `epd.id` — candidate `"EPD 165"` vs catalogue `"4788863727.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `35`
+- `epd.id` — candidate `"EPD-GTX-20180071-IBA1-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Edmonton"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 247"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Boissevain"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 246"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf** (top: `hwf000` — HempWood / Fibonacci / Natural Laminate Flooring / 16 mm):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `1063` vs catalogue `10.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf** (top: `ins040` — Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"each member"` vs catalogue `"SPFA"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Hemp fiber"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf** (top: `poly10` — Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Polyisocyanurate"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `33.73`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf** (top: `d0rm3c` — Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"PIMA"`
+- `epd.id` — candidate `"EPD 254 Product Polyisocyanurate High-Density"` vs catalogue `"EPD10465"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf** (top: `poly06` — Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Carlisle"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD 273 Product Polyisocyanurate Wall Insulation"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf** (top: `poly02` — Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf** (top: `poly05` — Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf** (top: `poly01` — Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf** (top: `poly04` — Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Fiberglass"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `0.488`
+- `epd.id` — candidate `"4787358620.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf** (top: `ins009` — Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.46`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"Boise Cascade in White City"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `483.4` vs catalogue `7.05`
+- `epd.id` — candidate `"Veneer Laminated Timber"` vs catalogue `"SCS-EPD-07526"`
+
+**Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Linoleum flooring EPD/EPD - Tarket Linoleum.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789275679.141.1"` vs catalogue `"4789365778.101.1"`
+
+**Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf** (top: `e075b4` — Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Forbo"`
+- `epd.id` — candidate `"12CA64879.101.1"` vs catalogue `"4790690881.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. LONGi solar monocrystalline"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4790285205.101.1 LR4-72HBD"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Tecnoglass, Inc."` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf** (top: `lam012` — Mass ply panels (MPP) / Freres Lumber):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `manufacturer.name` — candidate `"Freres Lumber in Lyons"` vs catalogue `"Freres Lumber Company Inc."`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `546`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789198858.107.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Manufacturer VP-001 O.C.O Technology Ltd"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"Factory of USG Middle East Ltd. Co."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Joplin"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.103.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf** (top: `f14060` — Wood framing - Softwood / Roseburg /):
+- `physical.density.value_kg_m3` — candidate `753` vs catalogue `456`
+- `epd.id` — candidate `"4789110727.101"` vs catalogue `"4786969381.105.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf** (top: `ply003` — Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `8.9`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+- `epd.id` — candidate `"4786969381.101.1"` vs catalogue `"4786969381.104.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf** (top: `ply004` — Plywood / 1/2" / Roseburg softwood plywood /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `4.38`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.103.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Schluter Systems"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4787455040.102.1"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. JA Solar mono-crystalline"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790076867.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf** (top: `car001` — Carpet / Shaw / Residential Broadloom):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.145.1"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"the facilities shown in the"` vs catalogue `"National Gypsum"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `epd.id` — candidate `"4789971341.101.1"` vs catalogue `"4789793365.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Wabash"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.102.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf** (top: `mwb012` — Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Mineral wool"`
+- `manufacturer.name` — candidate `"the locations listed below. Wabash"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `epd.id` — candidate `"4789103593.103.1"` vs catalogue `"4789103593.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"USG"` vs catalogue `"DATABASE AVERAGE"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"YKK AP America"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4786832322.107.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/EPD - Product Specific (32).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.103.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (33).pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**Windows/EPD - Product Specific (34).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.101.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (37).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"ES Windows by Tecnoglass"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.104.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20150313-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Italy-window.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-00514"` vs catalogue `"4789365778.101.1"`
+
+**Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/Pursoy-Window -EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Purso Oy"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-03838"` vs catalogue `"4789365778.101.1"`
+
+**Windows/SvenskaWindows.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Svenska F"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-01969"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Window-Finstral-EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-05676"` vs catalogue `"4789365778.101.1"`
+
+**Windows/kawneer_window_epd.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/scs-epd-07201_andersencorp_e-series_092721.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf** (top: `2fg4um` — OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8"):
+- `manufacturer.name` — candidate `"five different thicknesses"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `660`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"IBU - Institut Bauen und Umwelt e.V. Fermacell GmbH"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `1180` vs catalogue `40`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-mattype.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-mattype.md
@@ -1,0 +1,1342 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T17:11:07.625Z
+Samples: 208 · metadata: 1925/2912 (66.1%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 10/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 9/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 9/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 12/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 10/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 12/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 9/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 9/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 11/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 13/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 13/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 11/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 11/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 11/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 12/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 12/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 11/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 12/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 10/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 11/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 10/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 10/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 13/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 12/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 14/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 9/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 11/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 12/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 12/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 10/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 10/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 12/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 11/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 8/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 12/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 11/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 9/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 8/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 11/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 9/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 12/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 12/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 11/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 10/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 9/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 9/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 12/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 11/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 8/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 11/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 9/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 12/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 12/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 9/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 11/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 12/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 12/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 12/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 12/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 12/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 11/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 12/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 12/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 9/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |
+
+## Catalogue parity check
+
+208 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 33/208 | 16% |
+| strong-multi | 23/208 | 11% |
+| medium | 4/208 | 2% |
+| medium-multi | 42/208 | 20% |
+| weak | 76/208 | 37% |
+| unmatched | 30/208 | 14% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 143 | 27 | 8 | 0 | 80% |
+| `classification.material_type` | 81 | 40 | 53 | 4 | 47% |
+| `manufacturer.name` | 36 | 78 | 60 | 4 | 21% |
+| `physical.density.value_kg_m3` | 11 | 99 | 56 | 12 | 7% |
+| `epd.id` | 68 | 51 | 54 | 5 | 39% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | medium-multi | 50 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | unmatched | 27 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | medium-multi | 50 | `xsp4tl` (+4 more) | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(2/2), group |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unmatched | 0 | — | — | — |
+| April 2022/EPD Durabella.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | medium-multi | 50 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | medium-multi | 50 | `cmu000` (+3 more) | CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg \| CA] | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | strong-multi | 115 | `cmu004` (+1 more) | CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16 | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | strong | 160 | `f33e5e` | Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | strong-multi | 127 | `c9a7f3` (+1 more) | Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | strong | 170 | `vin001` | Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] | epd.id, mfr, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | strong-multi | 160 | `bri005` (+1 more) | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | strong-multi | 157 | `84c2b6` (+1 more) | Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg \| US-Canada] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | weak | 47 | `eps003` | EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg \| US & CA] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | medium-multi | 75 | `mpa001` (+1 more) | Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060" | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | strong | 130 | `4k2v0s` | Laminated strand lumber (LSL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | medium-multi | 75 | `l2jfis` (+4 more) | Rebar / Nucor Corporation / 10M | epd.id |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | strong | 150 | `ebd574` | Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | strong | 127 | `175f1a` | XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - Pac-Clad.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | strong | 120 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | strong | 120 | `rnd601` | Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch | epd.id, disp(3/4), group |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | strong | 150 | `9aedf1` | Wood I joist / Roseburg / RFPI Joist / | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs DONE/Straw EPD UK.pdf | strong | 95 | `b4t02m` | Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg \| EU] | epd.id, disp(1/2) |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | strong-multi | 90 | `d0rk2l` (+1 more) | Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm) | epd.id, group |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | strong | 120 | `f4l2kx` | Wood fiber board / R 2.7-inch / NAFA [Industry Avg \| US & CA] | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | weak | 30 | `lvt001` | Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg \| US & CA] | disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | strong | 80 | `lin003` | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(3/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | strong | 120 | `lvt007` | Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | medium-multi | 75 | `car003` (+1 more) | Carpet / Shaw / Strataworx / Carpet tile | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | strong | 110 | `cer002` | Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade / | epd.id, disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | strong | 120 | `cer001` | Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade / | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | weak | 37 | `4dadb7` | Ceramic tile / Crossville / Porcelain / Standard grade (mortar included) | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | strong | 160 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | medium-multi | 77 | `ins035` (+2 more) | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | medium-multi | 50 | `hwf000` (+4 more) | HempWood / Fibonacci / Natural Laminate Flooring / 16 mm | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | strong-multi | 120 | `ins040` (+2 more) | Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg \| US & CA] | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | medium | 75 | `poly10` | Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | strong | 120 | `poly06` | Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | strong | 120 | `poly02` | Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | strong-multi | 120 | `poly05` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | strong | 120 | `poly01` | Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | strong-multi | 120 | `poly04` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | medium-multi | 50 | `1f3cc3` (+4 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | strong | 160 | `ins009` | Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | weak | 40 | `e075b4` | Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum | disp(1/1) |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | strong | 90 | `lam012` | Mass ply panels (MPP) / Freres Lumber | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | medium-multi | 70 | `f14060` (+1 more) | Wood framing - Softwood / Roseburg / | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | strong | 160 | `ply003` | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | strong-multi | 160 | `ply004` (+1 more) | Plywood / 1/2" / Roseburg softwood plywood / | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | medium-multi | 50 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | medium | 75 | `car001` | Carpet / Shaw / Residential Broadloom | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | strong-multi | 120 | `int000` (+1 more) | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | weak | 35 | `l2jfis` | Rebar / Nucor Corporation / 10M | mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | medium-multi | 75 | `mwb012` (+4 more) | Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | medium-multi | 60 | `osb000` (+4 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | mfr, disp(1/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/DVP-window-EPD-mexico.pdf | unmatched | 0 | — | — | — |
+| Windows/EPD - Product Specific (32).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (33).pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| Windows/EPD - Product Specific (34).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (37).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Italy-window.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Pursoy-Window -EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/SvenskaWindows.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Window-Finstral-EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/kawneer_window_epd.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | strong-multi | 90 | `2fg4um` (+4 more) | OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8" | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | unmatched | 20 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Bituminous membrane"` vs catalogue `"Fiberglass"`
+- `epd.id` — candidate `"4789064623.101.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"Composite Panel Association"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787549627.101.1"` vs catalogue `"EPD-117"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Concrete"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"Nov 2020 to"` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"S-P-06876"` vs catalogue `"01-004"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4790057043.103.1 2"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Bituminous membrane"` vs catalogue `"Fiberglass"`
+- `epd.id` — candidate `"4789064623.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf** (top: `cmu000` — CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg | CA]):
+- `classification.material_type` — candidate `"Portland Cement"` vs catalogue `"Concrete"`
+- `epd.id` — candidate `"1 m3 of concrete formed into manufactured"` vs catalogue `"EPD-338"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf** (top: `cmu004` — CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16):
+- `classification.group_prefix` — candidate `"03"` vs catalogue `"04"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf** (top: `f33e5e` — Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.574`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf** (top: `c9a7f3` — Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties):
+- `manufacturer.name` — candidate `"Climate Earth, Inc"` vs catalogue `"Interstate"`
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `2060` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf** (top: `84c2b6` — Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg | US-Canada]):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `2120`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf** (top: `eps003` — EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `14.4`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf** (top: `mpa001` — Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060"):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Aluminum"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `10.49`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Long Products Canada"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf** (top: `4k2v0s` — Laminated strand lumber (LSL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Framing"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `570.22`
+
+**EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `manufacturer.name` — candidate `"Nucor Steel Auburn"` vs catalogue `"Nucor Corporation"`
+
+**EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf** (top: `ebd574` — Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `548`
+
+**EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf** (top: `175f1a` — XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi):
+- `manufacturer.name` — candidate `"the facilities TM TM located"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - Pac-Clad.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `manufacturer.name` — candidate `"the Pennsauken"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf** (top: `rnd601` — Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"HBS during the year. The"` vs catalogue `"Huntsman Building Solutions"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `38.4`
+
+**EPDs DONE/EPD_-_RFPIJoist-2.pdf** (top: `9aedf1` — Wood I joist / Roseburg / RFPI Joist /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `3.9`
+
+**EPDs DONE/EPD_-_RigidLam_LVL-1.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/Straw EPD UK.pdf** (top: `b4t02m` — Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+
+**EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf** (top: `d0rk2l` — Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm)):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Bamboo"`
+- `manufacturer.name` — candidate `"Zhejiang Daocheng Bamboo Industry Co., Ltd"` vs catalogue `"Dasso"`
+
+**EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD192"` vs catalogue `"6742-7944"`
+
+**EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf** (top: `f4l2kx` — Wood fiber board / R 2.7-inch / NAFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Wood fiber insulation"` vs catalogue `"Wood fibre"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf** (top: `lvt001` — Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"EGE SERAM"` vs catalogue `"Resilient Floor Covering Institute"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"ASSA ABLOY Door Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789049516.178.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"James"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"S-P-01432"` vs catalogue `"EPD 034"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf** (top: `lvt007` — Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"several stages beginning with the"` vs catalogue `"Shaw - Patcraft"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `0.00576`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf** (top: `car003` — Carpet / Shaw / Strataworx / Carpet tile):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Nylon"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf** (top: `cer002` — Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Aromas"` vs catalogue `"Fireclay Tile"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf** (top: `cer001` — Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Lebanon"` vs catalogue `"American Wonder Porcelain"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf** (top: `4dadb7` — Ceramic tile / Crossville / Porcelain / Standard grade (mortar included)):
+- `manufacturer.name` — candidate `"RAK Ceramics. Since tiles are"` vs catalogue `"Crossville"`
+- `epd.id` — candidate `"EPD 165"` vs catalogue `"4788863727.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `classification.material_type` — candidate `"Wood fiber insulation"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `35`
+- `epd.id` — candidate `"EPD-GTX-20180071-IBA1-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Edmonton"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 247"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Boissevain"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 246"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf** (top: `hwf000` — HempWood / Fibonacci / Natural Laminate Flooring / 16 mm):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `1063` vs catalogue `10.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf** (top: `ins040` — Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"each member"` vs catalogue `"SPFA"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Hemp fiber"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf** (top: `poly10` — Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Polyisocyanurate"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `33.73`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf** (top: `d0rm3c` — Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"PIMA"`
+- `epd.id` — candidate `"EPD 254 Product Polyisocyanurate High-Density"` vs catalogue `"EPD10465"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf** (top: `poly06` — Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Carlisle"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD 273 Product Polyisocyanurate Wall Insulation"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf** (top: `poly02` — Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf** (top: `poly05` — Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf** (top: `poly01` — Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf** (top: `poly04` — Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Fiberglass"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `0.488`
+- `epd.id` — candidate `"4787358620.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf** (top: `ins009` — Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.46`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"Boise Cascade in White City"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `483.4` vs catalogue `7.05`
+- `epd.id` — candidate `"Veneer Laminated Timber"` vs catalogue `"SCS-EPD-07526"`
+
+**Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Linoleum flooring EPD/EPD - Tarket Linoleum.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789275679.141.1"` vs catalogue `"4789365778.101.1"`
+
+**Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf** (top: `e075b4` — Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Forbo"`
+- `epd.id` — candidate `"12CA64879.101.1"` vs catalogue `"4790690881.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. LONGi solar monocrystalline"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4790285205.101.1 LR4-72HBD"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Tecnoglass, Inc."` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf** (top: `lam012` — Mass ply panels (MPP) / Freres Lumber):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `manufacturer.name` — candidate `"Freres Lumber in Lyons"` vs catalogue `"Freres Lumber Company Inc."`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `546`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789198858.107.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Manufacturer VP-001 O.C.O Technology Ltd"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"Factory of USG Middle East Ltd. Co."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Joplin"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.103.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf** (top: `f14060` — Wood framing - Softwood / Roseburg /):
+- `physical.density.value_kg_m3` — candidate `753` vs catalogue `456`
+- `epd.id` — candidate `"4789110727.101"` vs catalogue `"4786969381.105.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf** (top: `ply003` — Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `8.9`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+- `epd.id` — candidate `"4786969381.101.1"` vs catalogue `"4786969381.104.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf** (top: `ply004` — Plywood / 1/2" / Roseburg softwood plywood /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `4.38`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Bituminous membrane"` vs catalogue `"Fiberglass"`
+- `epd.id` — candidate `"4789064623.103.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Schluter Systems"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4787455040.102.1"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. JA Solar mono-crystalline"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790076867.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf** (top: `car001` — Carpet / Shaw / Residential Broadloom):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.145.1"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"the facilities shown in the"` vs catalogue `"National Gypsum"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `epd.id` — candidate `"4789971341.101.1"` vs catalogue `"4789793365.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Wabash"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.102.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf** (top: `mwb012` — Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Mineral wool"`
+- `manufacturer.name` — candidate `"the locations listed below. Wabash"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `epd.id` — candidate `"4789103593.103.1"` vs catalogue `"4789103593.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"USG"` vs catalogue `"DATABASE AVERAGE"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"YKK AP America"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4786832322.107.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/EPD - Product Specific (32).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.103.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (33).pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**Windows/EPD - Product Specific (34).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.101.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (37).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"ES Windows by Tecnoglass"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.104.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20150313-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Italy-window.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-00514"` vs catalogue `"4789365778.101.1"`
+
+**Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/Pursoy-Window -EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Purso Oy"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-03838"` vs catalogue `"4789365778.101.1"`
+
+**Windows/SvenskaWindows.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Svenska F"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-01969"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Window-Finstral-EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-05676"` vs catalogue `"4789365778.101.1"`
+
+**Windows/kawneer_window_epd.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/scs-epd-07201_andersencorp_e-series_092721.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf** (top: `2fg4um` — OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8"):
+- `manufacturer.name` — candidate `"five different thicknesses"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `660`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"IBU - Institut Bauen und Umwelt e.V. Fermacell GmbH"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `1180` vs catalogue `40`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-mfr-fixes.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-mfr-fixes.md
@@ -1,0 +1,1338 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:37:48.226Z
+Samples: 208 · metadata: 1883/2912 (64.7%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 11/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 8/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 12/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 11/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 12/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 9/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 11/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 11/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 11/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 9/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 11/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 10/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 11/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 12/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 12/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 11/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 12/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 9/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 11/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 8/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 8/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 10/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 10/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 10/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 13/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 6/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 11/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 12/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 11/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 10/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 10/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 12/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 11/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 8/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 12/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 11/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 8/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 11/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 9/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 12/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 12/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 11/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 11/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 8/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 12/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 11/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 8/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 11/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 9/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 12/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 12/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 9/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 11/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 12/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 10/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 12/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 10/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 11/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 11/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 11/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 11/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 10/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 12/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 8/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |
+
+## Catalogue parity check
+
+208 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 33/208 | 16% |
+| strong-multi | 26/208 | 13% |
+| medium | 4/208 | 2% |
+| medium-multi | 39/208 | 19% |
+| weak | 76/208 | 37% |
+| unmatched | 30/208 | 14% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 143 | 27 | 8 | 0 | 80% |
+| `classification.material_type` | 84 | 35 | 54 | 5 | 49% |
+| `manufacturer.name` | 36 | 78 | 60 | 4 | 21% |
+| `physical.density.value_kg_m3` | 10 | 102 | 54 | 12 | 6% |
+| `epd.id` | 68 | 51 | 54 | 5 | 39% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | unmatched | 27 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | medium-multi | 50 | `xsp4tl` (+4 more) | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(2/2), group |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unmatched | 0 | — | — | — |
+| April 2022/EPD Durabella.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | medium-multi | 50 | `cmu000` (+3 more) | CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg \| CA] | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | strong-multi | 115 | `cmu004` (+1 more) | CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16 | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | strong | 160 | `f33e5e` | Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | strong-multi | 127 | `c9a7f3` (+1 more) | Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | strong | 170 | `vin001` | Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] | epd.id, mfr, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | strong-multi | 160 | `bri005` (+1 more) | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | strong-multi | 157 | `84c2b6` (+1 more) | Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg \| US-Canada] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | weak | 47 | `eps003` | EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg \| US & CA] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | medium-multi | 75 | `mpa001` (+1 more) | Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060" | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | strong | 130 | `4k2v0s` | Laminated strand lumber (LSL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | medium-multi | 75 | `l2jfis` (+4 more) | Rebar / Nucor Corporation / 10M | epd.id |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | strong | 150 | `ebd574` | Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | strong | 127 | `175f1a` | XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - Pac-Clad.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | strong | 120 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | strong | 120 | `rnd601` | Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch | epd.id, disp(3/4), group |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | strong | 150 | `9aedf1` | Wood I joist / Roseburg / RFPI Joist / | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs DONE/Straw EPD UK.pdf | strong | 95 | `b4t02m` | Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg \| EU] | epd.id, disp(1/2) |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unmatched | 27 | — | — | — |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | strong-multi | 90 | `d0rk2l` (+1 more) | Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm) | epd.id, group |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | strong | 120 | `f4l2kx` | Wood fiber board / R 2.7-inch / NAFA [Industry Avg \| US & CA] | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | weak | 30 | `lvt001` | Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg \| US & CA] | disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | strong | 80 | `lin003` | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(3/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | strong | 120 | `lvt007` | Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | medium-multi | 75 | `car003` (+1 more) | Carpet / Shaw / Strataworx / Carpet tile | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | strong | 110 | `cer002` | Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade / | epd.id, disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | strong | 120 | `cer001` | Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade / | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | weak | 37 | `4dadb7` | Ceramic tile / Crossville / Porcelain / Standard grade (mortar included) | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | medium-multi | 77 | `ins035` (+2 more) | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | medium-multi | 50 | `hwf000` (+4 more) | HempWood / Fibonacci / Natural Laminate Flooring / 16 mm | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | strong-multi | 120 | `ins040` (+2 more) | Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg \| US & CA] | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | medium | 75 | `poly10` | Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | strong | 120 | `poly06` | Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | strong | 120 | `poly02` | Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | strong-multi | 120 | `poly05` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | strong | 120 | `poly01` | Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | strong-multi | 120 | `poly04` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | medium-multi | 50 | `1f3cc3` (+4 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | strong | 160 | `ins009` | Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | weak | 40 | `e075b4` | Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum | disp(1/1) |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | strong | 90 | `lam012` | Mass ply panels (MPP) / Freres Lumber | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | medium-multi | 70 | `f14060` (+1 more) | Wood framing - Softwood / Roseburg / | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | strong | 160 | `ply003` | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | strong-multi | 160 | `ply004` (+1 more) | Plywood / 1/2" / Roseburg softwood plywood / | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | medium | 75 | `car001` | Carpet / Shaw / Residential Broadloom | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | strong-multi | 120 | `int000` (+1 more) | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | weak | 35 | `l2jfis` | Rebar / Nucor Corporation / 10M | mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | medium-multi | 75 | `mwb012` (+4 more) | Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | medium-multi | 60 | `osb000` (+4 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | mfr, disp(1/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/DVP-window-EPD-mexico.pdf | unmatched | 0 | — | — | — |
+| Windows/EPD - Product Specific (32).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (33).pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| Windows/EPD - Product Specific (34).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (37).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Italy-window.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Pursoy-Window -EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/SvenskaWindows.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Window-Finstral-EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/kawneer_window_epd.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | strong-multi | 90 | `2fg4um` (+4 more) | OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8" | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | unmatched | 20 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.101.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"Composite Panel Association"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787549627.101.1"` vs catalogue `"EPD-117"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Concrete"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"Nov 2020 to"` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"S-P-06876"` vs catalogue `"01-004"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4790057043.103.1 2"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf** (top: `cmu000` — CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg | CA]):
+- `classification.material_type` — candidate `"Portland Cement"` vs catalogue `"Concrete"`
+- `epd.id` — candidate `"1 m3 of concrete formed into manufactured"` vs catalogue `"EPD-338"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf** (top: `cmu004` — CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16):
+- `classification.group_prefix` — candidate `"03"` vs catalogue `"04"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf** (top: `f33e5e` — Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.574`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf** (top: `c9a7f3` — Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties):
+- `manufacturer.name` — candidate `"Climate Earth, Inc"` vs catalogue `"Interstate"`
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `2060` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf** (top: `84c2b6` — Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg | US-Canada]):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `2120`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf** (top: `eps003` — EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `14.4`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf** (top: `mpa001` — Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060"):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Aluminum"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `10.49`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Long Products Canada"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf** (top: `4k2v0s` — Laminated strand lumber (LSL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Framing"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `570.22`
+
+**EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `manufacturer.name` — candidate `"Nucor Steel Auburn"` vs catalogue `"Nucor Corporation"`
+
+**EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf** (top: `ebd574` — Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `548`
+
+**EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf** (top: `175f1a` — XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi):
+- `manufacturer.name` — candidate `"the facilities TM TM located"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - Pac-Clad.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `manufacturer.name` — candidate `"the Pennsauken"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf** (top: `rnd601` — Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"HBS during the year. The"` vs catalogue `"Huntsman Building Solutions"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `38.4`
+
+**EPDs DONE/EPD_-_RFPIJoist-2.pdf** (top: `9aedf1` — Wood I joist / Roseburg / RFPI Joist /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `3.9`
+
+**EPDs DONE/EPD_-_RigidLam_LVL-1.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/Straw EPD UK.pdf** (top: `b4t02m` — Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+
+**EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf** (top: `d0rk2l` — Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm)):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Bamboo"`
+- `manufacturer.name` — candidate `"Zhejiang Daocheng Bamboo Industry Co., Ltd"` vs catalogue `"Dasso"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `1150`
+
+**EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD192"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf** (top: `lvt001` — Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"EGE SERAM"` vs catalogue `"Resilient Floor Covering Institute"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"ASSA ABLOY Door Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789049516.178.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"James"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"S-P-01432"` vs catalogue `"EPD 034"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf** (top: `lvt007` — Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"several stages beginning with the"` vs catalogue `"Shaw - Patcraft"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `0.00576`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf** (top: `car003` — Carpet / Shaw / Strataworx / Carpet tile):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Nylon"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf** (top: `cer002` — Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Aromas"` vs catalogue `"Fireclay Tile"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf** (top: `cer001` — Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Lebanon"` vs catalogue `"American Wonder Porcelain"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf** (top: `4dadb7` — Ceramic tile / Crossville / Porcelain / Standard grade (mortar included)):
+- `manufacturer.name` — candidate `"RAK Ceramics. Since tiles are"` vs catalogue `"Crossville"`
+- `epd.id` — candidate `"EPD 165"` vs catalogue `"4788863727.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `35`
+- `epd.id` — candidate `"EPD-GTX-20180071-IBA1-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Edmonton"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 247"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Boissevain"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 246"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf** (top: `hwf000` — HempWood / Fibonacci / Natural Laminate Flooring / 16 mm):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `1063` vs catalogue `10.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf** (top: `ins040` — Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"each member"` vs catalogue `"SPFA"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Hemp fiber"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf** (top: `poly10` — Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Polyisocyanurate"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `33.73`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf** (top: `d0rm3c` — Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"PIMA"`
+- `epd.id` — candidate `"EPD 254 Product Polyisocyanurate High-Density"` vs catalogue `"EPD10465"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf** (top: `poly06` — Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Carlisle"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD 273 Product Polyisocyanurate Wall Insulation"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf** (top: `poly02` — Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf** (top: `poly05` — Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf** (top: `poly01` — Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf** (top: `poly04` — Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Fiberglass"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `0.488`
+- `epd.id` — candidate `"4787358620.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf** (top: `ins009` — Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.46`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"Boise Cascade in White City"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `483.4` vs catalogue `7.05`
+- `epd.id` — candidate `"Veneer Laminated Timber"` vs catalogue `"SCS-EPD-07526"`
+
+**Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Linoleum flooring EPD/EPD - Tarket Linoleum.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789275679.141.1"` vs catalogue `"4789365778.101.1"`
+
+**Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf** (top: `e075b4` — Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Forbo"`
+- `epd.id` — candidate `"12CA64879.101.1"` vs catalogue `"4790690881.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. LONGi solar monocrystalline"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4790285205.101.1 LR4-72HBD"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Tecnoglass, Inc."` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf** (top: `lam012` — Mass ply panels (MPP) / Freres Lumber):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `manufacturer.name` — candidate `"Freres Lumber in Lyons"` vs catalogue `"Freres Lumber Company Inc."`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `546`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789198858.107.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Manufacturer VP-001 O.C.O Technology Ltd"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"Factory of USG Middle East Ltd. Co."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Joplin"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.103.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf** (top: `f14060` — Wood framing - Softwood / Roseburg /):
+- `physical.density.value_kg_m3` — candidate `753` vs catalogue `456`
+- `epd.id` — candidate `"4789110727.101"` vs catalogue `"4786969381.105.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf** (top: `ply003` — Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `8.9`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+- `epd.id` — candidate `"4786969381.101.1"` vs catalogue `"4786969381.104.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf** (top: `ply004` — Plywood / 1/2" / Roseburg softwood plywood /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `4.38`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.103.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Schluter Systems"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4787455040.102.1"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. JA Solar mono-crystalline"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790076867.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf** (top: `car001` — Carpet / Shaw / Residential Broadloom):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.145.1"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"the facilities shown in the"` vs catalogue `"National Gypsum"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `epd.id` — candidate `"4789971341.101.1"` vs catalogue `"4789793365.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Wabash"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.102.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf** (top: `mwb012` — Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Mineral wool"`
+- `manufacturer.name` — candidate `"the locations listed below. Wabash"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `epd.id` — candidate `"4789103593.103.1"` vs catalogue `"4789103593.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"USG"` vs catalogue `"DATABASE AVERAGE"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"YKK AP America"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4786832322.107.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/EPD - Product Specific (32).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.103.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (33).pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**Windows/EPD - Product Specific (34).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.101.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (37).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"ES Windows by Tecnoglass"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.104.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20150313-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Italy-window.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-00514"` vs catalogue `"4789365778.101.1"`
+
+**Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/Pursoy-Window -EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Purso Oy"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-03838"` vs catalogue `"4789365778.101.1"`
+
+**Windows/SvenskaWindows.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Svenska F"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-01969"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Window-Finstral-EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-05676"` vs catalogue `"4789365778.101.1"`
+
+**Windows/kawneer_window_epd.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/scs-epd-07201_andersencorp_e-series_092721.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf** (top: `2fg4um` — OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8"):
+- `manufacturer.name` — candidate `"five different thicknesses"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `660`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"IBU - Institut Bauen und Umwelt e.V. Fermacell GmbH"` vs catalogue `"CMS"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-type.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_existing-beam_post-type.md
@@ -1,0 +1,1338 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:58:55.475Z
+Samples: 208 · metadata: 1920/2912 (65.9%) · impacts: 1150/2080 (55.3%) · by_stage: 3618/35360 (10.2%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | nsf | 31 | 9/14 | 8/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | · | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | na | 22 | 11/14 | 5/10 | 35/170 | 11.009999999999998 | 4.80e-10 | 0.026539999999999998 | 2.06e-3 | · | · | 5.276999999999999 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | na | 18 | 8/14 | 7/10 | 20/170 | 705.3399999999999 | 0.00e+0 | 6.88 | 0.6 | 101.42999999999999 | · | · | 10.724 | 185 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 635.22 | 5.86e-5 | 6.37 | 1.63 | 71.83 | · | · | 5.938 | 1.936 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | epd_international | 17 | 10/14 | 3/10 | 1/170 | · | · | · | 3.10e-3 | · | 0.068 | -0.19 | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.535628 | · | · |
+| April 2022/EPD Durabella.pdf | unknown | 4 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | na | 20 | 11/14 | 4/10 | 19/170 | 0.0696 | · | 2.84e-4 | 2.76e-3 | · | · | 0.241 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | na | 20 | 12/14 | 4/10 | 19/170 | 0.0939 | · | 4.18e-4 | 4.44e-4 | · | · | 0.21 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | na | 21 | 11/14 | 6/10 | 18/170 | 10.57 | 1.90e-9 | 0.03446 | 2.13e-3 | · | · | 4.38 | · | 7.9399999999999995 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | na | 11 | 14/14 | 10/10 | 21/170 | 226.96 | 1.47e-5 | 1.6300000000000001 | 0.78 | 36.59 | 1352.8999999999999 | 0.22 | 910.13 | 2619.65 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | na | 24 | 12/14 | 9/10 | 0/170 | 138.67 | 6.42e-4 | 0.48 | 0.09 | 6.29 | 61.73 | 0.45 | 557.86 | 31.64 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | na | 10 | 9/14 | 4/10 | 11/170 | 158 | 3.23e-6 | 1.1400000000000001 | 0.05 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | na | 16 | 9/14 | 2/10 | 7/170 | · | · | · | · | · | · | 0.012353000000000001 | · | 32.693 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | na | 28 | 11/14 | 7/10 | 2/170 | 0.241 | 2.02e-8 | 1.14e-3 | 1.90e-4 | 0.0119 | 0.3 | 8.01e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | na | 20 | 13/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | na | 17 | 10/14 | 8/10 | 0/170 | 4.71 | 6.54e-7 | 0.0337 | 6.14e-3 | 0.207 | 17.3 | 0.023 | · | 2.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | na | 12 | 13/14 | 9/10 | 15/170 | 787 | 1.84e-5 | 7.592 | 1.2481 | 61.22 | 10400 | 29.3 | 9.67 | 383 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | na | 9 | 11/14 | 2/10 | 5/170 | 1.52 | · | 0.888 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unknown | 11 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | unknown | 12 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | epd_international | 18 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | nsf | 29 | 9/14 | 9/10 | 9/170 | 273.04 | 7.87e-6 | 1.15 | 0.51 | 21.81 | 1081.12 | 1.58 | 195 | 39.13 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | nsf | 30 | 9/14 | 9/10 | 9/170 | 179.42 | 7.56e-6 | 0.86 | 0.17 | 19.15 | 543.95 | 2.33 | 126 | 105.43 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 336.63 | 6.37e-6 | 1.76 | 0.31 | 42.72 | 1202.26 | · | 195 | 105.14 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | nsf | 26 | 9/14 | 8/10 | 9/170 | 202.25 | 5.63e-6 | 1.03 | 0.32 | 22.02 | 1108.95 | · | 151 | 75.45 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | nsf | 31 | 9/14 | 9/10 | 9/170 | 220.29 | 5.46e-6 | 1.09 | 0.17 | 18.99 | 574.04 | 2.41 | 145 | 63.92 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | nsf | 25 | 9/14 | 8/10 | 9/170 | 312.83 | 6.99e-6 | 1.81 | 0.47 | 35.22 | 1627.38 | · | 239 | 110.41 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | unknown | 33 | 5/14 | 7/10 | 77/170 | 77.74900000000001 | 2.71e-6 | 0.635036 | 0.9202035000000001 | 0.1002014 | 0.33209 | 8.3508 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 266 | 1.36e-8 | 0.276 | 0.0304 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | nsf | 12 | 7/14 | 4/10 | 15/170 | 260 | 2.37e-8 | 0.295 | 0.0384 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | nsf | 24 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | na | 17 | 11/14 | 9/10 | 15/170 | 11179 | 6.12e-6 | 61.672999999999995 | 1.3557000000000001 | 570.9 | 5860 | 153 | 65900 | 24200 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | na | 18 | 11/14 | 5/10 | 13/170 | 1.2855 | · | 9.58e-3 | 1.28e-3 | · | 16900 | 6.801 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | na | 15 | 12/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200001040000003 | 3.484 | 3.1534 | 13.8 | 3408.46 | 5.4 | 6512.45 | 5190.65 |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 803 | 2.54e-11 | 1.79 | 0.0889 | 29.6 | 842 | 4.26 | 10200 | 1090 |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | na | 17 | 12/14 | 9/10 | 18/170 | 5.220000000000001 | 3.1200000472 | 3.24 | 3.13 | 6.45 | 536.04 | 1.49 | 6130.89 | 3889.16 |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | unknown | 9 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | na | 16 | 12/14 | 9/10 | 78/170 | 18.1 | 1.84e-9 | 5.35e-3 | 4.99e-4 | 0.108 | 61 | 0.0117 | 39.5 | 1.97 |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| EPDs DONE/EPD - Pac-Clad.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | na | 14 | 11/14 | 9/10 | 78/170 | 2.39 | 1.67e-14 | 8.72e-3 | 5.13e-4 | 0.113 | 24.7 | 0.018 | 3.87 | 5.26 |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | na | 18 | 12/14 | 9/10 | 36/170 | 1.92 | 5.49e-8 | 6.51e-3 | 8.06e-4 | 0.0903 | 5.53 | 0.171 | 45.5 | 2.4 |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 1.82 | 1.09e-9 | 0.0123 | 7.24e-4 | · | · | · | 32.9 | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | unknown | 23 | 4/14 | 9/10 | 24/170 | 3.86 | 1.93e-7 | 0.021 | 7.33e-3 | 0.22 | 7.43 | 0.0599 | 45.3 | 3.2 |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | unknown | 10 | 6/14 | 1/10 | 2/170 | · | · | · | · | · | · | 7 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | epd_international | 28 | 5/14 | 4/10 | 28/170 | 0.8815 | · | · | · | 0.919 | · | 30.008 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unknown | 14 | 2/14 | 7/10 | 25/170 | -0.377 | 5.45e-11 | · | 2.43e-4 | · | · | 2.57e-3 | 14.1 | 16.7 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unknown | 1 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | eu_ibu | 13 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | unknown | 1 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | na | 21 | 12/14 | 10/10 | 9/170 | 129.86 | 2.57e-7 | 0.8409 | 0.0732 | 16.9 | 369 | 1.9805 | 2731.82 | 20.4 |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | na | 14 | 9/14 | 9/10 | 22/170 | 5.220000000000001 | 3.1200000119 | 3.16 | 3.12 | 4.19 | 155.37 | 1.38 | 328 | 568.24 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | eu_ibu | 27 | 5/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | na | 10 | 11/14 | 5/10 | 18/170 | 6.1 | 2.50e-9 | · | 0.024 | · | 97 | 56 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | epd_international | 14 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | 0.0656 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 106.1 | 1.05e-5 | 0.8236 | 0.98075 | 11.323 | 172.8 | 0.393 | 117 | 42.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | nsf | 16 | 9/14 | 4/10 | 39/170 | · | · | 0.02 | 1.62e-3 | · | · | 0.0595 | · | 12.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | nsf | 25 | 8/14 | 9/10 | 78/170 | 6.2 | 2.85e-9 | 9.22e-3 | 2.62e-3 | 0.228 | 65.7 | 0.0526 | 141 | 9.66 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | nsf | 24 | 8/14 | 9/10 | 65/170 | 6.18 | 2.10e-10 | 0.0179 | 1.71e-3 | 0.311 | 143 | 0.0593 | 147 | 19.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | nsf | 20 | 8/14 | 9/10 | 65/170 | 6.6 | 5.82e-10 | 0.0189 | 1.79e-3 | 0.335 | 150 | 0.0603 | 155 | 19.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | nsf | 18 | 8/14 | 9/10 | 65/170 | 11.7 | 4.27e-10 | 0.0279 | 2.43e-3 | 0.514 | 275 | 0.0843 | 283 | 22 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | na | 16 | 12/14 | 9/10 | 0/170 | 9.59 | 6.80e-8 | 0.0254 | 3.77e-3 | 0.427 | 198 | 0.0551 | 203 | 28.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 18.2 | 3.99e-13 | 0.0238 | 4.47e-3 | 0.58 | 307 | 7680 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 46.4 | 4.60e-8 | 0.054 | 3.66e-3 | 1.38 | 742 | 59.9 | 757 | 2.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | na | 19 | 9/14 | 2/10 | 1/170 | 11 | · | · | · | · | · | · | · | 0.00e+0 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | na | 21 | 10/14 | 9/10 | 65/170 | 11.6 | 1.97e-8 | 0.0276 | 2.83e-3 | 0.424 | 177 | 0.00e+0 | 29.7 | 29.7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | nsf | 15 | 7/14 | 2/10 | 0/170 | 22.2 | · | 0.0537 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | na | 23 | 10/14 | 7/10 | 48/170 | 728.8 | 9.77e-5 | 3.258 | 0.687 | · | 10733 | -28.8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | eu_ibu | 10 | 12/14 | 8/10 | 18/170 | -198.4 | 8.52e-13 | 0.132 | 0.0262 | · | 1451 | 0.31 | 1227 | 316 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | eu_ibu | 10 | 12/14 | 7/10 | 49/170 | -1.1448300000000002 | 2.08e-13 | 6.43e-4 | · | · | 9.392000000000001 | 4.84e-3 | 9.811 | 19.04476 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | eu_ibu | 11 | 12/14 | 7/10 | 49/170 | -37.88600000000001 | 4.38e-11 | 0.05052 | · | · | 852.39 | 0.284009 | 901.4 | 944.208 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | na | 12 | 14/14 | 10/10 | 21/170 | 234.72 | 0.178005230766 | 2.1399999999999997 | 2.54 | 628.52 | 1074.8600000000001 | 0.19999999999999998 | 910.13 | 3358.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | na | 12 | 14/14 | 10/10 | 30/170 | 124.5 | 2.27e-6 | 0.93 | 0.07 | 16.52 | 1766.23 | 0.37 | 2351.8 | 491.11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 267.42 | 9.10e-6 | 2.07 | 1.6300000000000001 | 48.65 | · | 1.42 | 7451.44 | 1666.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | na | 14 | 14/14 | 9/10 | 12/170 | 169.48 | 4.11e-6 | 1.87 | 0.31 | 70.74000000000001 | · | 0.41000000000000003 | 4816.77 | 1919.85 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | na | 18 | 14/14 | 5/10 | 18/170 | 11.62 | 3.66 | 0.01 | 0.01 | · | · | 0.12 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | na | 7 | 9/14 | 2/10 | 0/170 | · | · | · | · | · | 0.00e+0 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | na | 22 | 11/14 | 9/10 | 31/170 | 4.05 | 8.88e-8 | 0.0132 | 1.03e-3 | 0.192 | 10.3 | 0.0175 | 87.7 | 3.4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | na | 29 | 12/14 | 4/10 | 33/170 | 1 | 5.18e-7 | 0.02241 | 0.0252 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | na | 23 | 12/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | na | 27 | 11/14 | 9/10 | 5/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | na | 39 | 11/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | na | 23 | 11/14 | 9/10 | 24/170 | 3.95 | 1.94e-7 | 0.0213 | 7.27e-3 | 0.223 | 7.6 | 0.0618 | 46.8 | 3.26 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | na | 28 | 11/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | na | 27 | 10/14 | 9/10 | 12/170 | 10.5 | 1.66e-6 | 0.0489 | 0.028 | 0.528 | 20.7 | 0.0549 | 147 | 6.99 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | na | 40 | 10/14 | 9/10 | 19/170 | 1.85 | 3.34e-7 | 9.56e-3 | 2.82e-3 | 0.0862 | 5.91 | 0.0321 | 23.4 | 0.952 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | na | 17 | 12/14 | 4/10 | 0/170 | 0.0897 | 1.25e-8 | 5.24e-4 | 2.15e-4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | na | 15 | 12/14 | 9/10 | 78/170 | 3.51 | 4.05e-9 | 5.27e-3 | 4.85e-4 | 0.107 | 61.2 | 0.0121 | 31.7 | 1.81 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | na | 19 | 12/14 | 6/10 | 24/170 | 0.551 | 1.39e-12 | 1.10e-3 | 1.30e-4 | · | 0.0149 | 1.97e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | na | 16 | 10/14 | 9/10 | 66/170 | 2.05 | 3.87e-14 | 3.95e-3 | 5.08e-4 | 0.0973 | 40.8 | 0.0107 | 44.3 | 6.33 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unknown | 21 | 2/14 | 2/10 | 0/170 | · | · | · | · | · | 59.1 | 829 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | na | 21 | 10/14 | 7/10 | 7/170 | 0.419101995 | 2.40e-8 | 8.77e-5 | · | · | 5.116430855 | 0.00e+0 | 0.0494357 | 0.034854686 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | na | 12 | 12/14 | 10/10 | 24/170 | 239.47 | 6.19e-6 | 2.13 | 0.63 | 23.13 | 634.27 | 0.58 | 0.00e+0 | 2532.87 |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | nsf | 18 | 9/14 | 2/10 | 0/170 | 5.97 | · | 0.0543 | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unknown | 13 | 3/14 | 1/10 | 11/170 | · | · | · | · | · | · | 0.158121 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unknown | 9 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | nsf | 24 | 8/14 | 9/10 | 70/170 | 2.63 | 8.24e-15 | 0.011 | 0.0611 | 0.23 | 36 | 0.991 | 37.7 | 68.9 |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | na | 47 | 11/14 | 2/10 | 50/170 | · | · | · | · | · | 62.7 | 0.0618 | · | · |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | na | 54 | 8/14 | 2/10 | 52/170 | · | · | · | · | · | 53.7 | 2 | · | · |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | eu_ibu | 21 | 4/14 | 9/10 | 49/170 | 83.7 | 8.64e-6 | 0.9034 | 0.10083 | 9.440000000000001 | 795 | 0.414 | 293 | 41.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | na | 25 | 12/14 | 3/10 | 12/170 | · | · | · | · | 2.38e-5 | · | 4.01e-6 | · | 0.018989000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | na | 13 | 11/14 | 7/10 | 0/170 | 20.4 | 2.28e-6 | 0.175 | 0.0352 | 2.05 | 27.9 | 0.134 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unknown | 2 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | na | 16 | 8/14 | 7/10 | 15/170 | 1088.28 | 9.57e-5 | 8.29 | 3.9699999999999998 | 105.64999999999999 | · | · | 10.578 | 5.046 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | na | 47 | 8/14 | 2/10 | 50/170 | · | · | · | · | · | 63.2 | 0.0386 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | na | 11 | 14/14 | 9/10 | 18/170 | 365.17 | 1.51e-5 | 2.2 | 0.5700000000000001 | 44.71 | 700.06 | 1.15 | 4876.6 | 5075.6 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | na | 16 | 11/14 | 7/10 | 24/170 | 0.036 | 2.20e-11 | · | 9.60e-4 | · | 6.8 | 0.02 | 75 | 10 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | nsf | 33 | 9/14 | 9/10 | 9/170 | 178.72 | 5.50e-6 | 0.74 | 0.25 | 16.65 | 553.35 | 0.52 | 1347.76 | 16.91 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2480 | 1.73e-11 | 5.09 | 0.275 | 89.2 | 2020 | 11.7 | 30500 | 1590 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | na | 12 | 9/14 | 4/10 | 0/170 | 6.64 | · | · | · | · | 388 | 2.11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | eu_ibu | 21 | 7/14 | 8/10 | 21/170 | 10.3207 | 9.93e-8 | 0.134471 | · | 1.41782 | 118 | 3768.9 | 220.60000000000002 | 21.022000000000002 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | na | 40 | 12/14 | 9/10 | 36/170 | 9.680728 | 8.23e-7 | 0.06021118 | 0.0319123 | 0.6220313 | 7.760357 | 0.026 | 80.8 | 6.36 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | nsf | 10 | 7/14 | 4/10 | 0/170 | 68 | 5.20e-6 | 0.33 | 0.18 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 4.34 | 1.21e-11 | 0.0102 | 7.62e-4 | 0.19 | 158 | 0.0168 | 163 | 11 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | nsf | 15 | 8/14 | 9/10 | 33/170 | 3.88 | 1.16e-11 | 9.84e-3 | 7.59e-4 | 0.177 | 146 | 0.0138 | 152 | 7.67 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | eu_ibu | 30 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unknown | 10 | 2/14 | 4/10 | 24/170 | · | · | · | · | · | 49.4 | 0.0284 | 290 | 30 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | na | 23 | 12/14 | 7/10 | 20/170 | 384 | 3.32e-5 | 3.89 | 0.184 | 19.8 | 730 | 5.49 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 274 | 1.07e-8 | 1.43 | 0.114 | · | · | · | 5.42 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | na | 11 | 12/14 | 9/10 | 8/170 | 608 | 7.74e-8 | 3 | 0.242 | 59.5 | 1.06 | 7.88 | 9.69 | 11.5 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 4.57 | 6.40e-9 | 0.0403 | 5.12e-3 | · | · | · | 76.4 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | na | 9 | 11/14 | 5/10 | 0/170 | 8.97 | 6.43e-10 | 0.048 | 6.59e-3 | · | · | · | 139 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | na | 10 | 11/14 | 5/10 | 0/170 | 1.5 | 8.51e-11 | 8.39e-3 | 7.63e-4 | · | · | · | 29 | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | na | 39 | 11/14 | 5/10 | 25/170 | 8.25 | 6.51e-10 | 0.028880000000000003 | 2.49e-3 | · | · | 3.9800000000000004 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 9/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | na | 13 | 9/14 | 9/10 | 65/170 | 1.17 | -1.52e-13 | 1.75e-3 | 1.71e-4 | 0.0317 | 31.8 | 4.74e-3 | 33.3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | na | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | 3.28 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | na | 23 | 12/14 | 1/10 | 12/170 | · | · | · | · | · | · | 3.43e-5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 30.6 | 5.77e-14 | 0.0368 | 5.32e-3 | 0.961 | 493 | 7080 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 7.22 | 4.35e-14 | 8.95e-3 | 1.98e-3 | 0.203 | 140 | 5900 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 10.1 | 3.96e-13 | 0.0133 | 2.98e-3 | 0.301 | 214 | 7690 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | na | 15 | 11/14 | 8/10 | 16/170 | · | 1.49e-8 | 0.932 | 0.143 | 22.7 | 872 | 1.77 | 6800 | 1450 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | na | 19 | 12/14 | 5/10 | 12/170 | 37 | 6.40e-7 | · | 0.31 | · | 2000 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | na | 11 | 8/14 | 5/10 | 18/170 | 0.12 | 8.10e-7 | · | 0.24 | · | 15 | 0.066 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | na | 15 | 11/14 | 9/10 | 0/170 | 2150 | 1.64e-9 | 5.02 | 0.267 | 87.8 | 1960 | 8.53 | 27400 | 1640 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | na | 18 | 9/14 | 9/10 | 65/170 | 151 | 6.05e-9 | 0.356 | 0.0181 | 5.92 | 1450 | 0.612 | 1770 | 152 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | na | 20 | 12/14 | 8/10 | 12/170 | 2.71 | 1.10e-6 | 0.0188 | 6.07e-3 | 0.23 | 16.6 | · | 51.8 | 6.02 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | na | 28 | 10/14 | 6/10 | 18/170 | · | 1.49e-12 | 0.0219 | · | · | 47.3 | 0.055 | 44 | 8.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | na | 20 | 12/14 | 9/10 | 36/170 | 5.16 | 9.45e-7 | 0.0385 | 0.0125 | 0.63 | 8.22 | 0.0178 | 71.4 | 1.16 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | unknown | 11 | 6/14 | 6/10 | 24/170 | 2.65 | 3.63e-7 | 0.0105 | 2.59e-3 | 0.185 | 4.43 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | na | 53 | 12/14 | 9/10 | 48/170 | 1.581376 | 1.80e-7 | 0.014160638000000001 | 7.56e-4 | 0.1197166 | 1.777168 | 6.55e-3 | 17.5 | 0.315 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | na | 16 | 9/14 | 5/10 | 12/170 | 44 | 5.20e-7 | · | 0.29 | · | 1900 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | na | 42 | 12/14 | 6/10 | 24/170 | 65.2 | 2.57e-9 | 2.1 | 0.688 | · | 1100 | 4.85e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | na | 14 | 11/14 | 8/10 | 0/170 | 1030 | 5.02e-6 | 2.59e-6 | 0.311 | 35.3 | · | 94.2 | 18300 | 746 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | na | 16 | 12/14 | 9/10 | 15/170 | 13313 | 1.67e-4 | 29.872 | 1.7372 | 500.2 | 8270 | 27 | 99100 | 3330 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | unknown | 9 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | eu_ibu | 9 | 7/14 | 0/10 | 1/170 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | na | 14 | 12/14 | 8/10 | 14/170 | 189 | 3.65e-7 | 1.21 | 0.0278 | · | 2130 | 3.58 | 2240 | 810 |
+| Windows/746.Inline_Window_EPD.pdf | na | 11 | 12/14 | 4/10 | 12/170 | 139.75 | · | 0.9961 | 0.20350000000000001 | 12.57 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | unknown | 27 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | na | 14 | 12/14 | 4/10 | 9/170 | 342 | · | 1.708 | 0.0658 | · | · | 1.67 | · | · |
+| Windows/EPD - Product Specific (33).pdf | na | 13 | 12/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | na | 14 | 12/14 | 3/10 | 9/170 | 387.8 | · | 1.922 | 0.1504 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | na | 16 | 11/14 | 6/10 | 0/170 | 281 | · | 1.55 | 0.732 | 19.4 | 3420 | 1.44 | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | eu_ibu | 14 | 12/14 | 7/10 | 63/170 | 116 | 7.30e-6 | 0.567 | · | · | 1850 | 0.457 | 2210 | 112 |
+| Windows/Italy-window.pdf | epd_international | 40 | 8/14 | 2/10 | 0/170 | 5.44 | · | 0.0315 | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | eu_ibu | 13 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | epd_international | 32 | 12/14 | 2/10 | 0/170 | · | · | · | 0.303 | · | · | -338 | · | · |
+| Windows/SvenskaWindows.pdf | epd_international | 16 | 11/14 | 1/10 | 0/170 | 1 | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | epd_international | 18 | 8/14 | 3/10 | 7/170 | 60.8 | · | · | · | · | 974 | 4.15 | · | · |
+| Windows/kawneer_window_epd.pdf | unknown | 8 | 5/14 | 4/10 | 20/170 | 109.6525 | 9.00e-6 | 0.58653 | 0.1890178 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | nsf | 10 | 7/14 | 1/10 | 0/170 | · | · | 0.0234 | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | na | 25 | 12/14 | 5/10 | 12/170 | 38 | 4.30e-3 | · | 1900 | · | 1.70e+6 | 0.00e+0 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | na | 10 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | nsf | 3 | 6/14 | 8/10 | 18/170 | 164.5 | 9.55e-6 | 1.1500000000000001 | 0.16926 | 20.669999999999998 | 559 | · | 1.314 | 79.9 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | eu_ibu | 6 | 8/14 | 5/10 | 7/170 | 1.14 | 2.95e-11 | 1.74e-3 | · | · | 16.4 | 6.97e-3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | unknown | 1 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | 7 | · | 7 | 7 | 7 | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | · | · | · | 1 | · | · | · | · | · | · |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| April 2022/EPD Durabella.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | 6 | · | · | 6 | 6 | · | · | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | 2 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | · | · | · | · | · | · | · | 7 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | · | · | · | · | · | · | · | 1 | · | 1 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | 1 | · | 1 | 1 | 1 | 1 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | 11 | · | 11 | 11 | 11 | 11 | 11 | 11 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | · | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | 3 | · | · | 3 | 3 | · | · | 4 | · | · |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD - Pac-Clad.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | · | · | · | · | · | · | · | 2 | · | · |
+| EPDs DONE/Straw EPD UK.pdf | 7 | 7 | · | · | · | 7 | · | 7 | · | · |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | 5 | 5 | 5 | · | · | · | · | · | 5 | 5 |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/composite-panel-association-particleboard.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | 3 | · | · | · | 3 | · | · | 3 | · | · |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | 9 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | · | · | · | 13 | 13 | · | · | 13 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | 8 | 8 | 8 | 8 | 8 | · | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | 7 | · | 7 | 7 | · | · | 7 | 7 | 7 | 7 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | · | 3 | · | · | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | · | · | 6 | 6 | 6 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | 5 | · | 5 | 5 | 5 | 6 | 5 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | · | · | 11 | 11 | 11 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | 1 | · | 2 | 1 | 1 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | 4 | · | 4 | 4 | 4 | · | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | 13 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | 14 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | 1 | · | 3 | 2 | · | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | · | · |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | · | · | · | · | · | · | · | 11 | · | · |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| Linoleum flooring EPD/LCA_linoleum.pdf | · | · | · | · | · | · | · | · | · | · |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | 14 | · | 14 | 14 | 14 | 14 | · | · | · | · |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | 9 | · | 8 | 8 | 3 | · | 8 | · | 8 | 8 |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | 8 | · | 8 | 8 | 8 | 8 | 9 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | 8 | · | 8 | 8 | 2 | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | 3 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | 8 | · | · | · | 8 | · | · | 8 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | 2 | · | 2 | 2 | 2 | · | 1 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | 3 | · | 3 | 3 | · | 3 | · | 3 | 3 | 3 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | 7 | · | 7 | 7 | 6 | 6 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | · | · | · | · | · | · | 8 | · | 8 | 8 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | 5 | · | 5 | 5 | 5 | · | · | 5 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | · | · | · | · | · | 4 | · | 4 | · | 4 |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | 1 | · | 3 | 3 | 3 | 3 | · | 3 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | 6 | · | · | · | 6 | · | · | 6 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | 13 | · | 13 | 13 | 13 | 13 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | 2 | · | 2 | 2 | 2 | 2 | 2 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | · | · | 6 | 6 | · | · | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | 6 | · | 6 | 6 | 6 | 6 | 6 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | 4 | · | 4 | 4 | 4 | 4 | 4 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | 8 | · | 8 | 8 | 8 | 8 | 8 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | 4 | · | 4 | 4 | 4 | · | 4 | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | 3 | · | 3 | 3 | 3 | 3 | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | · | · | 2 | 2 | 2 | · | 2 | 2 | 2 | 2 |
+| Windows/746.Inline_Window_EPD.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| Windows/DVP-window-EPD-mexico.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/EPD - Product Specific (32).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (33).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (34).pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| Windows/EPD - Product Specific (37).pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| Windows/Italy-window.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Pursoy-Window -EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/SvenskaWindows.pdf | · | · | · | · | · | · | · | · | · | · |
+| Windows/Window-Finstral-EPD.pdf | 1 | · | · | 2 | · | · | · | 4 | · | · |
+| Windows/kawneer_window_epd.pdf | 5 | · | 5 | 5 | 5 | · | · | · | · | · |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | 4 | · | · | · | 4 | · | · | 4 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | 3 | · | 3 | 3 | 3 | 3 | 3 | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | 1 | · | 1 | 1 | 1 | 1 | 1 | 1 | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | · | · | · | · | · | · | · | · | · | · |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 85/208 | 41% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 8/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 83/208 | 40% |  |
+| 3 | `acidification_kgso2eq` — AP | 85/208 | 41% |  |
+| 4 | `eutrophication_kgneq` — EP | 85/208 | 41% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 82/208 | 39% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 103/208 | 50% |  |
+| 7 | `water_consumption_m3` — WDP | 2/208 | 1% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 6/208 | 3% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 5/208 | 2% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 26/208 | 13% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 2/208 | 1% |  |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 25/208 | 12% |  |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 19/208 | 9% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 28/208 | 13% |  |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 2/208 | 1% |  |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 31/208 | 15% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 3/208 | 1% |  |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 2/208 | 1% |  |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 2/208 | 1% |  |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 10/208 | 5% |  |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 3/208 | 1% |  |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 93/208 | 45% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 64/208 | 31% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 80/208 | 38% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 12/208 | 6% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 41/208 | 20% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 82/208 | 39% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 78/208 | 38% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 98/208 | 47% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 161/208 | 77% |  |
+| 1 | `gwp_bio_kgco2e` | 9/208 | 4% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 107/208 | 51% |  |
+| 3 | `acidification_kgso2eq` | 151/208 | 73% |  |
+| 4 | `eutrophication_kgneq` | 152/208 | 73% |  |
+| 5 | `smog_kgo3eq` | 48/208 | 23% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 69/208 | 33% |  |
+| 7 | `water_consumption_m3` | 91/208 | 44% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 2/208 | 1% |  |
+| 9 | `primary_energy_renewable_mj` | 11/208 | 5% |  |
+| 10 | `gwp_kgco2e` | 55/208 | 26% |  |
+| 11 | `gwp_bio_kgco2e` | 1/208 | 0% | thin |
+| 12 | `acidification_kgso2eq` | 55/208 | 26% |  |
+| 13 | `eutrophication_kgneq` | 42/208 | 20% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 56/208 | 27% |  |
+| 15 | `smog_kgo3eq` | 43/208 | 21% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 39/208 | 19% |  |
+| 17 | `water_consumption_m3` | 11/208 | 5% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 13/208 | 6% |  |
+| 19 | `primary_energy_renewable_mj` | 13/208 | 6% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 208 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 8/208 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 4/208 | 2% |  |
+| 2 | `acidification_kgso2eq` | 0/208 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/208 | 4% |  |
+| 4 | `smog_kgo3eq` | 1/208 | 0% | thin |
+| 5 | `abiotic_depletion_fossil_mj` | 0/208 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/208 | 0% | thin |
+
+## Catalogue parity check
+
+208 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 33/208 | 16% |
+| strong-multi | 26/208 | 13% |
+| medium | 4/208 | 2% |
+| medium-multi | 39/208 | 19% |
+| weak | 76/208 | 37% |
+| unmatched | 30/208 | 14% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 143 | 27 | 8 | 0 | 80% |
+| `classification.material_type` | 84 | 35 | 54 | 5 | 49% |
+| `manufacturer.name` | 36 | 78 | 60 | 4 | 21% |
+| `physical.density.value_kg_m3` | 10 | 102 | 54 | 12 | 6% |
+| `epd.id` | 68 | 51 | 54 | 5 | 39% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/810.CRMCA_EPD_BC.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/814.CRMCA_EPD_Ontario.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf | weak | 40 | `4s1lp2` | Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average | disp(2/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Particleboard-1902.pdf | unmatched | 27 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf | medium-multi | 50 | `xsp4tl` (+4 more) | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(2/2), group |
+| April 2022/EPD Durabella Biopolymer Seamless Terrazzo 01-01-2021.pdf | unmatched | 0 | — | — | — |
+| April 2022/EPD Durabella.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf | medium-multi | 50 | `cmu000` (+3 more) | CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg \| CA] | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf | strong-multi | 115 | `cmu004` (+1 more) | CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16 | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, 845.EPD380-Standard-WoodWorks.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Ceiling, Wall cladding, 819.5578_MF_Tectum_822w_signed.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf | strong | 160 | `f33e5e` | Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf | strong-multi | 127 | `c9a7f3` (+1 more) | Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 822.VinylSiding_VSI.pdf | strong | 170 | `vin001` | Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] | epd.id, mfr, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf | strong-multi | 160 | `bri005` (+1 more) | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf | strong-multi | 157 | `84c2b6` (+1 more) | Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg \| US-Canada] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, plaster, EPD-HASIT-FIXIT-222-Aerogel-Hochleistungsdämmputz-de.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf | weak | 47 | `eps003` | EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg \| US & CA] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Composite decking EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 809.CRMCA_EPD_Alberta.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 810.CRMCA_EPD_BC (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 812.CRMCA_EPD_Atlantic.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 813.CRMCA_EPD_Manitoba.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 814.CRMCA_EPD_Ontario (1).pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, 815.CRMCA_EPD_Saskatchewan.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Concrete, US NRMCA new concrete EPD10294.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 655.EPD_FOR_UltraLight_Panels.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Drywall, 659.EPD_FOR_UltraLight_Sag-Resistant_Interior_Ceiling_Board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - CertainTeed Glassrock gypsum board.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf | medium-multi | 75 | `mpa001` (+1 more) | Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060" | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf | strong | 130 | `4k2v0s` | Laminated strand lumber (LSL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, group |
+| EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf | medium-multi | 75 | `l2jfis` (+4 more) | Rebar / Nucor Corporation / 10M | epd.id |
+| EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf | strong | 150 | `ebd574` | Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg \| US & CA] | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/20170315_EPD_INT_Moso_Solid_EN.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf | strong | 127 | `175f1a` | XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| EPDs DONE/EPD - Pac-Clad.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf | strong | 120 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | epd.id, disp(1/2), group, mat |
+| EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf | strong | 120 | `rnd601` | Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch | epd.id, disp(3/4), group |
+| EPDs DONE/EPD_-_RFPIJoist-2.pdf | strong | 150 | `9aedf1` | Wood I joist / Roseburg / RFPI Joist / | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/EPD_-_RigidLam_LVL-1.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| EPDs DONE/Polyiso - wall board - PIMA_2020_EPD10466.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/Smith_Fong_Plyboo_EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs DONE/Straw EPD UK.pdf | strong | 95 | `b4t02m` | Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg \| EU] | epd.id, disp(1/2) |
+| EPDs DONE/Søuld_EPD for eelgrass insulation.pdf | unmatched | 27 | — | — | — |
+| EPDs DONE/cellulosic-fiberboard-cellulosic-fiberboard.pdf | unmatched | 0 | — | — | — |
+| EPDs DONE/composite-panel-association-particleboard.pdf | unmatched | 20 | — | — | — |
+| EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf | strong-multi | 90 | `d0rk2l` (+1 more) | Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm) | epd.id, group |
+| EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf | weak | 47 | `9cd566` | XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO] | disp(2/3), group, mat |
+| EPDs DONE/du-pont-de-nemours-inc-thermax-products.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs DONE/nafa_epd_northamericancellulosicfiberboard.pdf | strong | 120 | `f4l2kx` | Wood fiber board / R 2.7-inch / NAFA [Industry Avg \| US & CA] | epd.id, mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/EPS block with cement binder EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egeseramik glazed tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf | weak | 30 | `lvt001` | Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg \| US & CA] | disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik wall tiles EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum 2 EPD.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Gerflor linoleum EPD.pdf | strong | 80 | `lin003` | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(3/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf | strong | 120 | `lvt007` | Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf | medium-multi | 75 | `car003` (+1 more) | Carpet / Shaw / Strataworx / Carpet tile | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf | strong | 110 | `cer002` | Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade / | epd.id, disp(2/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, composite decking, SCS-EPD-07180_Fiberon_082622.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf | strong | 120 | `cer001` | Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade / | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf | weak | 37 | `4dadb7` | Ceramic tile / Crossville / Porcelain / Standard grade (mortar included) | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf | strong | 130 | `ins030` | Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU] | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf | strong | 157 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | epd.id, mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf | medium-multi | 77 | `ins035` (+2 more) | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | mfr, disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf | strong-multi | 130 | `lam009` (+1 more) | Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2" | epd.id, mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf | weak | 40 | `lam003` | Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf | medium-multi | 60 | `ewf001` (+4 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf | medium-multi | 50 | `hwf000` (+4 more) | HempWood / Fibonacci / Natural Laminate Flooring / 16 mm | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Heraklith wood wool-epd_knauf_insulation_heraklith_final.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf | strong-multi | 120 | `ins040` (+2 more) | Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg \| US & CA] | epd.id, disp(3/4), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf | medium | 75 | `poly10` | Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf | weak | 40 | `d0rm3c` | Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg \| US & CA] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf | strong | 120 | `poly06` | Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf | strong | 120 | `poly02` | Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf | strong-multi | 120 | `poly05` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf | strong | 120 | `poly01` | Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf | strong-multi | 120 | `poly04` (+1 more) | Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf | medium-multi | 50 | `1f3cc3` (+4 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf | strong | 127 | `1a16ad` | XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi | epd.id, disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf | strong | 160 | `ins009` | Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Recycled denim fiber batt insulation EPD10446.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, straw, BAU-EPD-Fasba-2019-1-GaBi-Baustrohballen-20191010.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/K50 floor tile adhesive EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf | medium-multi | 50 | `tru001` (+4 more) | Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords | disp(2/2), group |
+| Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/DURACRYL Linoleum product_epd_1123218 - NOT THIRD PARTY VERIFY.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/EPD - Tarket Linoleum.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| Linoleum flooring EPD/Gerflor-dlw-linoleum-epd-acoustic-plus-4788756650.101.1.pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| Linoleum flooring EPD/LCA_linoleum.pdf | unmatched | 0 | — | — | — |
+| Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf | medium-multi | 50 | `lvt002` (+4 more) | Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm | disp(3/4), group, mat |
+| Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf | weak | 40 | `e075b4` | Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum | disp(1/1) |
+| Linoleum flooring EPD/NEW Gerflor linoleum AcousticPlus - 4788756650.101.1 .pdf | medium-multi | 67 | `lin003` (+1 more) | Linoleum flooring / Gerflor  / DLW Linoleum Compact / 2.5 mm sheet style linoleum | mfr, disp(2/3) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF 2 EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/MDF EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Marmoleum modular tile EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf | strong | 90 | `lam012` | Mass ply panels (MPP) / Freres Lumber | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/NRMCA_EPDV3-2_20220301_1470a6f765bc4b948ac6be5ab03926c9.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Clark Dietrich steel stud 2 EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf | medium-multi | 75 | `sss001` (+1 more) | Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Prostud steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite surfaces EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Richlite-EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline 2 asphalt shingles EPD10396.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing GAF timberline asphalt shingles EPD10397.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tiles 2 Denmark EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf | strong | 120 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf | strong | 150 | `2c3p9d` | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | epd.id, mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf | medium-multi | 70 | `f14060` (+1 more) | Wood framing - Softwood / Roseburg / | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf | strong | 160 | `ply003` | Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf | medium-multi | 70 | `2c3p9d` (+2 more) | Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL | mfr, disp(1/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf | strong-multi | 160 | `ply004` (+1 more) | Plywood / 1/2" / Roseburg softwood plywood / | epd.id, mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf | strong-multi | 80 | `1f3cc3` (+1 more) | Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch | mfr, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/STO-EPD-Transition-Membrane-Final.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter all-set mortar EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf | medium | 75 | `car001` | Carpet / Shaw / Residential Broadloom | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf | medium | 75 | `car002` | Carpet / Shaw / Residential Broadloom with ClearTouch Platinum | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf | strong-multi | 120 | `int000` (+1 more) | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | epd.id, disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf | strong-multi | 90 | `osb000` (+1 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Shower valve EPD.pdf | unmatched | 0 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf | weak | 35 | `l2jfis` | Rebar / Nucor Corporation / 10M | mfr |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Steelcraft steel_polyu door EPD.pdf | unmatched | 10 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf | strong-multi | 90 | `g60979` (+2 more) | Asphalt Shingles / Owens Corning / Duration / | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf | strong-multi | 130 | `lin004` (+2 more) | Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle\|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum | epd.id, disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf | medium-multi | 75 | `mwb012` (+4 more) | Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch | epd.id |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf | medium-multi | 60 | `osb000` (+4 more) | OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing | mfr, disp(1/2) |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Versapanel metal insulated panel EPD.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/746.Inline_Window_EPD.pdf | strong | 135 | `s76tf2` | Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN | epd.id, mfr, disp(1/2) |
+| Windows/DVP-window-EPD-mexico.pdf | unmatched | 0 | — | — | — |
+| Windows/EPD - Product Specific (32).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (33).pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| Windows/EPD - Product Specific (34).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/EPD - Product Specific (37).pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Italy-window.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Pursoy-Window -EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/SvenskaWindows.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/Window-Finstral-EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/kawneer_window_epd.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| Windows/scs-epd-07201_andersencorp_e-series_092721.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf | strong-multi | 90 | `2fg4um` (+4 more) | OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8" | epd.id, group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_ecococon_2022.pdf | unmatched | 20 | — | — | — |
+| New EPDs for 2022 DUMP- STOP DUMPING!/epd_lafarge_vancouver_harbour_ready-mix_rmxug35a3a8m_version_1_2022324.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ Roofing, Cement tiles EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/APP modified asphalt roll roofing (torch down) EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.101.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/AWC-EPD-Hardboard-1608.pdf** (top: `4s1lp2` — Structural Precast Concrete / 10'' Hollow core slab / CPCI - PCI / North American Average):
+- `manufacturer.name` — candidate `"Composite Panel Association"` vs catalogue `"CPCI - PCI"`
+- `epd.id` — candidate `"4787549627.101.1"` vs catalogue `"EPD-117"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Agrocrete brick EPD.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Concrete"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"Nov 2020 to"` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"S-P-06876"` vs catalogue `"01-004"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Optima plant based ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Armstrong Ultima ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4790057043.103.1 2"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond satin stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Bond textured stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 643.EPD_FOR_Vaagen_Timbers_CLT_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CLT, 761.Kalesnikoff+CLT+EPD+.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `481.68` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 295"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 311.EPD_for_CCMPA_Normal-Weight_And_Light-Weight_Concrete_Masonry_Units.pdf** (top: `cmu000` — CMU - Light weight / 8" Light weight blocks / 15 MPa, 390 x 190 x 190 mm / CCMPA East Region [Industry Avg | CA]):
+- `classification.material_type` — candidate `"Portland Cement"` vs catalogue `"Concrete"`
+- `epd.id` — candidate `"1 m3 of concrete formed into manufactured"` vs catalogue `"EPD-338"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/CMU, 417.EPD_for_Boehmers_EPD_2019-01-06.pdf** (top: `cmu004` — CMU - Light weight / Brampton Brick (Boehmers) / 8" CarboClave Block  / 8 x 8 x 16):
+- `classification.group_prefix` — candidate `"03"` vs catalogue `"04"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Certainteed glass wool insulation EPD 4788647002.102.1.pdf** (top: `f33e5e` — Fiberglass loose fill / CertainTeed / InsulSafe, Optima, TruComfort / R 2.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.574`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 485.EPD_FOR_Interstate_Brick__EPD__FINAL__March__12-2020.pdf** (top: `c9a7f3` — Brick, Clay / Interstate / Avg Thin Face Brick / 3-9/16" x 5/8" x 11-5/8" (90 x 16 mm x 295) incl. 3/8" mortar and ties):
+- `manufacturer.name` — candidate `"Climate Earth, Inc"` vs catalogue `"Interstate"`
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, 836.Shaw_Brick_Clay_Brick_EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `2060` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding, US Canada clay brick EPD10447.pdf** (top: `84c2b6` — Brick, Clay, Generic Modular / Bricks by Volume (no mortar) / Brick Industry Association / [Industry Avg | US-Canada]):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `2120`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Cladding,Plaster,EPD-HASIT-840-CalceClima®-Thermo-Kalk-Dämmputz-de.pdf** (top: `eps003` — EPS foam board / Type I / R 3.6-inch, 10 psi / EPS Industry Alliance [Industry Avg | US & CA]):
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `14.4`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Criaterra final report EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD - Product Specific (4).pdf** (top: `mpa001` — Metal Wall Panels - Aluminum / CENTRIA / RZR / 0.060"):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Aluminum"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `10.49`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/EPD_GUTEX_Thermofibre-Zertifikat_en 2024.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**EPDs DONE/01_ArcelorMittal_EPD_FINAL_CSA_locked.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Long Products Canada"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs DONE/101-1_american-wood-council_epd_north-american-laminated-strand-lumber.pdf** (top: `4k2v0s` — Laminated strand lumber (LSL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Framing"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `570.22`
+
+**EPDs DONE/101.1_Nucor-Corporation_EPD_Fabricated-Concrete-Reinforcing-Bar-and-Merchant-Bar.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `manufacturer.name` — candidate `"Nucor Steel Auburn"` vs catalogue `"Nucor Corporation"`
+
+**EPDs DONE/105.1_AWC-CWC_EPD_North-American-Laminated-Veneer-Lumber-1.pdf** (top: `ebd574` — Laminated veneer lumber (LVL) / AWC & CWC [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `548`
+
+**EPDs DONE/20170315_EPD_INT_Moso_Density-_EN-.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/20170315_EPD_INT_Moso_X-treme_EN.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+
+**EPDs DONE/EPD  - DuPont reduced GWP XPS.pdf** (top: `175f1a` — XPS foam board / DuPont / Styrofoam / Reduced GWP / R 5.6-inch, 25 psi):
+- `manufacturer.name` — candidate `"the facilities TM TM located"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - DuPont TM Styrofoam TM Brand ST100 XPS.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD - Pac-Clad.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**EPDs DONE/EPD - Product Specific- Thermax Dupont - Polyiso.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `manufacturer.name` — candidate `"the Pennsauken"` vs catalogue `"DuPont"`
+
+**EPDs DONE/EPD Sprayfoam Soy Huntsman Building Solutions - Heatlok HFO & Heatlok Soya HFO.pdf** (top: `rnd601` — Spray polyurethane foam - Closed Cell (HFO gas) / Huntsman / Heatlok Soya HFO & Heatlok HFO / R 6.5-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"HBS during the year. The"` vs catalogue `"Huntsman Building Solutions"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `38.4`
+
+**EPDs DONE/EPD_-_RFPIJoist-2.pdf** (top: `9aedf1` — Wood I joist / Roseburg / RFPI Joist /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `3.9`
+
+**EPDs DONE/EPD_-_RigidLam_LVL-1.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**EPDs DONE/Straw EPD UK.pdf** (top: `b4t02m` — Straw Bale / Wheat & barley straw / SNaB (UK) / R 2.8/inch [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+
+**EPDs DONE/dassoXTR-dassoCTECH-EPD.pdf** (top: `d0rk2l` — Bamboo Cladding / Dasso / dassoXTR Bamboo RainClad® Siding / Shiplap, 3/4'' (19 mm)):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Bamboo"`
+- `manufacturer.name` — candidate `"Zhejiang Daocheng Bamboo Industry Co., Ltd"` vs catalogue `"Dasso"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `1150`
+
+**EPDs DONE/du-pont-de-nemours-inc-low-gwp-styrofoam-brand-xps-st-100-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/du-pont-de-nemours-inc-reduced-gwp-styrofoam-xps-brand-products.pdf** (top: `9cd566` — XPS foam board / Owens Corning / Foamular 250 / HFC-filled / R 5.0-inch, 25 psi [MEXICO]):
+- `physical.density.value_kg_m3` — candidate `28` vs catalogue `24.8`
+
+**EPDs DONE/lp-smartside-environmental-product-declaration-epd.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"EPD192"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Egesermik floor tiles EPD.pdf** (top: `lvt001` — Luxury Vinyl Tile / Resilient Floor Covering Institute / LVT and SVT [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"EGE SERAM"` vs catalogue `"Resilient Floor Covering Institute"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Exterior door Ceco EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"ASSA ABLOY Door Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789049516.178.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Fiber Cement siding - James Hardie.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"James"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"S-P-01432"` vs catalogue `"EPD 034"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, J&J carpet EPD10781.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Legato liquid linoleum EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Mannington LVT EPD10668.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre  LVT 3 EPD10156.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 1 EPD10158.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Parterre LVT 2 EPD10157.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Patcraft LVT flooring EPD.pdf** (top: `lvt007` — Luxury vinyl tile (LVT)  / Shaw - Patcraft / Luxury Vinyl Tile / 2 - 5 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"several stages beginning with the"` vs catalogue `"Shaw - Patcraft"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `0.00576`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Shaw residential carpet tile 3 EPD.pdf** (top: `car003` — Carpet / Shaw / Strataworx / Carpet tile):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Nylon"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, Wall cladding, Fireclay tile EPD10355.pdf** (top: `cer002` — Ceramic tile / Fireclay Tile / Ceramic / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Aromas"` vs catalogue `"Fireclay Tile"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, tile, American Wonder tiles EPD10277.pdf** (top: `cer001` — Ceramic tile / American Wonder Porcelain / Porcelain - recycled content / Standard and Second grade /):
+- `manufacturer.name` — candidate `"the facility located in Lebanon"` vs catalogue `"American Wonder Porcelain"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding Florim tiles EPD10141.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Flooring, wall cladding, 569.EPD_For_RAK_Ceramics_Ceramic_and_Porcelain_Tiles.pdf** (top: `4dadb7` — Ceramic tile / Crossville / Porcelain / Standard grade (mortar included)):
+- `manufacturer.name` — candidate `"RAK Ceramics. Since tiles are"` vs catalogue `"Crossville"`
+- `epd.id` — candidate `"EPD 165"` vs catalogue `"4788863727.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX-Zertifikat-EPD_wood_fibre_insulating_boards_en.pdf** (top: `ins030` — Wood fiber board / GUTEX / Multi-Therm / R 3.6-inch, 40-200 mm [EU]):
+- `physical.density.value_kg_m3` — candidate `167` vs catalogue `140`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermofibre-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/GUTEX_Thermoflex-Zertifikat-EPD_en.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood fibre"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `35`
+- `epd.id` — candidate `"EPD-GTX-20180071-IBA1-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 644.EPD_FOR_Vaagen_Timbers__Gulam_EPD_20210414.pdf** (top: `lam009` — Cross Laminated Timber (CLT) / Vaagen / Crosslam CLT / 3-1/2"):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `442.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 760.Kalesnikoff+Glulam+EPD+.pdf** (top: `lam003` — Glued Laminated Timber (Glulam) / Kalesnikoff Lumber Co. / BC):
+- `manufacturer.name` — candidate `"Kalesnikoff in South Slocan"` vs catalogue `"Kalesnikoff Lumber Co."`
+- `epd.id` — candidate `"EPD 296"` vs catalogue `"EPD296"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 763.WesternArchib_Edmonton_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Edmonton"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 247"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Glulam, 764.WesternArchib_Boissevain_Glulam_EPD_20220203.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Western Archrib in Boissevain"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+- `epd.id` — candidate `"EPD 246"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Hemp fiber batt Sweden EPD.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/HempWood Flooring_EPD.pdf** (top: `hwf000` — HempWood / Fibonacci / Natural Laminate Flooring / 16 mm):
+- `classification.material_type` — candidate `"Plywood"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `1063` vs catalogue `10.5`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 451.EPD_for_SPFA_EPD_20181029_HFO_excl_2K-LP.pdf** (top: `ins040` — Spray polyurethane foam - Closed Cell (HFO gas) / R 6.6-inch / SPFA [Industry Avg | US & CA]):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Polyurethane"`
+- `manufacturer.name` — candidate `"each member"` vs catalogue `"SPFA"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 649.EPD_for_Natur_Chanv_Hemp_English_version.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Hemp fiber"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 720.EPD_FOR_Hunter_Wall_Final_15Sept2021.pdf** (top: `poly10` — Polyisocyanurate / Wall Boards / Hunter / Xci / R 6.3-inch, 20 psi):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Polyisocyanurate"`
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `33.73`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 721.EPD_FOR_Carlisle_Cover_Board_Final_15Sept2021.pdf** (top: `d0rm3c` — Polyisocyanurate / Roof Boards / GRF Facer / R 5.6/inch / PIMA [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"PIMA"`
+- `epd.id` — candidate `"EPD 254 Product Polyisocyanurate High-Density"` vs catalogue `"EPD10465"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 722.EPD_FOR_Carlisle_Roof_Final_15Sept2021.pdf** (top: `poly06` — Polyisocyanurate / Roof Boards / GRF facer / Carlisle / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Carlisle"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 736.CCW_Wall_EPD_Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD 273 Product Polyisocyanurate Wall Insulation"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 744.Hunter_Cover_Board_EPD_Final.pdf** (top: `poly02` — Polyisocyanurate / Roof Boards / High density / Hunter / Type II R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 745.Hunter_Roof_EPD_Final.pdf** (top: `poly05` — Polyisocyanurate / Roof Boards / CGF facer / Hunter / H-Shield CG / Type II R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Hunter"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 749.Versico_Cover_Board_EPD_Final.pdf** (top: `poly01` — Polyisocyanurate / Roof Boards / High density / Versico / Type II, R 5.0-inch, 80 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, 751.Versico_Roof_EPD_Final.pdf** (top: `poly04` — Polyisocyanurate / Roof Boards / CGF facer / Versico / Type II, R 5.6-inch, 16 psi):
+- `manufacturer.name` — candidate `"For more information, please contact"` vs catalogue `"Versico"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Certainteed fiberglass blanket EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `classification.material_type` — candidate `"Spray polyurethane foam"` vs catalogue `"Fiberglass"`
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `0.488`
+- `epd.id` — candidate `"4787358620.102.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Dupont low GWP XPS EPD.pdf** (top: `1a16ad` — XPS foam board / DuPont / Styrofoam ST-100 / R 5.0-inch, 25 psi):
+- `manufacturer.name` — candidate `"TM the facilities located in"` vs catalogue `"DuPont"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Insulation, Johns Manville 2 blown in fiberglass formaldehyde free EPD.pdf** (top: `ins009` — Fiberglass loose fill / Johns Manville / Climate Pro, Attic Protector, JM Spider PLUS (Canada) / R 2.8-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.46`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/LVL, 708.Epd_for_BoiseCascade_A1-A3_EPD_20210817.pdf** (top: `tru001` — Wood/steel hybrid floor truss / RedBuilt / Red-S Open-Web / 16" deep, double 1.5 x 2.3" LVL chords):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood/steel"`
+- `manufacturer.name` — candidate `"Boise Cascade in White City"` vs catalogue `"RedBuilt"`
+- `physical.density.value_kg_m3` — candidate `483.4` vs catalogue `7.05`
+- `epd.id` — candidate `"Veneer Laminated Timber"` vs catalogue `"SCS-EPD-07526"`
+
+**Linoleum flooring EPD/Armstrong - Linoleum-Enviroment-Declaration.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Linoleum flooring EPD/EPD - Tarket Linoleum.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**Linoleum flooring EPD/Mannington - Liquid linoleum flooring - Legato - EPD10362.pdf** (top: `lvt002` — Luxury vinyl tile (LVT) / Mohawk / Hot & Heavy Floating Tiles / 5.0 mm):
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `8.09`
+
+**Linoleum flooring EPD/Marmoleum Striato FR EPD-UL-4789275679.141.1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789275679.141.1"` vs catalogue `"4789365778.101.1"`
+
+**Linoleum flooring EPD/Marmoleum-2 mm-EPD 12CA648.pdf** (top: `e075b4` — Linoleum flooring / Forbo / Marmoleum / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"P.O. Box 13"` vs catalogue `"Forbo"`
+- `epd.id` — candidate `"12CA64879.101.1"` vs catalogue `"4790690881.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Longi PV panel EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. LONGi solar monocrystalline"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4790285205.101.1 LR4-72HBD"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Low-e glass EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Tecnoglass, Inc."` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino WARE steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Marino steel joist framing EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Mass Plywood, 563.EPD_For_FinalFreres_Lumber_Company.pdf** (top: `lam012` — Mass ply panels (MPP) / Freres Lumber):
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Wood"`
+- `manufacturer.name` — candidate `"Freres Lumber in Lyons"` vs catalogue `"Freres Lumber Company Inc."`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `546`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/McKinney door hinge EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789198858.107.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New ClarkDietrich steel stud EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/New Marino steel stud EPD.pdf** (top: `sss001` — Steel studs - Load bearing / MarinoWARE / Structural stud and track / 600-S-137-54, 16 gauge):
+- `classification.group_prefix` — candidate `"09"` vs catalogue `"05"`
+- `classification.material_type` — candidate `"Gypsum"` vs catalogue `"Steel"`
+- `physical.density.value_kg_m3` — candidate `900` vs catalogue `7800`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/OCO aggregate EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Manufacturer VP-001 O.C.O Technology Ltd"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Olympia ceiling tile EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"Factory of USG Middle East Ltd. Co."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Owens Corning thermafiber mineral wool formaldehyde free EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Joplin"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.103.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Peterson Snap Clad metal roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roman stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Cement tile EPD-Mannok-Rooftiles-9-11-18-EPDIE-18-12.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, Oakridge asphalt shingles EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roofing, cladding, Petersen metal panels (one of many) EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"commercial and residential applications. This"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg LVL EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg MDF EPD.pdf** (top: `f14060` — Wood framing - Softwood / Roseburg /):
+- `physical.density.value_kg_m3` — candidate `753` vs catalogue `456`
+- `epd.id` — candidate `"4789110727.101"` vs catalogue `"4786969381.105.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg hardwood plywood panels EPD.pdf** (top: `ply003` — Plywood / 3/4" / Roseburg / SkyPly / hardwood plywood, incl. walnut, alder, cherry, mahogany, oak, birch, maple faces):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `8.9`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg particle board EPD.pdf** (top: `2c3p9d` — Laminated veneer lumber (LVL) / Roseburg F.P. / RigidLam LVL):
+- `classification.material_type` — candidate `"LVL"` vs catalogue `"Wood"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `539`
+- `epd.id` — candidate `"4786969381.101.1"` vs catalogue `"4786969381.104.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Roseburg plywood EPD.pdf** (top: `ply004` — Plywood / 1/2" / Roseburg softwood plywood /):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `4.38`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SBS modified asphalt roll roofing EPD.pdf** (top: `1f3cc3` — Fiberglass batt / CertainTeed / Sustainable Insulation / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `0.488`
+- `epd.id` — candidate `"4789064623.103.1"` vs catalogue `"4788647002.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/SCS-EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Schluter unmodified mortar EPD.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `manufacturer.name` — candidate `"Schluter Systems"` vs catalogue `"SHAW"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+- `epd.id` — candidate `"4787455040.102.1"` vs catalogue `"EPD 359"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shanghai Ja PV panel EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Photovoltaic Modules. JA Solar mono-crystalline"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790076867.102.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom 4 EPD.pdf** (top: `car001` — Carpet / Shaw / Residential Broadloom):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential broadloom carpet EPD.pdf** (top: `car002` — Carpet / Shaw / Residential Broadloom with ClearTouch Platinum):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"09"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Shaw Flooring"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Shaw residential carpet tile EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.145.1"` vs catalogue `"6742-7944"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Gold bond gypsum panels EPD10792.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"the facilities shown in the"` vs catalogue `"National Gypsum"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB 2 EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Sheathing, Huber Advantech OSB EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `manufacturer.name` — candidate `"plants in Commerce"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Steel roof and floor deck EPD.pdf** (top: `l2jfis` — Rebar / Nucor Corporation / 10M):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"03"`
+- `epd.id` — candidate `"4789971341.101.1"` vs catalogue `"4789793365.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof shake EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Stone coated steel roof tile textured EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Supreme asphalt shingle EPD.pdf** (top: `g60979` — Asphalt Shingles / Owens Corning / Duration /):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Owens Corning"`
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `10.12`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tarkett linoleum flooring EPD.pdf** (top: `lin004` — Linoleum flooring / Tarkett  / Lino Veneto xf2, Etrusco, Style Elle|Emme, Veneto, Originale, LinoRail, Linosport / 2.5 mm sheet style linoleum):
+- `manufacturer.name` — candidate `"various species of pines and"` vs catalogue `"Tarkett"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool blown in EPD.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"the location listed below. Wabash"` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+- `epd.id` — candidate `"4788956323.102.1"` vs catalogue `"4788424634.102.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD - Optimization.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Thermafiber mineral wool board EPD.pdf** (top: `mwb012` — Mineral wool batt / Owens Corning / UltraBatt - Fire & Sound Guard Plus R-15, R-30 (plant Avg) / R 4.2-inch):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Mineral wool"`
+- `manufacturer.name` — candidate `"the locations listed below. Wabash"` vs catalogue `"Owens Corning"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tru spec engineered wood EPD.pdf** (top: `osb000` — OSB sheathing / 1/2" / Huber  / AdvanTech / 1/2" Sheathing):
+- `epd.id` — candidate `"4789103593.103.1"` vs catalogue `"4789103593.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Tudor stone coated steel roofing EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"Ross Roof Group"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788415833.101.1"` vs catalogue `"4789365778.101.1"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/USG Halcion panels with bio binder EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"USG"` vs catalogue `"DATABASE AVERAGE"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/Windows, 746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/1022_H-vindet-AT200SE-top-hinged-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/1022_H-vinduet-AT450SE-fixed-window_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/107.1_YKK_EPD_Aluminum-Window-Systems.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"YKK AP America"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4786832322.107.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/746.Inline_Window_EPD.pdf** (top: `s76tf2` — Window - double-glazed / Inline Fiberglass / Series 300, 325, 325, 400 / Fiberglass frame / CAN):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"08"`
+
+**Windows/EPD - Product Specific (32).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.103.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (33).pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**Windows/EPD - Product Specific (34).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789733794.101.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/EPD - Product Specific (37).pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"ES Windows by Tecnoglass"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789316837.104.1"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Environmental-Declaration_-PVC-U-Windows_DoubleGlazing.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20150313-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Italy-window.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-00514"` vs catalogue `"4789365778.101.1"`
+
+**Windows/NEPD-2996-1653_Norgesvinduet-Fixed-Frame-Window-with-and-without-aluminum-cladding.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/Pursoy-Window -EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Purso Oy"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-03838"` vs catalogue `"4789365778.101.1"`
+
+**Windows/SvenskaWindows.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Svenska F"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-01969"` vs catalogue `"4789365778.101.1"`
+
+**Windows/Window-Finstral-EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"S-P-05676"` vs catalogue `"4789365778.101.1"`
+
+**Windows/kawneer_window_epd.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**Windows/scs-epd-07201_andersencorp_e-series_092721.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/ZIP-System-Sheathing-and-Tape-EPD-ZIP-System.pdf** (top: `2fg4um` — OSB sheathing & barrier / Huber ZIP System / Roof and Wall Sheathing / 5/8"):
+- `manufacturer.name` — candidate `"five different thicknesses"` vs catalogue `"Huber"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `660`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/fermacell EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"IBU - Institut Bauen und Umwelt e.V. Fermacell GmbH"` vs catalogue `"CMS"`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-afb.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-comfortbatt.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**New EPDs for 2022 DUMP- STOP DUMPING!/rockwool-rockwool-stone-wool-insulation.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_v1.1-candidates.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_v1.1-candidates.md
@@ -1,0 +1,326 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T15:50:41.251Z
+Samples: 116 · metadata: 908/1624 (55.9%) · impacts: 563/1160 (48.5%) · by_stage: 2280/19720 (11.6%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | na | 9 | 10/14 | 7/10 | 12/170 | 688.8 | 1.15e-6 | 2.49 | 0.67374 | 25.88 | 116 | · | · | 11.6 |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | na | 9 | 10/14 | 6/10 | 9/170 | 692.65 | · | 0.15 | 0.5700000000000001 | 25.89 | 318 | · | · | 53.44 |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | na | 18 | 8/14 | 8/10 | 1/170 | 2.44 | 9.09e-5 | 4.30e-3 | 4.82e-4 | 0.038 | · | 0.0126 | 41.8 | 2.84 |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 264.52 | 1.17e-5 | 1.64 | 0.6 | 40.54 | 496.73 | 1.58 | 4146.4 | 3681.7 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 283.3 | 9.84e-6 | 29.34 | 1.49 | 0.52 | 666.43 | 1.41 | 4514.47 | 3712.72 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 333.48 | 2.76e-5 | 1.69 | 0.9 | 32.54 | 627.15 | 2.6 | 600.01 | 2008.65 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 323.38 | 1.44e-5 | 1.57 | 0.62 | 42.86 | 699.46 | 2.83 | 921.15 | 5544.68 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | na | 26 | 12/14 | 10/10 | 102/170 | 487.03 | 1.21e-5 | 2.97 | 1.55 | 54.5 | 6479.68 | 2.53 | 72.07 | 43.16 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | na | 27 | 11/14 | 10/10 | 110/170 | 267.01 | 9.40e-6 | 2.23 | 0.32 | 48.77 | 628.16 | 2.37 | 43.89 | 47.96 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | na | 8 | 10/14 | 5/10 | 8/170 | 131.07 | 4.5 | 4.42 | · | · | · | · | 1514.61 | 309.87 |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | na | 15 | 8/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | na | 15 | 8/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | na | 13 | 6/14 | 4/10 | 12/170 | 1097.6 | 7.10e-6 | 0.622 | 0.106 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | na | 15 | 10/14 | 8/10 | 15/170 | 182.61 | 15.190000000000001 | 1.23 | 0.38 | · | 1056.05 | 5.0600000000000005 | 1161.92 | 116.05 |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | na | 20 | 10/14 | 8/10 | 1/170 | 5.85 | 4.46e-8 | 0.0162 | 2.13e-3 | 0.305 | · | 0.0223 | 141 | 2.09 |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | na | 24 | 11/14 | 8/10 | 1/170 | 1.78 | 1.89e-5 | 6.11e-3 | 2.29e-3 | 0.0961 | · | 0.011 | 28.8 | 1.39 |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | na | 18 | 11/14 | 8/10 | 1/170 | 5.34 | 8.46e-8 | 0.0167 | 3.20e-3 | 0.304 | · | 0.0262 | 85.8 | 2.95 |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | na | 20 | 11/14 | 8/10 | 1/170 | 2.51 | 9.47e-6 | 8.49e-3 | 1.53e-3 | 0.147 | · | 9.94e-3 | 45.9 | 1 |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | na | 17 | 8/14 | 8/10 | 1/170 | 0.969 | 2.32e-5 | 3.27e-3 | 2.06e-3 | 0.0433 | · | 0.013 | 2.76 | 1.07 |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | na | 10 | 7/14 | 1/10 | 0/170 | · | · | · | · | · | · | 0.0665 | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | eu_ibu | 7 | 10/14 | 7/10 | 42/170 | 45.59 | 1.05e-6 | 0.109 | · | · | 660.7 | 0.172 | 700.8 | 185.47 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unknown | 45 | 3/14 | 2/10 | 0/170 | · | · | · | · | · | 158 | 4.89 | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | eu_ibu | 11 | 9/14 | 8/10 | 48/170 | 40.7 | 2.06e+6 | · | 104 | · | 284 | 11.4 | 288 | 17 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | unknown | 12 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | · | 1.06 | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | unknown | 12 | 4/14 | 7/10 | 42/170 | 100 | 7.00e-6 | 0.7 | · | · | 747 | 8 | 3900 | 77000 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | na | 14 | 10/14 | 8/10 | 20/170 | 141 | 9.69e-7 | 0.424 | 0.0294 | 5.68 | · | 0.745 | 1770 | 296 |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unknown | 12 | 2/14 | 6/10 | 10/170 | -30.9 | 5.41e-7 | · | 3.28e-3 | · | · | 0.0279 | 850 | 7600 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unknown | 10 | 3/14 | 7/10 | 10/170 | -0.22 | 2.41e-7 | · | 0.0179 | · | · | 0.0161 | 890 | 110 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | eu_ibu | 12 | 11/14 | 6/10 | 30/170 | 0.433 | 3.01e-9 | 8.27e-4 | 1.46e-4 | · | 4.3 | 0.0253 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | na | 19 | 11/14 | 8/10 | 0/170 | 6.05 | 6.79e-7 | 0.0396 | 7.26e-3 | 0.288 | 21.6 | 0.0404 | · | 4.36 |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unknown | 8 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | eu_ibu | 11 | 7/14 | 7/10 | 42/170 | -13 | 9.53e-7 | 0.0504 | · | · | 203 | 0.194 | 209 | 31800 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | eu_ibu | 7 | 7/14 | 7/10 | 56/170 | -2.74 | 4.57e-12 | 4.84e-3 | · | · | 35.68 | 0.013 | 36.82 | 59.21 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | eu_ibu | 19 | 4/14 | 3/10 | 0/170 | · | 0.00e+0 | 0.00e+0 | · | · | 0.00e+0 | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unknown | 23 | 2/14 | 4/10 | 0/170 | -730 | 1.23e-5 | · | 0.804 | · | · | 73.8 | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | eu_ibu | 18 | 10/14 | 7/10 | 63/170 | 96.3 | 1.38e-5 | · | · | · | 1600 | 1.09 | 1610 | 101 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | epd_international | 22 | 8/14 | 4/10 | 0/170 | 0.737 | · | · | · | · | 6.01 | · | 7.95 | 9.12 |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | na | 19 | 10/14 | 9/10 | 0/170 | 225 | 4.14e-7 | 0.682 | 0.0593 | 9.37 | 1.02e-3 | 0.692 | 5140 | 558 |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unknown | 20 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | na | 9 | 7/14 | 7/10 | 20/170 | -1010 | · | 0.23 | 0.746 | · | 1110 | 0.413 | 1440 | 305 |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | eu_ibu | 18 | 10/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | epd_international | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | · | 7.31 | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | na | 4 | 7/14 | 1/10 | 0/170 | · | · | · | · | · | · | 8.05e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | unknown | 14 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | 44.2 | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | eu_ibu | 11 | 9/14 | 6/10 | 42/170 | -253 | 1.76e-6 | 0.412 | · | · | 1100 | · | 2160 | 3990 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | eu_ibu | 8 | 7/14 | 7/10 | 49/170 | 1.11 | 2.34e-13 | · | · | · | 31.3 | 8.40e-3 | 31.3 | 3.18 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | eu_ibu | 11 | 7/14 | 6/10 | 24/170 | 0.469 | 1.33e-11 | 1.54e-3 | · | · | 11.6 | 5.82e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | eu_ibu | 11 | 7/14 | 6/10 | 24/170 | 0.737 | 1.33e-11 | 2.50e-3 | · | · | 18.5 | 8.70e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | eu_ibu | 11 | 7/14 | 6/10 | 24/170 | 0.569 | 1.33e-11 | 2.00e-3 | · | · | 14.1 | 6.45e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | eu_ibu | 8 | 7/14 | 6/10 | 24/170 | 0.534 | 1.49e-11 | 1.47e-3 | · | · | 12.5 | 3.46e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | eu_ibu | 10 | 10/14 | 6/10 | 24/170 | 0.281 | 4.18e-12 | 1.08e-3 | · | · | 6.99 | 3.96e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | eu_ibu | 10 | 10/14 | 6/10 | 24/170 | 0.331 | 4.18e-12 | 1.28e-3 | · | · | 8.28 | 4.16e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | eu_ibu | 10 | 10/14 | 6/10 | 24/170 | 0.385 | 4.32e-12 | 1.49e-3 | · | · | 9.67 | 4.38e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | eu_ibu | 16 | 5/14 | 2/10 | 6/170 | 0.621 | · | · | · | · | · | 0.01658226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | eu_ibu | 16 | 4/14 | 2/10 | 6/170 | 0.543 | · | · | · | · | · | 0.01350226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | eu_ibu | 18 | 7/14 | 7/10 | 66/170 | 0.5285 | 3.54e-8 | · | 3.59e-4 | · | · | 7.23e-3 | 13.145 | 0.6950700000000001 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | eu_ibu | 17 | 5/14 | 7/10 | 66/170 | 0.41459999999999997 | 2.39e-8 | · | 2.93e-4 | · | · | 9.24e-3 | 10.540000000000001 | 0.59316 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | epd_international | 16 | 9/14 | 5/10 | 0/170 | 0.707 | 6.43e-8 | · | 7.29e-4 | · | 11.9 | 0.199 | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | eu_ibu | 10 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | nsf | 25 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | nsf | 30 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | na | 55 | 7/14 | 8/10 | 54/170 | 8.23e-3 | 2.65e-15 | · | 1.49e-4 | · | 10.29821 | 0.0388 | 10.298509999999998 | 0.8022100000000001 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | na | 13 | 9/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | na | 14 | 9/14 | 3/10 | 9/170 | 443.8 | · | 2.199 | 0.1674 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | eu_ibu | 6 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | na | 9 | 8/14 | 5/10 | 2/170 | 0.3 | · | · | 2.43e-4 | · | 8.61 | 2.88e-5 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | eu_ibu | 11 | 10/14 | 8/10 | 18/170 | 0.00e+0 | 1.35e+7 | 110 | 1120 | · | 0.00e+0 | 0.00e+0 | 0.00e+0 | 0.00e+0 |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | unknown | 27 | 3/14 | 4/10 | 40/170 | 7.8100000000000005 | · | · | · | 0.02286 | · | 0.027100000000000003 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | na | 17 | 8/14 | 7/10 | 12/170 | 6.7 | 1.16e-6 | 0.028359999999999996 | 9.81e-3 | 0.0898 | · | · | 72 | 1 |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | eu_ibu | 18 | 10/14 | 7/10 | 63/170 | 80 | 1.34e-5 | · | · | · | 1380 | 0.998 | 1380 | 81.2 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | na | 16 | 8/14 | 7/10 | 8/170 | 5.1 | 1.20e-7 | 0.029 | 4.00e-3 | 0.3 | · | · | 145.6 | 0.06 |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unknown | 19 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | na | 19 | 10/14 | 7/10 | 6/170 | 282 | 4.35e-7 | 0.996 | 0.0807 | 15.9 | 819 | 0.76 | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unknown | 20 | 3/14 | 2/10 | 8/170 | · | · | · | · | 0.0169 | · | 0.0213 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | eu_ibu | 10 | 7/14 | 6/10 | 24/170 | 0.535 | 9.04e-12 | 1.77e-3 | · | · | 13.4 | 6.86e-3 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | eu_ibu | 15 | 10/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | na | 17 | 10/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | na | 18 | 10/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | unknown | 32 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | unknown | 18 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | na | 27 | 11/14 | 5/10 | 0/170 | 3.51 | 4.49e-6 | · | 0.0996 | · | · | 3.64 | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | na | 19 | 10/14 | 9/10 | 0/170 | 280 | 5.37e-7 | 0.848 | 0.0765 | 11.7 | 5970 | 0.775 | 5920 | 531 |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | na | 19 | 10/14 | 5/10 | 20/170 | 7.24 | · | 0.0226 | 2.56e-3 | · | 12.5 | 3.14e-4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | na | 20 | 9/14 | 9/10 | 0/170 | 1.2 | 9.57e-15 | 2.04e-3 | 1.97e-4 | 0.0377 | 2.16 | 4.21e-3 | 20 | 1.47 |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | eu_ibu | 8 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | eu_ibu | 8 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | epd_international | 21 | 10/14 | 6/10 | 21/170 | 0.373 | · | 1.15e-3 | 1.76e-4 | · | 3.68 | 1.61e-4 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | na | 21 | 10/14 | 3/10 | 0/170 | · | · | · | · | · | · | 3 | 1 | 0.00e+0 |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unknown | 8 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | na | 18 | 10/14 | 9/10 | 24/170 | 343 | 7.03e-7 | 1.02 | 0.0959 | 14.5 | 987 | 0.0467 | 7300 | 519 |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | na | 15 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | na | 17 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | na | 17 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | na | 17 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | na | 31 | 10/14 | 9/10 | 48/170 | 5.44 | 5.27e-7 | 0.0253 | 0.028 | 0.255 | 8.94 | 0.0371 | 71 | 1.54 |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 13.7 | 4.56e-14 | 0.0172 | 3.20e-3 | 0.437 | 228 | 6460 | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | na | 15 | 9/14 | 7/10 | 0/170 | 9.32 | 4.41e-14 | 0.0111 | 2.11e-3 | 0.272 | 198 | 5920 | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | na | 47 | 10/14 | 7/10 | 44/170 | 0.4506 | 4.51e-14 | · | 3.67e-4 | · | · | 0.113 | 290.98 | 42.629999999999995 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | unknown | 10 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | na | 15 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | na | 18 | 10/14 | 9/10 | 6/170 | 299 | 5.76e-7 | 0.917 | 0.0842 | 12.4 | 906 | 1.01 | 6680 | 738 |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | na | 15 | 10/14 | 8/10 | 15/170 | 150.16 | 13.969999999999999 | 0.98 | 0.24 | · | 904.68 | 5.109999999999999 | 997.74 | 79.99 |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | na | 15 | 10/14 | 8/10 | 6/170 | 453 | · | 1.25 | 0.141 | 17.4 | 1330 | 2.39 | 9910 | 1180 |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | na | 16 | 12/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | eu_ibu | 10 | 10/14 | 7/10 | 98/170 | 11.324 | 6.59e-7 | 0.03444 | · | · | 112.57 | 0.011706999999999999 | 139.08 | 26.262999999999998 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | eu_ibu | 12 | 4/14 | 4/10 | 0/170 | -1.48e-3 | 7.81e-9 | · | 2.46e-4 | · | · | 0.289 | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | eu_ibu | 9 | 12/14 | 6/10 | 37/170 | 1.0950000000196 | 1.01e-66 | 6.20e-21 | · | · | 41.9 | 0.21474 | · | 0.6157 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | eu_ibu | 10 | 10/14 | 6/10 | 37/170 | 7.500000000019801 | 3.90e-71 | 3.09e-26 | · | · | 77.9 | 0.10596 | · | 0.905 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | 3 | · | · | · | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 3 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | 3 | · | · | 3 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | · | 8 | 8 | · | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | 5 | · | 5 | 5 | 5 | · | 5 | 5 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | 8 | · | 8 | 8 | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | 4 | · | · | 4 | 4 | · | 4 | · | 4 | · |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | 7 | 7 | 7 | · | · | · | 7 | 7 | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | 7 | 7 | 10 | · | · | · | 10 | · | 10 | 10 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | · | · | · | 1 | · | · | · | 1 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | 10 | 10 | · | · | · | 10 | · | 10 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | · | · | · | · | · | 4 | · | 4 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | 4 | · | · | 4 | 4 | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | 1 | · | · | 10 | · | · | · | 10 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | 6 | · | 6 | 6 | 6 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | 7 | · | 7 | 7 | 7 | 7 | 7 | 6 | · | · |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | 7 | 7 | 10 | · | · | · | · | · | 10 | 10 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | 14 | · | 14 | 14 | · | · | 14 | 14 | 14 | 14 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 38/116 | 33% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 11/116 | 9% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 35/116 | 30% |  |
+| 3 | `acidification_kgso2eq` — AP | 28/116 | 24% |  |
+| 4 | `eutrophication_kgneq` — EP | 39/116 | 34% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 26/116 | 22% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 42/116 | 36% |  |
+| 7 | `water_consumption_m3` — WDP | 7/116 | 6% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 11/116 | 9% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 11/116 | 9% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 3/116 | 3% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 0/116 | 0% | DEAD |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 0/116 | 0% | DEAD |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 17/116 | 15% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 1/116 | 1% | thin |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 0/116 | 0% | DEAD |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 2/116 | 2% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 0/116 | 0% | DEAD |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 0/116 | 0% | DEAD |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 0/116 | 0% | DEAD |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 0/116 | 0% | DEAD |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 0/116 | 0% | DEAD |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 29/116 | 25% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 26/116 | 22% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 24/116 | 21% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 14/116 | 12% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 24/116 | 21% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 26/116 | 22% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 24/116 | 21% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 51/116 | 44% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 87/116 | 75% |  |
+| 1 | `gwp_bio_kgco2e` | 16/116 | 14% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 64/116 | 55% |  |
+| 3 | `acidification_kgso2eq` | 84/116 | 72% |  |
+| 4 | `eutrophication_kgneq` | 74/116 | 64% |  |
+| 5 | `smog_kgo3eq` | 43/116 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 46/116 | 40% |  |
+| 7 | `water_consumption_m3` | 52/116 | 45% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 7/116 | 6% |  |
+| 9 | `primary_energy_renewable_mj` | 8/116 | 7% |  |
+| 10 | `gwp_kgco2e` | 21/116 | 18% |  |
+| 11 | `gwp_bio_kgco2e` | 8/116 | 7% |  |
+| 12 | `acidification_kgso2eq` | 14/116 | 12% |  |
+| 13 | `eutrophication_kgneq` | 4/116 | 3% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 22/116 | 19% |  |
+| 15 | `smog_kgo3eq` | 4/116 | 3% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 18/116 | 16% |  |
+| 17 | `water_consumption_m3` | 16/116 | 14% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 20/116 | 17% |  |
+| 19 | `primary_energy_renewable_mj` | 20/116 | 17% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 5/116 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 7/116 | 6% |  |
+| 2 | `acidification_kgso2eq` | 0/116 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/116 | 7% |  |
+| 4 | `smog_kgo3eq` | 0/116 | 0% | DEAD |
+| 5 | `abiotic_depletion_fossil_mj` | 0/116 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/116 | 1% | thin |

--- a/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-dates.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-dates.md
@@ -1,0 +1,788 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:49:38.122Z
+Samples: 116 · metadata: 1019/1624 (62.7%) · impacts: 563/1160 (48.5%) · by_stage: 2280/19720 (11.6%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | na | 9 | 11/14 | 7/10 | 12/170 | 688.8 | 1.15e-6 | 2.49 | 0.67374 | 25.88 | 116 | · | · | 11.6 |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | na | 9 | 11/14 | 6/10 | 9/170 | 692.65 | · | 0.15 | 0.5700000000000001 | 25.89 | 318 | · | · | 53.44 |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | na | 18 | 10/14 | 8/10 | 1/170 | 2.44 | 9.09e-5 | 4.30e-3 | 4.82e-4 | 0.038 | · | 0.0126 | 41.8 | 2.84 |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 264.52 | 1.17e-5 | 1.64 | 0.6 | 40.54 | 496.73 | 1.58 | 4146.4 | 3681.7 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 283.3 | 9.84e-6 | 29.34 | 1.49 | 0.52 | 666.43 | 1.41 | 4514.47 | 3712.72 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 333.48 | 2.76e-5 | 1.69 | 0.9 | 32.54 | 627.15 | 2.6 | 600.01 | 2008.65 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 323.38 | 1.44e-5 | 1.57 | 0.62 | 42.86 | 699.46 | 2.83 | 921.15 | 5544.68 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | na | 26 | 13/14 | 10/10 | 102/170 | 487.03 | 1.21e-5 | 2.97 | 1.55 | 54.5 | 6479.68 | 2.53 | 72.07 | 43.16 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | na | 27 | 11/14 | 10/10 | 110/170 | 267.01 | 9.40e-6 | 2.23 | 0.32 | 48.77 | 628.16 | 2.37 | 43.89 | 47.96 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | na | 8 | 13/14 | 5/10 | 8/170 | 131.07 | 4.5 | 4.42 | · | · | · | · | 1514.61 | 309.87 |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | na | 15 | 10/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | na | 15 | 10/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | na | 13 | 6/14 | 4/10 | 12/170 | 1097.6 | 7.10e-6 | 0.622 | 0.106 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | na | 15 | 12/14 | 8/10 | 15/170 | 182.61 | 15.190000000000001 | 1.23 | 0.38 | · | 1056.05 | 5.0600000000000005 | 1161.92 | 116.05 |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | na | 20 | 12/14 | 8/10 | 1/170 | 5.85 | 4.46e-8 | 0.0162 | 2.13e-3 | 0.305 | · | 0.0223 | 141 | 2.09 |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | na | 24 | 13/14 | 8/10 | 1/170 | 1.78 | 1.89e-5 | 6.11e-3 | 2.29e-3 | 0.0961 | · | 0.011 | 28.8 | 1.39 |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | na | 18 | 13/14 | 8/10 | 1/170 | 5.34 | 8.46e-8 | 0.0167 | 3.20e-3 | 0.304 | · | 0.0262 | 85.8 | 2.95 |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | na | 20 | 13/14 | 8/10 | 1/170 | 2.51 | 9.47e-6 | 8.49e-3 | 1.53e-3 | 0.147 | · | 9.94e-3 | 45.9 | 1 |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | na | 17 | 10/14 | 8/10 | 1/170 | 0.969 | 2.32e-5 | 3.27e-3 | 2.06e-3 | 0.0433 | · | 0.013 | 2.76 | 1.07 |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | na | 10 | 8/14 | 1/10 | 0/170 | · | · | · | · | · | · | 0.0665 | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | eu_ibu | 7 | 12/14 | 7/10 | 42/170 | 45.59 | 1.05e-6 | 0.109 | · | · | 660.7 | 0.172 | 700.8 | 185.47 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unknown | 45 | 3/14 | 2/10 | 0/170 | · | · | · | · | · | 158 | 4.89 | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | eu_ibu | 11 | 11/14 | 8/10 | 48/170 | 40.7 | 2.06e+6 | · | 104 | · | 284 | 11.4 | 288 | 17 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | unknown | 12 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | · | 1.06 | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | unknown | 12 | 4/14 | 7/10 | 42/170 | 100 | 7.00e-6 | 0.7 | · | · | 747 | 8 | 3900 | 77000 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | na | 14 | 12/14 | 8/10 | 20/170 | 141 | 9.69e-7 | 0.424 | 0.0294 | 5.68 | · | 0.745 | 1770 | 296 |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unknown | 12 | 2/14 | 6/10 | 10/170 | -30.9 | 5.41e-7 | · | 3.28e-3 | · | · | 0.0279 | 850 | 7600 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unknown | 10 | 3/14 | 7/10 | 10/170 | -0.22 | 2.41e-7 | · | 0.0179 | · | · | 0.0161 | 890 | 110 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | eu_ibu | 12 | 13/14 | 6/10 | 30/170 | 0.433 | 3.01e-9 | 8.27e-4 | 1.46e-4 | · | 4.3 | 0.0253 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | na | 19 | 11/14 | 8/10 | 0/170 | 6.05 | 6.79e-7 | 0.0396 | 7.26e-3 | 0.288 | 21.6 | 0.0404 | · | 4.36 |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unknown | 8 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | eu_ibu | 11 | 9/14 | 7/10 | 42/170 | -13 | 9.53e-7 | 0.0504 | · | · | 203 | 0.194 | 209 | 31800 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | eu_ibu | 7 | 9/14 | 7/10 | 56/170 | -2.74 | 4.57e-12 | 4.84e-3 | · | · | 35.68 | 0.013 | 36.82 | 59.21 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | eu_ibu | 19 | 4/14 | 3/10 | 0/170 | · | 0.00e+0 | 0.00e+0 | · | · | 0.00e+0 | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unknown | 23 | 2/14 | 4/10 | 0/170 | -730 | 1.23e-5 | · | 0.804 | · | · | 73.8 | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 96.3 | 1.38e-5 | · | · | · | 1600 | 1.09 | 1610 | 101 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | epd_international | 22 | 8/14 | 4/10 | 0/170 | 0.737 | · | · | · | · | 6.01 | · | 7.95 | 9.12 |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 225 | 4.14e-7 | 0.682 | 0.0593 | 9.37 | 1.02e-3 | 0.692 | 5140 | 558 |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unknown | 20 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | na | 9 | 9/14 | 7/10 | 20/170 | -1010 | · | 0.23 | 0.746 | · | 1110 | 0.413 | 1440 | 305 |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | epd_international | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | · | 7.31 | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | na | 4 | 7/14 | 1/10 | 0/170 | · | · | · | · | · | · | 8.05e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | unknown | 14 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | 44.2 | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | eu_ibu | 11 | 11/14 | 6/10 | 42/170 | -253 | 1.76e-6 | 0.412 | · | · | 1100 | · | 2160 | 3990 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | eu_ibu | 8 | 9/14 | 7/10 | 49/170 | 1.11 | 2.34e-13 | · | · | · | 31.3 | 8.40e-3 | 31.3 | 3.18 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.469 | 1.33e-11 | 1.54e-3 | · | · | 11.6 | 5.82e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.737 | 1.33e-11 | 2.50e-3 | · | · | 18.5 | 8.70e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.569 | 1.33e-11 | 2.00e-3 | · | · | 14.1 | 6.45e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | eu_ibu | 8 | 9/14 | 6/10 | 24/170 | 0.534 | 1.49e-11 | 1.47e-3 | · | · | 12.5 | 3.46e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.281 | 4.18e-12 | 1.08e-3 | · | · | 6.99 | 3.96e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.331 | 4.18e-12 | 1.28e-3 | · | · | 8.28 | 4.16e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.385 | 4.32e-12 | 1.49e-3 | · | · | 9.67 | 4.38e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | eu_ibu | 16 | 5/14 | 2/10 | 6/170 | 0.621 | · | · | · | · | · | 0.01658226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | eu_ibu | 16 | 4/14 | 2/10 | 6/170 | 0.543 | · | · | · | · | · | 0.01350226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | eu_ibu | 18 | 7/14 | 7/10 | 66/170 | 0.5285 | 3.54e-8 | · | 3.59e-4 | · | · | 7.23e-3 | 13.145 | 0.6950700000000001 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | eu_ibu | 17 | 5/14 | 7/10 | 66/170 | 0.41459999999999997 | 2.39e-8 | · | 2.93e-4 | · | · | 9.24e-3 | 10.540000000000001 | 0.59316 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | epd_international | 16 | 9/14 | 5/10 | 0/170 | 0.707 | 6.43e-8 | · | 7.29e-4 | · | 11.9 | 0.199 | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | eu_ibu | 10 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | nsf | 25 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | nsf | 30 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | na | 55 | 8/14 | 8/10 | 54/170 | 8.23e-3 | 2.65e-15 | · | 1.49e-4 | · | 10.29821 | 0.0388 | 10.298509999999998 | 0.8022100000000001 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | na | 13 | 11/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | na | 14 | 11/14 | 3/10 | 9/170 | 443.8 | · | 2.199 | 0.1674 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | eu_ibu | 6 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | na | 9 | 9/14 | 5/10 | 2/170 | 0.3 | · | · | 2.43e-4 | · | 8.61 | 2.88e-5 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | eu_ibu | 11 | 12/14 | 8/10 | 18/170 | 0.00e+0 | 1.35e+7 | 110 | 1120 | · | 0.00e+0 | 0.00e+0 | 0.00e+0 | 0.00e+0 |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | unknown | 27 | 3/14 | 4/10 | 40/170 | 7.8100000000000005 | · | · | · | 0.02286 | · | 0.027100000000000003 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | na | 17 | 10/14 | 7/10 | 12/170 | 6.7 | 1.16e-6 | 0.028359999999999996 | 9.81e-3 | 0.0898 | · | · | 72 | 1 |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 80 | 1.34e-5 | · | · | · | 1380 | 0.998 | 1380 | 81.2 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | na | 16 | 10/14 | 7/10 | 8/170 | 5.1 | 1.20e-7 | 0.029 | 4.00e-3 | 0.3 | · | · | 145.6 | 0.06 |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unknown | 19 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | na | 19 | 11/14 | 7/10 | 6/170 | 282 | 4.35e-7 | 0.996 | 0.0807 | 15.9 | 819 | 0.76 | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unknown | 20 | 3/14 | 2/10 | 8/170 | · | · | · | · | 0.0169 | · | 0.0213 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | eu_ibu | 10 | 9/14 | 6/10 | 24/170 | 0.535 | 9.04e-12 | 1.77e-3 | · | · | 13.4 | 6.86e-3 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | eu_ibu | 15 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | unknown | 32 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | unknown | 18 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | na | 27 | 12/14 | 5/10 | 0/170 | 3.51 | 4.49e-6 | · | 0.0996 | · | · | 3.64 | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 280 | 5.37e-7 | 0.848 | 0.0765 | 11.7 | 5970 | 0.775 | 5920 | 531 |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | na | 19 | 11/14 | 5/10 | 20/170 | 7.24 | · | 0.0226 | 2.56e-3 | · | 12.5 | 3.14e-4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | na | 20 | 11/14 | 9/10 | 0/170 | 1.2 | 9.57e-15 | 2.04e-3 | 1.97e-4 | 0.0377 | 2.16 | 4.21e-3 | 20 | 1.47 |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | eu_ibu | 8 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | eu_ibu | 8 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | epd_international | 21 | 10/14 | 6/10 | 21/170 | 0.373 | · | 1.15e-3 | 1.76e-4 | · | 3.68 | 1.61e-4 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | na | 21 | 12/14 | 3/10 | 0/170 | · | · | · | · | · | · | 3 | 1 | 0.00e+0 |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unknown | 8 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | na | 18 | 11/14 | 9/10 | 24/170 | 343 | 7.03e-7 | 1.02 | 0.0959 | 14.5 | 987 | 0.0467 | 7300 | 519 |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | na | 15 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | na | 17 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | na | 17 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | na | 17 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | na | 31 | 12/14 | 9/10 | 48/170 | 5.44 | 5.27e-7 | 0.0253 | 0.028 | 0.255 | 8.94 | 0.0371 | 71 | 1.54 |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 13.7 | 4.56e-14 | 0.0172 | 3.20e-3 | 0.437 | 228 | 6460 | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 9.32 | 4.41e-14 | 0.0111 | 2.11e-3 | 0.272 | 198 | 5920 | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | na | 47 | 11/14 | 7/10 | 44/170 | 0.4506 | 4.51e-14 | · | 3.67e-4 | · | · | 0.113 | 290.98 | 42.629999999999995 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | unknown | 10 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | na | 15 | 8/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | na | 18 | 11/14 | 9/10 | 6/170 | 299 | 5.76e-7 | 0.917 | 0.0842 | 12.4 | 906 | 1.01 | 6680 | 738 |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | na | 15 | 12/14 | 8/10 | 15/170 | 150.16 | 13.969999999999999 | 0.98 | 0.24 | · | 904.68 | 5.109999999999999 | 997.74 | 79.99 |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | na | 15 | 11/14 | 8/10 | 6/170 | 453 | · | 1.25 | 0.141 | 17.4 | 1330 | 2.39 | 9910 | 1180 |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | na | 16 | 12/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 98/170 | 11.324 | 6.59e-7 | 0.03444 | · | · | 112.57 | 0.011706999999999999 | 139.08 | 26.262999999999998 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | eu_ibu | 12 | 4/14 | 4/10 | 0/170 | -1.48e-3 | 7.81e-9 | · | 2.46e-4 | · | · | 0.289 | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | eu_ibu | 9 | 12/14 | 6/10 | 37/170 | 1.0950000000196 | 1.01e-66 | 6.20e-21 | · | · | 41.9 | 0.21474 | · | 0.6157 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | eu_ibu | 10 | 12/14 | 6/10 | 37/170 | 7.500000000019801 | 3.90e-71 | 3.09e-26 | · | · | 77.9 | 0.10596 | · | 0.905 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | 3 | · | · | · | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 3 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | 3 | · | · | 3 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | · | 8 | 8 | · | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | 5 | · | 5 | 5 | 5 | · | 5 | 5 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | 8 | · | 8 | 8 | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | 4 | · | · | 4 | 4 | · | 4 | · | 4 | · |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | 7 | 7 | 7 | · | · | · | 7 | 7 | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | 7 | 7 | 10 | · | · | · | 10 | · | 10 | 10 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | · | · | · | 1 | · | · | · | 1 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | 10 | 10 | · | · | · | 10 | · | 10 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | · | · | · | · | · | 4 | · | 4 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | 4 | · | · | 4 | 4 | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | 1 | · | · | 10 | · | · | · | 10 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | 6 | · | 6 | 6 | 6 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | 7 | · | 7 | 7 | 7 | 7 | 7 | 6 | · | · |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | 7 | 7 | 10 | · | · | · | · | · | 10 | 10 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | 14 | · | 14 | 14 | · | · | 14 | 14 | 14 | 14 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 38/116 | 33% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 11/116 | 9% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 35/116 | 30% |  |
+| 3 | `acidification_kgso2eq` — AP | 28/116 | 24% |  |
+| 4 | `eutrophication_kgneq` — EP | 39/116 | 34% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 26/116 | 22% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 42/116 | 36% |  |
+| 7 | `water_consumption_m3` — WDP | 7/116 | 6% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 11/116 | 9% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 11/116 | 9% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 3/116 | 3% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 0/116 | 0% | DEAD |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 0/116 | 0% | DEAD |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 17/116 | 15% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 1/116 | 1% | thin |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 0/116 | 0% | DEAD |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 2/116 | 2% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 0/116 | 0% | DEAD |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 0/116 | 0% | DEAD |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 0/116 | 0% | DEAD |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 0/116 | 0% | DEAD |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 0/116 | 0% | DEAD |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 29/116 | 25% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 26/116 | 22% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 24/116 | 21% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 14/116 | 12% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 24/116 | 21% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 26/116 | 22% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 24/116 | 21% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 51/116 | 44% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 87/116 | 75% |  |
+| 1 | `gwp_bio_kgco2e` | 16/116 | 14% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 64/116 | 55% |  |
+| 3 | `acidification_kgso2eq` | 84/116 | 72% |  |
+| 4 | `eutrophication_kgneq` | 74/116 | 64% |  |
+| 5 | `smog_kgo3eq` | 43/116 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 46/116 | 40% |  |
+| 7 | `water_consumption_m3` | 52/116 | 45% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 7/116 | 6% |  |
+| 9 | `primary_energy_renewable_mj` | 8/116 | 7% |  |
+| 10 | `gwp_kgco2e` | 21/116 | 18% |  |
+| 11 | `gwp_bio_kgco2e` | 8/116 | 7% |  |
+| 12 | `acidification_kgso2eq` | 14/116 | 12% |  |
+| 13 | `eutrophication_kgneq` | 4/116 | 3% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 22/116 | 19% |  |
+| 15 | `smog_kgo3eq` | 4/116 | 3% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 18/116 | 16% |  |
+| 17 | `water_consumption_m3` | 16/116 | 14% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 20/116 | 17% |  |
+| 19 | `primary_energy_renewable_mj` | 20/116 | 17% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 5/116 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 7/116 | 6% |  |
+| 2 | `acidification_kgso2eq` | 0/116 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/116 | 7% |  |
+| 4 | `smog_kgo3eq` | 0/116 | 0% | DEAD |
+| 5 | `abiotic_depletion_fossil_mj` | 0/116 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/116 | 1% | thin |
+
+## Catalogue parity check
+
+116 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 22/116 | 19% |
+| strong-multi | 12/116 | 10% |
+| medium | 10/116 | 9% |
+| medium-multi | 18/116 | 16% |
+| weak | 33/116 | 28% |
+| unmatched | 21/116 | 18% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 56 | 21 | 18 | 0 | 59% |
+| `classification.material_type` | 31 | 31 | 29 | 4 | 34% |
+| `manufacturer.name` | 28 | 37 | 28 | 2 | 30% |
+| `physical.density.value_kg_m3` | 4 | 42 | 45 | 4 | 4% |
+| `epd.id` | 43 | 26 | 24 | 2 | 46% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | weak | 40 | `bbb021` | Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm | disp(3/3) |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | strong | 90 | `osb003` | OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16" | epd.id, group |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | strong | 90 | `osb007` | OSB subflooring / LP / LP Legacy® Premium / 5/8" | epd.id, group |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | strong | 90 | `osb002` | OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side | epd.id, group |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | strong-multi | 90 | `osb004` (+1 more) | OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2" | epd.id, group |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | strong | 95 | `lp0001` | Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm) | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | strong | 120 | `lp0000` | Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm) | epd.id, disp(1/1) |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | medium | 55 | `www118` | Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | weak | 40 | `s12345` | Ground screw / American Ground Screw / AGS IM3316 / 76 x 1600 mm | mfr |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | medium-multi | 55 | `www119` (+1 more) | Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | medium-multi | 50 | `bbb012` (+4 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, group |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | strong-multi | 80 | `bbb012` (+1 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, disp(2/2) |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | medium-multi | 75 | `ccf00x` (+1 more) | Cementitious Foam / R 3.5-inch [BEAM Avg] | epd.id |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | medium | 75 | `vrs000` | Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes | epd.id |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | strong | 115 | `stu000` | Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | strong | 115 | `vin002` | Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] / R-0.5 | epd.id, mfr |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | weak | 40 | `cbi000` | Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU] | mfr |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | strong | 120 | `ae7e1c` | Cork flooring / European Resilient Flooring Manufacturers' Institute [Industry Avg \| EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | medium | 75 | `www121` | Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | strong-multi | 80 | `lcp001` (+2 more) | Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU] | epd.id |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | strong | 90 | `rrr114` | Asphalt Shingles / Malarkey Roofing / Dura-Seal / | epd.id, group |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | strong | 160 | `cel000` | Cellulose / batt / Ekovilla / Ekovilla Slab / R3.7-inch [EU] | epd.id, mfr, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | medium | 60 | `bbb031` | Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | weak | 40 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | strong | 115 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | strong | 90 | `bbb025` | Int. Wall barrier, sheet / Isover / Vario KM Duplex / Moisture-variable / EU | epd.id, group |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | strong | 80 | `bbb026` | Int. Wall barrier, sheet / Isover / Vario XTRA / Moisture-variable / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | strong-multi | 107 | `ins022` (+2 more) | Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU] | epd.id, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | weak | 30 | `676103` | EPDM Roofing Membrane / Non-reinforced single ply / SPRI  [Industry Avg \| US] | disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | strong-multi | 80 | `bbb000` (+4 more) | Int. Wall & Ceiling Barrier, sheet / Rothoblaas / Vapor In Green 200 / Non-permeable / 0.35 mm / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | strong | 95 | `www116` | Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL\|TLF, 526, AA 6400\|6500, NX-300\|3000 / Projected & casement | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | strong-multi | 115 | `s12347` (+1 more) | Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | weak | 40 | `int007` | MgO board 1/2" / Sinh Build / MAGOXX boards / 1/2" [EU] | disp(2/2) |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | medium-multi | 50 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, group |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | medium | 75 | `www114` | Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | medium-multi | 70 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, disp(2/4), group |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | strong-multi | 90 | `rrr112` (+1 more) | Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | strong-multi | 115 | `ins013` (+2 more) | Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | strong | 90 | `rrr115` | Asphalt Shingles / Malarkey Roofing / Highlander NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | strong | 120 | `lvt012` | Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm | epd.id, disp(3/4), group |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | strong | 90 | `rrr116` | Asphalt Shingles / Malarkey Roofing / Legacy / | epd.id, group |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | strong | 120 | `ins004` | Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg \| N.America] | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | strong | 90 | `rrr117` | Asphalt Shingles / Malarkey Roofing / Vista / | epd.id, group |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | strong | 90 | `rrr118` | Asphalt Shingles / Malarkey Roofing / Windsor / | epd.id, group |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | strong | 120 | `8b5828` | Window - frame only / AluQuébec / Aluminum frame / Canada | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | weak | 40 | `bbb032` | Int. Wall & Ceiling Barrier, sheet / Synwer / Syn U 120 Sd 2 / Moisture-variable / EU | mfr |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | medium | 75 | `fib001` | Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU] | epd.id |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | unmatched | 0 | — | — | — |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-539 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-540 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf** (top: `bbb021` — Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm):
+- `manufacturer.name` — candidate `"the facility located in Michigan"` vs catalogue `"Soprema"`
+
+**EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf** (top: `osb003` — OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf** (top: `osb007` — OSB subflooring / LP / LP Legacy® Premium / 5/8"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf** (top: `osb002` — OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `678.28`
+
+**EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf** (top: `osb004` — OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf** (top: `lp0001` — Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm)):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered Wood siding"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf** (top: `lp0000` — Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm)):
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf** (top: `www118` — Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf** (top: `www119` — Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf** (top: `bbb012` — Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Barrier"`
+
+**EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"National Gypsum"`
+
+**EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"several defined by the functional"` vs catalogue `"CMS"`
+
+**EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf** (top: `ccf00x` — Cementitious Foam / R 3.5-inch [BEAM Avg]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"03"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Cementitious foam"`
+- `physical.density.value_kg_m3` — candidate `70` vs catalogue `80`
+
+**EPDs to consider for v1.1 update/Airkrete spray EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"Holcim"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `130` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf** (top: `vrs000` — Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"PU Foam"`
+- `manufacturer.name` — candidate `"the facility and no allocation"` vs catalogue `"Branch"`
+- `physical.density.value_kg_m3` — candidate `214.5` vs catalogue `32.6`
+
+**EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf** (top: `stu000` — Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Cement stucco"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `1600`
+
+**EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf** (top: `vin002` — Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg | US & CA] / R-0.5):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Vinyl"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `2.53`
+
+**EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf** (top: `cbi000` — Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU]):
+- `epd.id` — candidate `"EPD-AMO-20210078-ICA1-EN"` vs catalogue `"EPD HUB-0281"`
+
+**EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf** (top: `www121` — Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Triple pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf** (top: `lcp001` — Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU]):
+- `manufacturer.name` — candidate `"TDS"` vs catalogue `"Diasen"`
+
+**EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf** (top: `rrr114` — Asphalt Shingles / Malarkey Roofing / Dura-Seal /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-DE"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf** (top: `bbb031` — Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU):
+- `epd.id` — candidate `"EPD-SIG-20220186-CBA1-EN"` vs catalogue `"EPD-SIG-20220185-CBA1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210188-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210187-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210186-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `epd.id` — candidate `"EPD-DUP-20220250-CBA1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"HDPE"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `0.058`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210189-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210184-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf** (top: `ins022` — Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU]):
+- `manufacturer.name` — candidate `"Eden Renewable Innovations Limited"` vs catalogue `"Thermafleece"`
+
+**EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"IBU"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf** (top: `www116` — Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL|TLF, 526, AA 6400|6500, NX-300|3000 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Building Product Design Ltd"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf** (top: `s12347` — Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"31"`
+- `classification.material_type` — candidate `"Steel"` vs catalogue `"Ground screw"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `5.5`
+
+**EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-075 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf** (top: `www114` — Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-074 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf** (top: `rrr112` — Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210185-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf** (top: `ins013` — Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Hemp"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `230`
+
+**EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf** (top: `rrr115` — Asphalt Shingles / Malarkey Roofing / Highlander NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790545973.103.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"the United States and Canada."` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/LECA EPD 4.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `epd.id` — candidate `"S-P-04459"` vs catalogue `"EPD10792"`
+
+**EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf** (top: `lvt012` — Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"Co., Ltd"` vs catalogue `"Jiangsu Fuhua"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `7094.7`
+
+**EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf** (top: `rrr116` — Asphalt Shingles / Malarkey Roofing / Legacy /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf** (top: `ins004` — Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg | N.America]):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `57.6`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788986648.101.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.144.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.142.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"2021M10140 Registration Number EPDITALY0140"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"nor LCA practitioner."` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `280` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Vista asphalt shingles.pdf** (top: `rrr117` — Asphalt Shingles / Malarkey Roofing / Vista /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Wausau Window and Wall Systems, a part of Apogee"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"499"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf** (top: `rrr118` — Asphalt Shingles / Malarkey Roofing / Windsor /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Eternit GmbH"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"EPD-ELH-20180136-CAC1-EN"` vs catalogue `"EPD 034"`
+
+**EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf** (top: `fib001` — Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Fiber cement"`
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Equitone"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `1850`
+
+**EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-ETE-20190007-ICA1-EN"` vs catalogue `"4789365778.101.1"`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-density.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-density.md
@@ -1,0 +1,794 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T17:06:07.075Z
+Samples: 116 · metadata: 1053/1624 (64.8%) · impacts: 563/1160 (48.5%) · by_stage: 2280/19720 (11.6%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | na | 9 | 13/14 | 7/10 | 12/170 | 688.8 | 1.15e-6 | 2.49 | 0.67374 | 25.88 | 116 | · | · | 11.6 |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | na | 9 | 13/14 | 6/10 | 9/170 | 692.65 | · | 0.15 | 0.5700000000000001 | 25.89 | 318 | · | · | 53.44 |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | na | 18 | 12/14 | 8/10 | 1/170 | 2.44 | 9.09e-5 | 4.30e-3 | 4.82e-4 | 0.038 | · | 0.0126 | 41.8 | 2.84 |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 264.52 | 1.17e-5 | 1.64 | 0.6 | 40.54 | 496.73 | 1.58 | 4146.4 | 3681.7 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 283.3 | 9.84e-6 | 29.34 | 1.49 | 0.52 | 666.43 | 1.41 | 4514.47 | 3712.72 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 333.48 | 2.76e-5 | 1.69 | 0.9 | 32.54 | 627.15 | 2.6 | 600.01 | 2008.65 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 323.38 | 1.44e-5 | 1.57 | 0.62 | 42.86 | 699.46 | 2.83 | 921.15 | 5544.68 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | na | 26 | 13/14 | 10/10 | 102/170 | 487.03 | 1.21e-5 | 2.97 | 1.55 | 54.5 | 6479.68 | 2.53 | 72.07 | 43.16 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | na | 27 | 11/14 | 10/10 | 110/170 | 267.01 | 9.40e-6 | 2.23 | 0.32 | 48.77 | 628.16 | 2.37 | 43.89 | 47.96 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | na | 8 | 13/14 | 5/10 | 8/170 | 131.07 | 4.5 | 4.42 | · | · | · | · | 1514.61 | 309.87 |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | na | 15 | 11/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | na | 15 | 11/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | na | 13 | 7/14 | 4/10 | 12/170 | 1097.6 | 7.10e-6 | 0.622 | 0.106 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | na | 15 | 13/14 | 8/10 | 15/170 | 182.61 | 15.190000000000001 | 1.23 | 0.38 | · | 1056.05 | 5.0600000000000005 | 1161.92 | 116.05 |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | na | 20 | 14/14 | 8/10 | 1/170 | 5.85 | 4.46e-8 | 0.0162 | 2.13e-3 | 0.305 | · | 0.0223 | 141 | 2.09 |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | na | 24 | 14/14 | 8/10 | 1/170 | 1.78 | 1.89e-5 | 6.11e-3 | 2.29e-3 | 0.0961 | · | 0.011 | 28.8 | 1.39 |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | na | 18 | 14/14 | 8/10 | 1/170 | 5.34 | 8.46e-8 | 0.0167 | 3.20e-3 | 0.304 | · | 0.0262 | 85.8 | 2.95 |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | na | 20 | 14/14 | 8/10 | 1/170 | 2.51 | 9.47e-6 | 8.49e-3 | 1.53e-3 | 0.147 | · | 9.94e-3 | 45.9 | 1 |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | na | 17 | 11/14 | 8/10 | 1/170 | 0.969 | 2.32e-5 | 3.27e-3 | 2.06e-3 | 0.0433 | · | 0.013 | 2.76 | 1.07 |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | na | 10 | 10/14 | 1/10 | 0/170 | · | · | · | · | · | · | 0.0665 | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | eu_ibu | 7 | 12/14 | 7/10 | 42/170 | 45.59 | 1.05e-6 | 0.109 | · | · | 660.7 | 0.172 | 700.8 | 185.47 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unknown | 45 | 3/14 | 2/10 | 0/170 | · | · | · | · | · | 158 | 4.89 | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | eu_ibu | 11 | 11/14 | 8/10 | 48/170 | 40.7 | 2.06e+6 | · | 104 | · | 284 | 11.4 | 288 | 17 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | unknown | 12 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | · | 1.06 | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | unknown | 12 | 4/14 | 7/10 | 42/170 | 100 | 7.00e-6 | 0.7 | · | · | 747 | 8 | 3900 | 77000 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | na | 14 | 12/14 | 8/10 | 20/170 | 141 | 9.69e-7 | 0.424 | 0.0294 | 5.68 | · | 0.745 | 1770 | 296 |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unknown | 12 | 2/14 | 6/10 | 10/170 | -30.9 | 5.41e-7 | · | 3.28e-3 | · | · | 0.0279 | 850 | 7600 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unknown | 10 | 3/14 | 7/10 | 10/170 | -0.22 | 2.41e-7 | · | 0.0179 | · | · | 0.0161 | 890 | 110 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | eu_ibu | 12 | 13/14 | 6/10 | 30/170 | 0.433 | 3.01e-9 | 8.27e-4 | 1.46e-4 | · | 4.3 | 0.0253 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | na | 19 | 11/14 | 8/10 | 0/170 | 6.05 | 6.79e-7 | 0.0396 | 7.26e-3 | 0.288 | 21.6 | 0.0404 | · | 4.36 |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unknown | 8 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | eu_ibu | 11 | 9/14 | 7/10 | 42/170 | -13 | 9.53e-7 | 0.0504 | · | · | 203 | 0.194 | 209 | 31800 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | eu_ibu | 7 | 9/14 | 7/10 | 56/170 | -2.74 | 4.57e-12 | 4.84e-3 | · | · | 35.68 | 0.013 | 36.82 | 59.21 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | eu_ibu | 19 | 4/14 | 3/10 | 0/170 | · | 0.00e+0 | 0.00e+0 | · | · | 0.00e+0 | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unknown | 23 | 2/14 | 4/10 | 0/170 | -730 | 1.23e-5 | · | 0.804 | · | · | 73.8 | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 96.3 | 1.38e-5 | · | · | · | 1600 | 1.09 | 1610 | 101 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | epd_international | 22 | 8/14 | 4/10 | 0/170 | 0.737 | · | · | · | · | 6.01 | · | 7.95 | 9.12 |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 225 | 4.14e-7 | 0.682 | 0.0593 | 9.37 | 1.02e-3 | 0.692 | 5140 | 558 |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unknown | 20 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | na | 9 | 10/14 | 7/10 | 20/170 | -1010 | · | 0.23 | 0.746 | · | 1110 | 0.413 | 1440 | 305 |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | epd_international | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | · | 7.31 | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | na | 4 | 8/14 | 1/10 | 0/170 | · | · | · | · | · | · | 8.05e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | unknown | 14 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | 44.2 | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | eu_ibu | 11 | 11/14 | 6/10 | 42/170 | -253 | 1.76e-6 | 0.412 | · | · | 1100 | · | 2160 | 3990 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | eu_ibu | 8 | 9/14 | 7/10 | 49/170 | 1.11 | 2.34e-13 | · | · | · | 31.3 | 8.40e-3 | 31.3 | 3.18 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.469 | 1.33e-11 | 1.54e-3 | · | · | 11.6 | 5.82e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.737 | 1.33e-11 | 2.50e-3 | · | · | 18.5 | 8.70e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.569 | 1.33e-11 | 2.00e-3 | · | · | 14.1 | 6.45e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | eu_ibu | 8 | 9/14 | 6/10 | 24/170 | 0.534 | 1.49e-11 | 1.47e-3 | · | · | 12.5 | 3.46e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.281 | 4.18e-12 | 1.08e-3 | · | · | 6.99 | 3.96e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.331 | 4.18e-12 | 1.28e-3 | · | · | 8.28 | 4.16e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.385 | 4.32e-12 | 1.49e-3 | · | · | 9.67 | 4.38e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 9/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | eu_ibu | 16 | 5/14 | 2/10 | 6/170 | 0.621 | · | · | · | · | · | 0.01658226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | eu_ibu | 16 | 4/14 | 2/10 | 6/170 | 0.543 | · | · | · | · | · | 0.01350226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | eu_ibu | 18 | 7/14 | 7/10 | 66/170 | 0.5285 | 3.54e-8 | · | 3.59e-4 | · | · | 7.23e-3 | 13.145 | 0.6950700000000001 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | eu_ibu | 17 | 5/14 | 7/10 | 66/170 | 0.41459999999999997 | 2.39e-8 | · | 2.93e-4 | · | · | 9.24e-3 | 10.540000000000001 | 0.59316 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | epd_international | 16 | 9/14 | 5/10 | 0/170 | 0.707 | 6.43e-8 | · | 7.29e-4 | · | 11.9 | 0.199 | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | eu_ibu | 10 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | nsf | 25 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | nsf | 30 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | na | 55 | 9/14 | 8/10 | 54/170 | 8.23e-3 | 2.65e-15 | · | 1.49e-4 | · | 10.29821 | 0.0388 | 10.298509999999998 | 0.8022100000000001 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | na | 13 | 12/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | na | 14 | 12/14 | 3/10 | 9/170 | 443.8 | · | 2.199 | 0.1674 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | eu_ibu | 6 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | na | 9 | 9/14 | 5/10 | 2/170 | 0.3 | · | · | 2.43e-4 | · | 8.61 | 2.88e-5 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | eu_ibu | 11 | 12/14 | 8/10 | 18/170 | 0.00e+0 | 1.35e+7 | 110 | 1120 | · | 0.00e+0 | 0.00e+0 | 0.00e+0 | 0.00e+0 |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | unknown | 27 | 3/14 | 4/10 | 40/170 | 7.8100000000000005 | · | · | · | 0.02286 | · | 0.027100000000000003 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | na | 17 | 11/14 | 7/10 | 12/170 | 6.7 | 1.16e-6 | 0.028359999999999996 | 9.81e-3 | 0.0898 | · | · | 72 | 1 |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 80 | 1.34e-5 | · | · | · | 1380 | 0.998 | 1380 | 81.2 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | na | 16 | 11/14 | 7/10 | 8/170 | 5.1 | 1.20e-7 | 0.029 | 4.00e-3 | 0.3 | · | · | 145.6 | 0.06 |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unknown | 19 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | na | 19 | 11/14 | 7/10 | 6/170 | 282 | 4.35e-7 | 0.996 | 0.0807 | 15.9 | 819 | 0.76 | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unknown | 20 | 3/14 | 2/10 | 8/170 | · | · | · | · | 0.0169 | · | 0.0213 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | eu_ibu | 10 | 9/14 | 6/10 | 24/170 | 0.535 | 9.04e-12 | 1.77e-3 | · | · | 13.4 | 6.86e-3 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | eu_ibu | 15 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | unknown | 32 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | unknown | 18 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | na | 27 | 12/14 | 5/10 | 0/170 | 3.51 | 4.49e-6 | · | 0.0996 | · | · | 3.64 | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 280 | 5.37e-7 | 0.848 | 0.0765 | 11.7 | 5970 | 0.775 | 5920 | 531 |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | na | 19 | 12/14 | 5/10 | 20/170 | 7.24 | · | 0.0226 | 2.56e-3 | · | 12.5 | 3.14e-4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | na | 20 | 12/14 | 9/10 | 0/170 | 1.2 | 9.57e-15 | 2.04e-3 | 1.97e-4 | 0.0377 | 2.16 | 4.21e-3 | 20 | 1.47 |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | eu_ibu | 8 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | eu_ibu | 8 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | epd_international | 21 | 10/14 | 6/10 | 21/170 | 0.373 | · | 1.15e-3 | 1.76e-4 | · | 3.68 | 1.61e-4 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | na | 21 | 12/14 | 3/10 | 0/170 | · | · | · | · | · | · | 3 | 1 | 0.00e+0 |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unknown | 8 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | na | 18 | 11/14 | 9/10 | 24/170 | 343 | 7.03e-7 | 1.02 | 0.0959 | 14.5 | 987 | 0.0467 | 7300 | 519 |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | na | 15 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | na | 31 | 12/14 | 9/10 | 48/170 | 5.44 | 5.27e-7 | 0.0253 | 0.028 | 0.255 | 8.94 | 0.0371 | 71 | 1.54 |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 13.7 | 4.56e-14 | 0.0172 | 3.20e-3 | 0.437 | 228 | 6460 | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 9.32 | 4.41e-14 | 0.0111 | 2.11e-3 | 0.272 | 198 | 5920 | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | na | 47 | 12/14 | 7/10 | 44/170 | 0.4506 | 4.51e-14 | · | 3.67e-4 | · | · | 0.113 | 290.98 | 42.629999999999995 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | unknown | 10 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | na | 15 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | na | 18 | 11/14 | 9/10 | 6/170 | 299 | 5.76e-7 | 0.917 | 0.0842 | 12.4 | 906 | 1.01 | 6680 | 738 |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | na | 15 | 13/14 | 8/10 | 15/170 | 150.16 | 13.969999999999999 | 0.98 | 0.24 | · | 904.68 | 5.109999999999999 | 997.74 | 79.99 |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | na | 15 | 11/14 | 8/10 | 6/170 | 453 | · | 1.25 | 0.141 | 17.4 | 1330 | 2.39 | 9910 | 1180 |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | na | 16 | 12/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 98/170 | 11.324 | 6.59e-7 | 0.03444 | · | · | 112.57 | 0.011706999999999999 | 139.08 | 26.262999999999998 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | eu_ibu | 12 | 4/14 | 4/10 | 0/170 | -1.48e-3 | 7.81e-9 | · | 2.46e-4 | · | · | 0.289 | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | eu_ibu | 9 | 12/14 | 6/10 | 37/170 | 1.0950000000196 | 1.01e-66 | 6.20e-21 | · | · | 41.9 | 0.21474 | · | 0.6157 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | eu_ibu | 10 | 12/14 | 6/10 | 37/170 | 7.500000000019801 | 3.90e-71 | 3.09e-26 | · | · | 77.9 | 0.10596 | · | 0.905 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | 3 | · | · | · | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 3 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | 3 | · | · | 3 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | · | 8 | 8 | · | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | 5 | · | 5 | 5 | 5 | · | 5 | 5 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | 8 | · | 8 | 8 | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | 4 | · | · | 4 | 4 | · | 4 | · | 4 | · |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | 7 | 7 | 7 | · | · | · | 7 | 7 | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | 7 | 7 | 10 | · | · | · | 10 | · | 10 | 10 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | · | · | · | 1 | · | · | · | 1 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | 10 | 10 | · | · | · | 10 | · | 10 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | · | · | · | · | · | 4 | · | 4 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | 4 | · | · | 4 | 4 | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | 1 | · | · | 10 | · | · | · | 10 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | 6 | · | 6 | 6 | 6 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | 7 | · | 7 | 7 | 7 | 7 | 7 | 6 | · | · |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | 7 | 7 | 10 | · | · | · | · | · | 10 | 10 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | 14 | · | 14 | 14 | · | · | 14 | 14 | 14 | 14 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 38/116 | 33% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 11/116 | 9% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 35/116 | 30% |  |
+| 3 | `acidification_kgso2eq` — AP | 28/116 | 24% |  |
+| 4 | `eutrophication_kgneq` — EP | 39/116 | 34% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 26/116 | 22% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 42/116 | 36% |  |
+| 7 | `water_consumption_m3` — WDP | 7/116 | 6% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 11/116 | 9% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 11/116 | 9% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 3/116 | 3% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 0/116 | 0% | DEAD |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 0/116 | 0% | DEAD |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 17/116 | 15% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 1/116 | 1% | thin |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 0/116 | 0% | DEAD |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 2/116 | 2% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 0/116 | 0% | DEAD |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 0/116 | 0% | DEAD |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 0/116 | 0% | DEAD |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 0/116 | 0% | DEAD |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 0/116 | 0% | DEAD |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 29/116 | 25% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 26/116 | 22% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 24/116 | 21% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 14/116 | 12% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 24/116 | 21% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 26/116 | 22% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 24/116 | 21% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 51/116 | 44% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 87/116 | 75% |  |
+| 1 | `gwp_bio_kgco2e` | 16/116 | 14% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 64/116 | 55% |  |
+| 3 | `acidification_kgso2eq` | 84/116 | 72% |  |
+| 4 | `eutrophication_kgneq` | 74/116 | 64% |  |
+| 5 | `smog_kgo3eq` | 43/116 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 46/116 | 40% |  |
+| 7 | `water_consumption_m3` | 52/116 | 45% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 7/116 | 6% |  |
+| 9 | `primary_energy_renewable_mj` | 8/116 | 7% |  |
+| 10 | `gwp_kgco2e` | 21/116 | 18% |  |
+| 11 | `gwp_bio_kgco2e` | 8/116 | 7% |  |
+| 12 | `acidification_kgso2eq` | 14/116 | 12% |  |
+| 13 | `eutrophication_kgneq` | 4/116 | 3% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 22/116 | 19% |  |
+| 15 | `smog_kgo3eq` | 4/116 | 3% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 18/116 | 16% |  |
+| 17 | `water_consumption_m3` | 16/116 | 14% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 20/116 | 17% |  |
+| 19 | `primary_energy_renewable_mj` | 20/116 | 17% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 5/116 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 7/116 | 6% |  |
+| 2 | `acidification_kgso2eq` | 0/116 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/116 | 7% |  |
+| 4 | `smog_kgo3eq` | 0/116 | 0% | DEAD |
+| 5 | `abiotic_depletion_fossil_mj` | 0/116 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/116 | 1% | thin |
+
+## Catalogue parity check
+
+116 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 22/116 | 19% |
+| strong-multi | 12/116 | 10% |
+| medium | 10/116 | 9% |
+| medium-multi | 18/116 | 16% |
+| weak | 33/116 | 28% |
+| unmatched | 21/116 | 18% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 56 | 21 | 18 | 0 | 59% |
+| `classification.material_type` | 31 | 31 | 29 | 4 | 34% |
+| `manufacturer.name` | 28 | 37 | 28 | 2 | 30% |
+| `physical.density.value_kg_m3` | 4 | 46 | 41 | 4 | 4% |
+| `epd.id` | 43 | 26 | 24 | 2 | 46% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | weak | 40 | `bbb021` | Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm | disp(3/3) |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | strong | 90 | `osb003` | OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16" | epd.id, group |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | strong | 90 | `osb007` | OSB subflooring / LP / LP Legacy® Premium / 5/8" | epd.id, group |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | strong | 90 | `osb002` | OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side | epd.id, group |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | strong-multi | 90 | `osb004` (+1 more) | OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2" | epd.id, group |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | strong | 95 | `lp0001` | Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm) | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | strong | 120 | `lp0000` | Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm) | epd.id, disp(1/1) |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | medium | 55 | `www118` | Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | weak | 40 | `s12345` | Ground screw / American Ground Screw / AGS IM3316 / 76 x 1600 mm | mfr |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | medium-multi | 55 | `www119` (+1 more) | Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | medium-multi | 50 | `bbb012` (+4 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, group |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | strong-multi | 80 | `bbb012` (+1 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, disp(2/2) |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | medium-multi | 75 | `ccf00x` (+1 more) | Cementitious Foam / R 3.5-inch [BEAM Avg] | epd.id |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | medium | 75 | `vrs000` | Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes | epd.id |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | strong | 115 | `stu000` | Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | strong | 115 | `vin002` | Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] / R-0.5 | epd.id, mfr |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | weak | 40 | `cbi000` | Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU] | mfr |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | strong | 120 | `ae7e1c` | Cork flooring / European Resilient Flooring Manufacturers' Institute [Industry Avg \| EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | medium | 75 | `www121` | Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | strong-multi | 80 | `lcp001` (+2 more) | Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU] | epd.id |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | strong | 90 | `rrr114` | Asphalt Shingles / Malarkey Roofing / Dura-Seal / | epd.id, group |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | strong | 160 | `cel000` | Cellulose / batt / Ekovilla / Ekovilla Slab / R3.7-inch [EU] | epd.id, mfr, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | medium | 60 | `bbb031` | Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | weak | 40 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | strong | 115 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | strong | 90 | `bbb025` | Int. Wall barrier, sheet / Isover / Vario KM Duplex / Moisture-variable / EU | epd.id, group |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | strong | 80 | `bbb026` | Int. Wall barrier, sheet / Isover / Vario XTRA / Moisture-variable / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | strong-multi | 107 | `ins022` (+2 more) | Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU] | epd.id, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | weak | 30 | `676103` | EPDM Roofing Membrane / Non-reinforced single ply / SPRI  [Industry Avg \| US] | disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | strong-multi | 80 | `bbb000` (+4 more) | Int. Wall & Ceiling Barrier, sheet / Rothoblaas / Vapor In Green 200 / Non-permeable / 0.35 mm / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | strong | 95 | `www116` | Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL\|TLF, 526, AA 6400\|6500, NX-300\|3000 / Projected & casement | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | strong-multi | 115 | `s12347` (+1 more) | Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | weak | 40 | `int007` | MgO board 1/2" / Sinh Build / MAGOXX boards / 1/2" [EU] | disp(2/2) |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | medium-multi | 50 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, group |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | medium | 75 | `www114` | Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | medium-multi | 70 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, disp(2/4), group |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | strong-multi | 90 | `rrr112` (+1 more) | Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | strong-multi | 115 | `ins013` (+2 more) | Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | strong | 90 | `rrr115` | Asphalt Shingles / Malarkey Roofing / Highlander NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | strong | 120 | `lvt012` | Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm | epd.id, disp(3/4), group |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | strong | 90 | `rrr116` | Asphalt Shingles / Malarkey Roofing / Legacy / | epd.id, group |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | strong | 120 | `ins004` | Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg \| N.America] | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | strong | 90 | `rrr117` | Asphalt Shingles / Malarkey Roofing / Vista / | epd.id, group |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | strong | 90 | `rrr118` | Asphalt Shingles / Malarkey Roofing / Windsor / | epd.id, group |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | strong | 120 | `8b5828` | Window - frame only / AluQuébec / Aluminum frame / Canada | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | weak | 40 | `bbb032` | Int. Wall & Ceiling Barrier, sheet / Synwer / Syn U 120 Sd 2 / Moisture-variable / EU | mfr |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | medium | 75 | `fib001` | Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU] | epd.id |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | unmatched | 0 | — | — | — |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-539 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-540 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf** (top: `bbb021` — Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm):
+- `manufacturer.name` — candidate `"the facility located in Michigan"` vs catalogue `"Soprema"`
+- `physical.density.value_kg_m3` — candidate `1080` vs catalogue `0.569`
+
+**EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf** (top: `osb003` — OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf** (top: `osb007` — OSB subflooring / LP / LP Legacy® Premium / 5/8"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf** (top: `osb002` — OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `678.28`
+
+**EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf** (top: `osb004` — OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf** (top: `lp0001` — Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm)):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered Wood siding"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf** (top: `lp0000` — Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm)):
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf** (top: `www118` — Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf** (top: `www119` — Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf** (top: `bbb012` — Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Barrier"`
+- `physical.density.value_kg_m3` — candidate `1060` vs catalogue `0.975`
+
+**EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"National Gypsum"`
+
+**EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"several defined by the functional"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `25.214` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf** (top: `ccf00x` — Cementitious Foam / R 3.5-inch [BEAM Avg]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"03"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Cementitious foam"`
+- `physical.density.value_kg_m3` — candidate `70` vs catalogue `80`
+
+**EPDs to consider for v1.1 update/Airkrete spray EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"Holcim"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `130` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf** (top: `vrs000` — Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"PU Foam"`
+- `manufacturer.name` — candidate `"the facility and no allocation"` vs catalogue `"Branch"`
+- `physical.density.value_kg_m3` — candidate `214.5` vs catalogue `32.6`
+
+**EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf** (top: `stu000` — Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Cement stucco"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `1600`
+
+**EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf** (top: `vin002` — Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg | US & CA] / R-0.5):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Vinyl"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `2.53`
+
+**EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf** (top: `cbi000` — Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU]):
+- `epd.id` — candidate `"EPD-AMO-20210078-ICA1-EN"` vs catalogue `"EPD HUB-0281"`
+
+**EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf** (top: `www121` — Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Triple pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf** (top: `lcp001` — Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU]):
+- `manufacturer.name` — candidate `"TDS"` vs catalogue `"Diasen"`
+
+**EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf** (top: `rrr114` — Asphalt Shingles / Malarkey Roofing / Dura-Seal /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-DE"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `17.1` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf** (top: `bbb031` — Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU):
+- `epd.id` — candidate `"EPD-SIG-20220186-CBA1-EN"` vs catalogue `"EPD-SIG-20220185-CBA1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210188-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210187-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210186-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `epd.id` — candidate `"EPD-DUP-20220250-CBA1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"HDPE"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `0.058`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210189-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210184-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf** (top: `ins022` — Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU]):
+- `manufacturer.name` — candidate `"Eden Renewable Innovations Limited"` vs catalogue `"Thermafleece"`
+
+**EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"IBU"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf** (top: `www116` — Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL|TLF, 526, AA 6400|6500, NX-300|3000 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Building Product Design Ltd"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf** (top: `s12347` — Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"31"`
+- `classification.material_type` — candidate `"Steel"` vs catalogue `"Ground screw"`
+- `physical.density.value_kg_m3` — candidate `7850` vs catalogue `5.5`
+
+**EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-075 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf** (top: `www114` — Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-074 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf** (top: `rrr112` — Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210185-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf** (top: `ins013` — Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Hemp"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `230`
+
+**EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf** (top: `rrr115` — Asphalt Shingles / Malarkey Roofing / Highlander NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790545973.103.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"the United States and Canada."` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/LECA EPD 4.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `epd.id` — candidate `"S-P-04459"` vs catalogue `"EPD10792"`
+
+**EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf** (top: `lvt012` — Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"Co., Ltd"` vs catalogue `"Jiangsu Fuhua"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `7094.7`
+
+**EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf** (top: `rrr116` — Asphalt Shingles / Malarkey Roofing / Legacy /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf** (top: `ins004` — Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg | N.America]):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `57.6`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `99.9` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `38.3` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `32.1` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788986648.101.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.144.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.142.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"2021M10140 Registration Number EPDITALY0140"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"nor LCA practitioner."` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `280` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Vista asphalt shingles.pdf** (top: `rrr117` — Asphalt Shingles / Malarkey Roofing / Vista /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Wausau Window and Wall Systems, a part of Apogee"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"499"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf** (top: `rrr118` — Asphalt Shingles / Malarkey Roofing / Windsor /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Eternit GmbH"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"EPD-ELH-20180136-CAC1-EN"` vs catalogue `"EPD 034"`
+
+**EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf** (top: `fib001` — Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Fiber cement"`
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Equitone"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `1850`
+
+**EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-ETE-20190007-ICA1-EN"` vs catalogue `"4789365778.101.1"`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-mattype.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-mattype.md
@@ -1,0 +1,811 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T17:10:50.810Z
+Samples: 116 · metadata: 1066/1624 (65.6%) · impacts: 563/1160 (48.5%) · by_stage: 2280/19720 (11.6%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | na | 9 | 13/14 | 7/10 | 12/170 | 688.8 | 1.15e-6 | 2.49 | 0.67374 | 25.88 | 116 | · | · | 11.6 |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | na | 9 | 13/14 | 6/10 | 9/170 | 692.65 | · | 0.15 | 0.5700000000000001 | 25.89 | 318 | · | · | 53.44 |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | na | 18 | 13/14 | 8/10 | 1/170 | 2.44 | 9.09e-5 | 4.30e-3 | 4.82e-4 | 0.038 | · | 0.0126 | 41.8 | 2.84 |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 264.52 | 1.17e-5 | 1.64 | 0.6 | 40.54 | 496.73 | 1.58 | 4146.4 | 3681.7 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 283.3 | 9.84e-6 | 29.34 | 1.49 | 0.52 | 666.43 | 1.41 | 4514.47 | 3712.72 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 333.48 | 2.76e-5 | 1.69 | 0.9 | 32.54 | 627.15 | 2.6 | 600.01 | 2008.65 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 323.38 | 1.44e-5 | 1.57 | 0.62 | 42.86 | 699.46 | 2.83 | 921.15 | 5544.68 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | na | 26 | 13/14 | 10/10 | 102/170 | 487.03 | 1.21e-5 | 2.97 | 1.55 | 54.5 | 6479.68 | 2.53 | 72.07 | 43.16 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | na | 27 | 12/14 | 10/10 | 110/170 | 267.01 | 9.40e-6 | 2.23 | 0.32 | 48.77 | 628.16 | 2.37 | 43.89 | 47.96 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | na | 8 | 13/14 | 5/10 | 8/170 | 131.07 | 4.5 | 4.42 | · | · | · | · | 1514.61 | 309.87 |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | na | 15 | 11/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | na | 15 | 11/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | na | 13 | 7/14 | 4/10 | 12/170 | 1097.6 | 7.10e-6 | 0.622 | 0.106 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | na | 15 | 13/14 | 8/10 | 15/170 | 182.61 | 15.190000000000001 | 1.23 | 0.38 | · | 1056.05 | 5.0600000000000005 | 1161.92 | 116.05 |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | na | 20 | 14/14 | 8/10 | 1/170 | 5.85 | 4.46e-8 | 0.0162 | 2.13e-3 | 0.305 | · | 0.0223 | 141 | 2.09 |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | na | 24 | 14/14 | 8/10 | 1/170 | 1.78 | 1.89e-5 | 6.11e-3 | 2.29e-3 | 0.0961 | · | 0.011 | 28.8 | 1.39 |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | na | 18 | 14/14 | 8/10 | 1/170 | 5.34 | 8.46e-8 | 0.0167 | 3.20e-3 | 0.304 | · | 0.0262 | 85.8 | 2.95 |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | na | 20 | 14/14 | 8/10 | 1/170 | 2.51 | 9.47e-6 | 8.49e-3 | 1.53e-3 | 0.147 | · | 9.94e-3 | 45.9 | 1 |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | na | 17 | 12/14 | 8/10 | 1/170 | 0.969 | 2.32e-5 | 3.27e-3 | 2.06e-3 | 0.0433 | · | 0.013 | 2.76 | 1.07 |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | na | 10 | 10/14 | 1/10 | 0/170 | · | · | · | · | · | · | 0.0665 | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | eu_ibu | 7 | 12/14 | 7/10 | 42/170 | 45.59 | 1.05e-6 | 0.109 | · | · | 660.7 | 0.172 | 700.8 | 185.47 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unknown | 45 | 3/14 | 2/10 | 0/170 | · | · | · | · | · | 158 | 4.89 | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | eu_ibu | 11 | 11/14 | 8/10 | 48/170 | 40.7 | 2.06e+6 | · | 104 | · | 284 | 11.4 | 288 | 17 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | unknown | 12 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | · | 1.06 | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | unknown | 12 | 4/14 | 7/10 | 42/170 | 100 | 7.00e-6 | 0.7 | · | · | 747 | 8 | 3900 | 77000 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | na | 14 | 12/14 | 8/10 | 20/170 | 141 | 9.69e-7 | 0.424 | 0.0294 | 5.68 | · | 0.745 | 1770 | 296 |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unknown | 12 | 2/14 | 6/10 | 10/170 | -30.9 | 5.41e-7 | · | 3.28e-3 | · | · | 0.0279 | 850 | 7600 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unknown | 10 | 2/14 | 7/10 | 10/170 | -0.22 | 2.41e-7 | · | 0.0179 | · | · | 0.0161 | 890 | 110 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | eu_ibu | 12 | 13/14 | 6/10 | 30/170 | 0.433 | 3.01e-9 | 8.27e-4 | 1.46e-4 | · | 4.3 | 0.0253 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | na | 19 | 11/14 | 8/10 | 0/170 | 6.05 | 6.79e-7 | 0.0396 | 7.26e-3 | 0.288 | 21.6 | 0.0404 | · | 4.36 |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unknown | 8 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | eu_ibu | 11 | 10/14 | 7/10 | 42/170 | -13 | 9.53e-7 | 0.0504 | · | · | 203 | 0.194 | 209 | 31800 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | eu_ibu | 7 | 10/14 | 7/10 | 56/170 | -2.74 | 4.57e-12 | 4.84e-3 | · | · | 35.68 | 0.013 | 36.82 | 59.21 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | eu_ibu | 19 | 4/14 | 3/10 | 0/170 | · | 0.00e+0 | 0.00e+0 | · | · | 0.00e+0 | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unknown | 23 | 2/14 | 4/10 | 0/170 | -730 | 1.23e-5 | · | 0.804 | · | · | 73.8 | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 96.3 | 1.38e-5 | · | · | · | 1600 | 1.09 | 1610 | 101 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | epd_international | 22 | 8/14 | 4/10 | 0/170 | 0.737 | · | · | · | · | 6.01 | · | 7.95 | 9.12 |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 225 | 4.14e-7 | 0.682 | 0.0593 | 9.37 | 1.02e-3 | 0.692 | 5140 | 558 |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unknown | 20 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | na | 9 | 11/14 | 7/10 | 20/170 | -1010 | · | 0.23 | 0.746 | · | 1110 | 0.413 | 1440 | 305 |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | epd_international | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | · | 7.31 | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | na | 4 | 8/14 | 1/10 | 0/170 | · | · | · | · | · | · | 8.05e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | unknown | 14 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | 44.2 | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | eu_ibu | 11 | 12/14 | 6/10 | 42/170 | -253 | 1.76e-6 | 0.412 | · | · | 1100 | · | 2160 | 3990 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | eu_ibu | 8 | 9/14 | 7/10 | 49/170 | 1.11 | 2.34e-13 | · | · | · | 31.3 | 8.40e-3 | 31.3 | 3.18 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.469 | 1.33e-11 | 1.54e-3 | · | · | 11.6 | 5.82e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.737 | 1.33e-11 | 2.50e-3 | · | · | 18.5 | 8.70e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.569 | 1.33e-11 | 2.00e-3 | · | · | 14.1 | 6.45e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | eu_ibu | 8 | 9/14 | 6/10 | 24/170 | 0.534 | 1.49e-11 | 1.47e-3 | · | · | 12.5 | 3.46e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.281 | 4.18e-12 | 1.08e-3 | · | · | 6.99 | 3.96e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.331 | 4.18e-12 | 1.28e-3 | · | · | 8.28 | 4.16e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.385 | 4.32e-12 | 1.49e-3 | · | · | 9.67 | 4.38e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 9/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | eu_ibu | 16 | 5/14 | 2/10 | 6/170 | 0.621 | · | · | · | · | · | 0.01658226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | eu_ibu | 16 | 4/14 | 2/10 | 6/170 | 0.543 | · | · | · | · | · | 0.01350226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | eu_ibu | 18 | 7/14 | 7/10 | 66/170 | 0.5285 | 3.54e-8 | · | 3.59e-4 | · | · | 7.23e-3 | 13.145 | 0.6950700000000001 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | eu_ibu | 17 | 6/14 | 7/10 | 66/170 | 0.41459999999999997 | 2.39e-8 | · | 2.93e-4 | · | · | 9.24e-3 | 10.540000000000001 | 0.59316 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | epd_international | 16 | 10/14 | 5/10 | 0/170 | 0.707 | 6.43e-8 | · | 7.29e-4 | · | 11.9 | 0.199 | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | eu_ibu | 10 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | nsf | 25 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | nsf | 30 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | na | 55 | 9/14 | 8/10 | 54/170 | 8.23e-3 | 2.65e-15 | · | 1.49e-4 | · | 10.29821 | 0.0388 | 10.298509999999998 | 0.8022100000000001 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | na | 13 | 12/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | na | 14 | 12/14 | 3/10 | 9/170 | 443.8 | · | 2.199 | 0.1674 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | eu_ibu | 6 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | na | 9 | 9/14 | 5/10 | 2/170 | 0.3 | · | · | 2.43e-4 | · | 8.61 | 2.88e-5 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | eu_ibu | 11 | 12/14 | 8/10 | 18/170 | 0.00e+0 | 1.35e+7 | 110 | 1120 | · | 0.00e+0 | 0.00e+0 | 0.00e+0 | 0.00e+0 |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | unknown | 27 | 3/14 | 4/10 | 40/170 | 7.8100000000000005 | · | · | · | 0.02286 | · | 0.027100000000000003 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | na | 17 | 12/14 | 7/10 | 12/170 | 6.7 | 1.16e-6 | 0.028359999999999996 | 9.81e-3 | 0.0898 | · | · | 72 | 1 |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 80 | 1.34e-5 | · | · | · | 1380 | 0.998 | 1380 | 81.2 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | na | 16 | 12/14 | 7/10 | 8/170 | 5.1 | 1.20e-7 | 0.029 | 4.00e-3 | 0.3 | · | · | 145.6 | 0.06 |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unknown | 19 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | na | 19 | 11/14 | 7/10 | 6/170 | 282 | 4.35e-7 | 0.996 | 0.0807 | 15.9 | 819 | 0.76 | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unknown | 20 | 3/14 | 2/10 | 8/170 | · | · | · | · | 0.0169 | · | 0.0213 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | eu_ibu | 10 | 9/14 | 6/10 | 24/170 | 0.535 | 9.04e-12 | 1.77e-3 | · | · | 13.4 | 6.86e-3 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | eu_ibu | 15 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | unknown | 32 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | unknown | 18 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | na | 27 | 12/14 | 5/10 | 0/170 | 3.51 | 4.49e-6 | · | 0.0996 | · | · | 3.64 | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 280 | 5.37e-7 | 0.848 | 0.0765 | 11.7 | 5970 | 0.775 | 5920 | 531 |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | na | 19 | 12/14 | 5/10 | 20/170 | 7.24 | · | 0.0226 | 2.56e-3 | · | 12.5 | 3.14e-4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | na | 20 | 12/14 | 9/10 | 0/170 | 1.2 | 9.57e-15 | 2.04e-3 | 1.97e-4 | 0.0377 | 2.16 | 4.21e-3 | 20 | 1.47 |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | eu_ibu | 8 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | eu_ibu | 8 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | epd_international | 21 | 10/14 | 6/10 | 21/170 | 0.373 | · | 1.15e-3 | 1.76e-4 | · | 3.68 | 1.61e-4 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | na | 21 | 12/14 | 3/10 | 0/170 | · | · | · | · | · | · | 3 | 1 | 0.00e+0 |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unknown | 8 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | na | 18 | 11/14 | 9/10 | 24/170 | 343 | 7.03e-7 | 1.02 | 0.0959 | 14.5 | 987 | 0.0467 | 7300 | 519 |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | na | 15 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | na | 31 | 12/14 | 9/10 | 48/170 | 5.44 | 5.27e-7 | 0.0253 | 0.028 | 0.255 | 8.94 | 0.0371 | 71 | 1.54 |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 13.7 | 4.56e-14 | 0.0172 | 3.20e-3 | 0.437 | 228 | 6460 | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 9.32 | 4.41e-14 | 0.0111 | 2.11e-3 | 0.272 | 198 | 5920 | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | na | 47 | 12/14 | 7/10 | 44/170 | 0.4506 | 4.51e-14 | · | 3.67e-4 | · | · | 0.113 | 290.98 | 42.629999999999995 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | unknown | 10 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | na | 15 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | na | 18 | 11/14 | 9/10 | 6/170 | 299 | 5.76e-7 | 0.917 | 0.0842 | 12.4 | 906 | 1.01 | 6680 | 738 |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | na | 15 | 13/14 | 8/10 | 15/170 | 150.16 | 13.969999999999999 | 0.98 | 0.24 | · | 904.68 | 5.109999999999999 | 997.74 | 79.99 |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | na | 15 | 11/14 | 8/10 | 6/170 | 453 | · | 1.25 | 0.141 | 17.4 | 1330 | 2.39 | 9910 | 1180 |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | na | 16 | 12/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 98/170 | 11.324 | 6.59e-7 | 0.03444 | · | · | 112.57 | 0.011706999999999999 | 139.08 | 26.262999999999998 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | eu_ibu | 12 | 4/14 | 4/10 | 0/170 | -1.48e-3 | 7.81e-9 | · | 2.46e-4 | · | · | 0.289 | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | eu_ibu | 9 | 12/14 | 6/10 | 37/170 | 1.0950000000196 | 1.01e-66 | 6.20e-21 | · | · | 41.9 | 0.21474 | · | 0.6157 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | eu_ibu | 10 | 12/14 | 6/10 | 37/170 | 7.500000000019801 | 3.90e-71 | 3.09e-26 | · | · | 77.9 | 0.10596 | · | 0.905 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | na | 15 | 9/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | 3 | · | · | · | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 3 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | 3 | · | · | 3 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | · | 8 | 8 | · | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | 5 | · | 5 | 5 | 5 | · | 5 | 5 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | 8 | · | 8 | 8 | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | 4 | · | · | 4 | 4 | · | 4 | · | 4 | · |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | 7 | 7 | 7 | · | · | · | 7 | 7 | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | 7 | 7 | 10 | · | · | · | 10 | · | 10 | 10 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | · | · | · | 1 | · | · | · | 1 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | 10 | 10 | · | · | · | 10 | · | 10 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | · | · | · | · | · | 4 | · | 4 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | 4 | · | · | 4 | 4 | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | 1 | · | · | 10 | · | · | · | 10 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | 6 | · | 6 | 6 | 6 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | 7 | · | 7 | 7 | 7 | 7 | 7 | 6 | · | · |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | 7 | 7 | 10 | · | · | · | · | · | 10 | 10 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | 14 | · | 14 | 14 | · | · | 14 | 14 | 14 | 14 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 38/116 | 33% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 11/116 | 9% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 35/116 | 30% |  |
+| 3 | `acidification_kgso2eq` — AP | 28/116 | 24% |  |
+| 4 | `eutrophication_kgneq` — EP | 39/116 | 34% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 26/116 | 22% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 42/116 | 36% |  |
+| 7 | `water_consumption_m3` — WDP | 7/116 | 6% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 11/116 | 9% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 11/116 | 9% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 3/116 | 3% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 0/116 | 0% | DEAD |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 0/116 | 0% | DEAD |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 17/116 | 15% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 1/116 | 1% | thin |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 0/116 | 0% | DEAD |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 2/116 | 2% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 0/116 | 0% | DEAD |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 0/116 | 0% | DEAD |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 0/116 | 0% | DEAD |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 0/116 | 0% | DEAD |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 0/116 | 0% | DEAD |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 29/116 | 25% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 26/116 | 22% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 24/116 | 21% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 14/116 | 12% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 24/116 | 21% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 26/116 | 22% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 24/116 | 21% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 51/116 | 44% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 87/116 | 75% |  |
+| 1 | `gwp_bio_kgco2e` | 16/116 | 14% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 64/116 | 55% |  |
+| 3 | `acidification_kgso2eq` | 84/116 | 72% |  |
+| 4 | `eutrophication_kgneq` | 74/116 | 64% |  |
+| 5 | `smog_kgo3eq` | 43/116 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 46/116 | 40% |  |
+| 7 | `water_consumption_m3` | 52/116 | 45% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 7/116 | 6% |  |
+| 9 | `primary_energy_renewable_mj` | 8/116 | 7% |  |
+| 10 | `gwp_kgco2e` | 21/116 | 18% |  |
+| 11 | `gwp_bio_kgco2e` | 8/116 | 7% |  |
+| 12 | `acidification_kgso2eq` | 14/116 | 12% |  |
+| 13 | `eutrophication_kgneq` | 4/116 | 3% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 22/116 | 19% |  |
+| 15 | `smog_kgo3eq` | 4/116 | 3% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 18/116 | 16% |  |
+| 17 | `water_consumption_m3` | 16/116 | 14% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 20/116 | 17% |  |
+| 19 | `primary_energy_renewable_mj` | 20/116 | 17% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 5/116 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 7/116 | 6% |  |
+| 2 | `acidification_kgso2eq` | 0/116 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/116 | 7% |  |
+| 4 | `smog_kgo3eq` | 0/116 | 0% | DEAD |
+| 5 | `abiotic_depletion_fossil_mj` | 0/116 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/116 | 1% | thin |
+
+## Catalogue parity check
+
+116 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 22/116 | 19% |
+| strong-multi | 12/116 | 10% |
+| medium | 13/116 | 11% |
+| medium-multi | 16/116 | 14% |
+| weak | 35/116 | 30% |
+| unmatched | 18/116 | 16% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 61 | 21 | 16 | 0 | 62% |
+| `classification.material_type` | 31 | 37 | 28 | 2 | 32% |
+| `manufacturer.name` | 28 | 39 | 29 | 2 | 29% |
+| `physical.density.value_kg_m3` | 4 | 47 | 42 | 5 | 4% |
+| `epd.id` | 43 | 28 | 25 | 2 | 45% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | weak | 40 | `bbb021` | Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm | disp(3/3) |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | strong | 90 | `osb003` | OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16" | epd.id, group |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | strong | 90 | `osb007` | OSB subflooring / LP / LP Legacy® Premium / 5/8" | epd.id, group |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | strong | 90 | `osb002` | OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side | epd.id, group |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | strong-multi | 90 | `osb004` (+1 more) | OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2" | epd.id, group |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | strong | 95 | `lp0001` | Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm) | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | strong | 120 | `lp0000` | Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm) | epd.id, disp(1/1) |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | medium | 55 | `www118` | Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | weak | 40 | `s12345` | Ground screw / American Ground Screw / AGS IM3316 / 76 x 1600 mm | mfr |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | medium-multi | 55 | `www119` (+1 more) | Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | medium-multi | 50 | `bbb012` (+4 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, group |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | strong-multi | 80 | `bbb012` (+1 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, disp(2/2) |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | medium-multi | 75 | `ccf00x` (+1 more) | Cementitious Foam / R 3.5-inch [BEAM Avg] | epd.id |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | medium | 75 | `vrs000` | Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes | epd.id |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | strong | 115 | `stu000` | Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | strong | 115 | `vin002` | Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] / R-0.5 | epd.id, mfr |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | medium | 74 | `a13a3e` | Cork flooring / Amorim /  Revestimentos S.A. / Cork floating floor planks [EU] | mfr, disp(3/5), group |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | strong | 130 | `ae7e1c` | Cork flooring / European Resilient Flooring Manufacturers' Institute [Industry Avg \| EU] | epd.id, mfr, group |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | medium | 75 | `www121` | Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | strong-multi | 109 | `lcp001` (+2 more) | Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU] | epd.id, disp(5/7) |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | strong | 90 | `rrr114` | Asphalt Shingles / Malarkey Roofing / Dura-Seal / | epd.id, group |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | weak | 30 | `xsp4tl` | Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs | disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | strong | 160 | `cel000` | Cellulose / batt / Ekovilla / Ekovilla Slab / R3.7-inch [EU] | epd.id, mfr, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | weak | 40 | `ins035` | Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU] | disp(3/4), group |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | medium | 60 | `bbb031` | Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | weak | 40 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | strong | 115 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | strong | 90 | `bbb025` | Int. Wall barrier, sheet / Isover / Vario KM Duplex / Moisture-variable / EU | epd.id, group |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | strong | 80 | `bbb026` | Int. Wall barrier, sheet / Isover / Vario XTRA / Moisture-variable / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | weak | 30 | `676103` | EPDM Roofing Membrane / Non-reinforced single ply / SPRI  [Industry Avg \| US] | disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | strong-multi | 107 | `ins022` (+2 more) | Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU] | epd.id, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | weak | 30 | `676103` | EPDM Roofing Membrane / Non-reinforced single ply / SPRI  [Industry Avg \| US] | disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | strong-multi | 80 | `bbb000` (+4 more) | Int. Wall & Ceiling Barrier, sheet / Rothoblaas / Vapor In Green 200 / Non-permeable / 0.35 mm / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | strong | 95 | `www116` | Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL\|TLF, 526, AA 6400\|6500, NX-300\|3000 / Projected & casement | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | strong-multi | 115 | `s12347` (+1 more) | Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | weak | 40 | `int007` | MgO board 1/2" / Sinh Build / MAGOXX boards / 1/2" [EU] | disp(2/2) |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | medium | 70 | `7f7bd8` | Waterproofing membrane adhesive / GCP / Bituthene / | mfr, disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | medium | 75 | `www114` | Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | medium | 70 | `7f7bd8` | Waterproofing membrane adhesive / GCP / Bituthene / | mfr, disp(1/2), group |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | strong-multi | 90 | `rrr112` (+1 more) | Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | strong-multi | 115 | `ins013` (+2 more) | Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | strong | 90 | `rrr115` | Asphalt Shingles / Malarkey Roofing / Highlander NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | strong | 120 | `lvt012` | Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm | epd.id, disp(3/4), group |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | strong | 90 | `rrr116` | Asphalt Shingles / Malarkey Roofing / Legacy / | epd.id, group |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | strong | 120 | `ins004` | Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg \| N.America] | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | strong | 90 | `rrr117` | Asphalt Shingles / Malarkey Roofing / Vista / | epd.id, group |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | strong | 90 | `rrr118` | Asphalt Shingles / Malarkey Roofing / Windsor / | epd.id, group |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | strong | 120 | `8b5828` | Window - frame only / AluQuébec / Aluminum frame / Canada | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | weak | 40 | `bbb032` | Int. Wall & Ceiling Barrier, sheet / Synwer / Syn U 120 Sd 2 / Moisture-variable / EU | mfr |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | medium | 75 | `fib001` | Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU] | epd.id |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | unmatched | 0 | — | — | — |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-539 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-540 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf** (top: `bbb021` — Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm):
+- `classification.material_type` — candidate `"Membrane"` vs catalogue `"Barrier"`
+- `manufacturer.name` — candidate `"the facility located in Michigan"` vs catalogue `"Soprema"`
+- `physical.density.value_kg_m3` — candidate `1080` vs catalogue `0.569`
+
+**EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf** (top: `osb003` — OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf** (top: `osb007` — OSB subflooring / LP / LP Legacy® Premium / 5/8"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf** (top: `osb002` — OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `678.28`
+
+**EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf** (top: `osb004` — OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf** (top: `lp0001` — Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm)):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered Wood siding"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf** (top: `lp0000` — Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm)):
+- `classification.material_type` — candidate `"Wood fiber insulation"` vs catalogue `"Engineered Wood siding"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf** (top: `www118` — Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf** (top: `www119` — Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf** (top: `bbb012` — Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Barrier"`
+- `physical.density.value_kg_m3` — candidate `1060` vs catalogue `0.975`
+
+**EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"National Gypsum"`
+
+**EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf** (top: `bbb012` — Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm):
+- `classification.material_type` — candidate `"Membrane"` vs catalogue `"Barrier"`
+
+**EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"several defined by the functional"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `25.214` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf** (top: `ccf00x` — Cementitious Foam / R 3.5-inch [BEAM Avg]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"03"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Cementitious foam"`
+- `physical.density.value_kg_m3` — candidate `70` vs catalogue `80`
+
+**EPDs to consider for v1.1 update/Airkrete spray EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"Holcim"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `130` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf** (top: `vrs000` — Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"PU Foam"`
+- `manufacturer.name` — candidate `"the facility and no allocation"` vs catalogue `"Branch"`
+- `physical.density.value_kg_m3` — candidate `214.5` vs catalogue `32.6`
+
+**EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf** (top: `stu000` — Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Cement stucco"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `1600`
+
+**EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf** (top: `vin002` — Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg | US & CA] / R-0.5):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Vinyl"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `2.53`
+
+**EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf** (top: `a13a3e` — Cork flooring / Amorim /  Revestimentos S.A. / Cork floating floor planks [EU]):
+- `epd.id` — candidate `"EPD-AMO-20210078-ICA1-EN"` vs catalogue `"EPD-AMO-20150057-IAA1-EN"`
+
+**EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf** (top: `www121` — Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Triple pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf** (top: `lcp001` — Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU]):
+- `manufacturer.name` — candidate `"TDS"` vs catalogue `"Diasen"`
+
+**EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf** (top: `rrr114` — Asphalt Shingles / Malarkey Roofing / Dura-Seal /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf** (top: `xsp4tl` — Stucco Base coat / Sto / BTS Plus – adhered over rough masonry concrete & CMUs):
+- `classification.material_type` — candidate `"Admixture"` vs catalogue `"Cement-based"`
+- `manufacturer.name` — candidate `"the manufacturer."` vs catalogue `"Sto Corp."`
+- `epd.id` — candidate `"EPD 507"` vs catalogue `"01-004"`
+
+**EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-DE"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `physical.density.value_kg_m3` — candidate `17.1` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf** (top: `ins035` — Wood fiber loose fill / GUTEX / ThermoFiber / R 3.8-inch [EU]):
+- `classification.material_type` — candidate `"Wood fiber insulation"` vs catalogue `"Wood fibre"`
+- `manufacturer.name` — candidate `"IBU"` vs catalogue `"GUTEX"`
+- `physical.density.value_kg_m3` — candidate `200` vs catalogue `35`
+- `epd.id` — candidate `"EPD-PAV-20190182-IBA4-EN"` vs catalogue `"EPD-GTX-20190018-IBA1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf** (top: `bbb031` — Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU):
+- `epd.id` — candidate `"EPD-SIG-20220186-CBA1-EN"` vs catalogue `"EPD-SIG-20220185-CBA1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210188-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210187-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210186-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `epd.id` — candidate `"EPD-DUP-20220250-CBA1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"HDPE"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `0.058`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210189-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210184-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf** (top: `ins022` — Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU]):
+- `classification.material_type` — candidate `"Sheep wool insulation"` vs catalogue `"Wool"`
+- `manufacturer.name` — candidate `"Eden Renewable Innovations Limited"` vs catalogue `"Thermafleece"`
+
+**EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"IBU"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf** (top: `www116` — Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL|TLF, 526, AA 6400|6500, NX-300|3000 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Building Product Design Ltd"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf** (top: `s12347` — Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"31"`
+- `classification.material_type` — candidate `"Steel"` vs catalogue `"Ground screw"`
+- `physical.density.value_kg_m3` — candidate `7850` vs catalogue `5.5`
+
+**EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf** (top: `7f7bd8` — Waterproofing membrane adhesive / GCP / Bituthene /):
+- `epd.id` — candidate `"EPD-075 EPD Information"` vs catalogue `"EPD-073"`
+
+**EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf** (top: `www114` — Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf** (top: `7f7bd8` — Waterproofing membrane adhesive / GCP / Bituthene /):
+- `epd.id` — candidate `"EPD-074 EPD Information"` vs catalogue `"EPD-073"`
+
+**EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf** (top: `rrr112` — Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210185-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf** (top: `ins013` — Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Hemp"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `230`
+
+**EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf** (top: `rrr115` — Asphalt Shingles / Malarkey Roofing / Highlander NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790545973.103.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"the United States and Canada."` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/LECA EPD 4.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `epd.id` — candidate `"S-P-04459"` vs catalogue `"EPD10792"`
+
+**EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf** (top: `lvt012` — Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"Co., Ltd"` vs catalogue `"Jiangsu Fuhua"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `7094.7`
+
+**EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf** (top: `rrr116` — Asphalt Shingles / Malarkey Roofing / Legacy /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf** (top: `ins004` — Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg | N.America]):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `57.6`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `99.9` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `38.3` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `32.1` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788986648.101.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.144.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.142.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"2021M10140 Registration Number EPDITALY0140"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"nor LCA practitioner."` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `280` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Vista asphalt shingles.pdf** (top: `rrr117` — Asphalt Shingles / Malarkey Roofing / Vista /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Wausau Window and Wall Systems, a part of Apogee"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"499"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf** (top: `rrr118` — Asphalt Shingles / Malarkey Roofing / Windsor /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Eternit GmbH"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"EPD-ELH-20180136-CAC1-EN"` vs catalogue `"EPD 034"`
+
+**EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf** (top: `fib001` — Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Fiber cement"`
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Equitone"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `1850`
+
+**EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-ETE-20190007-ICA1-EN"` vs catalogue `"4789365778.101.1"`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-mfr-fixes.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-mfr-fixes.md
@@ -1,0 +1,788 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:37:29.167Z
+Samples: 116 · metadata: 967/1624 (59.5%) · impacts: 563/1160 (48.5%) · by_stage: 2280/19720 (11.6%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | na | 9 | 11/14 | 7/10 | 12/170 | 688.8 | 1.15e-6 | 2.49 | 0.67374 | 25.88 | 116 | · | · | 11.6 |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | na | 9 | 11/14 | 6/10 | 9/170 | 692.65 | · | 0.15 | 0.5700000000000001 | 25.89 | 318 | · | · | 53.44 |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | na | 18 | 10/14 | 8/10 | 1/170 | 2.44 | 9.09e-5 | 4.30e-3 | 4.82e-4 | 0.038 | · | 0.0126 | 41.8 | 2.84 |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 264.52 | 1.17e-5 | 1.64 | 0.6 | 40.54 | 496.73 | 1.58 | 4146.4 | 3681.7 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 283.3 | 9.84e-6 | 29.34 | 1.49 | 0.52 | 666.43 | 1.41 | 4514.47 | 3712.72 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 333.48 | 2.76e-5 | 1.69 | 0.9 | 32.54 | 627.15 | 2.6 | 600.01 | 2008.65 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 323.38 | 1.44e-5 | 1.57 | 0.62 | 42.86 | 699.46 | 2.83 | 921.15 | 5544.68 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | na | 26 | 13/14 | 10/10 | 102/170 | 487.03 | 1.21e-5 | 2.97 | 1.55 | 54.5 | 6479.68 | 2.53 | 72.07 | 43.16 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | na | 27 | 11/14 | 10/10 | 110/170 | 267.01 | 9.40e-6 | 2.23 | 0.32 | 48.77 | 628.16 | 2.37 | 43.89 | 47.96 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | na | 8 | 11/14 | 5/10 | 8/170 | 131.07 | 4.5 | 4.42 | · | · | · | · | 1514.61 | 309.87 |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | na | 15 | 10/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | na | 15 | 10/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | na | 13 | 6/14 | 4/10 | 12/170 | 1097.6 | 7.10e-6 | 0.622 | 0.106 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | na | 15 | 12/14 | 8/10 | 15/170 | 182.61 | 15.190000000000001 | 1.23 | 0.38 | · | 1056.05 | 5.0600000000000005 | 1161.92 | 116.05 |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | na | 20 | 12/14 | 8/10 | 1/170 | 5.85 | 4.46e-8 | 0.0162 | 2.13e-3 | 0.305 | · | 0.0223 | 141 | 2.09 |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | na | 24 | 13/14 | 8/10 | 1/170 | 1.78 | 1.89e-5 | 6.11e-3 | 2.29e-3 | 0.0961 | · | 0.011 | 28.8 | 1.39 |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | na | 18 | 13/14 | 8/10 | 1/170 | 5.34 | 8.46e-8 | 0.0167 | 3.20e-3 | 0.304 | · | 0.0262 | 85.8 | 2.95 |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | na | 20 | 13/14 | 8/10 | 1/170 | 2.51 | 9.47e-6 | 8.49e-3 | 1.53e-3 | 0.147 | · | 9.94e-3 | 45.9 | 1 |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | na | 17 | 10/14 | 8/10 | 1/170 | 0.969 | 2.32e-5 | 3.27e-3 | 2.06e-3 | 0.0433 | · | 0.013 | 2.76 | 1.07 |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | na | 10 | 8/14 | 1/10 | 0/170 | · | · | · | · | · | · | 0.0665 | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | eu_ibu | 7 | 10/14 | 7/10 | 42/170 | 45.59 | 1.05e-6 | 0.109 | · | · | 660.7 | 0.172 | 700.8 | 185.47 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unknown | 45 | 3/14 | 2/10 | 0/170 | · | · | · | · | · | 158 | 4.89 | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | eu_ibu | 11 | 9/14 | 8/10 | 48/170 | 40.7 | 2.06e+6 | · | 104 | · | 284 | 11.4 | 288 | 17 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | unknown | 12 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | · | 1.06 | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | unknown | 12 | 4/14 | 7/10 | 42/170 | 100 | 7.00e-6 | 0.7 | · | · | 747 | 8 | 3900 | 77000 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | na | 14 | 12/14 | 8/10 | 20/170 | 141 | 9.69e-7 | 0.424 | 0.0294 | 5.68 | · | 0.745 | 1770 | 296 |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unknown | 12 | 2/14 | 6/10 | 10/170 | -30.9 | 5.41e-7 | · | 3.28e-3 | · | · | 0.0279 | 850 | 7600 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unknown | 10 | 3/14 | 7/10 | 10/170 | -0.22 | 2.41e-7 | · | 0.0179 | · | · | 0.0161 | 890 | 110 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | eu_ibu | 12 | 11/14 | 6/10 | 30/170 | 0.433 | 3.01e-9 | 8.27e-4 | 1.46e-4 | · | 4.3 | 0.0253 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | na | 19 | 11/14 | 8/10 | 0/170 | 6.05 | 6.79e-7 | 0.0396 | 7.26e-3 | 0.288 | 21.6 | 0.0404 | · | 4.36 |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unknown | 8 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | eu_ibu | 11 | 7/14 | 7/10 | 42/170 | -13 | 9.53e-7 | 0.0504 | · | · | 203 | 0.194 | 209 | 31800 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | eu_ibu | 7 | 7/14 | 7/10 | 56/170 | -2.74 | 4.57e-12 | 4.84e-3 | · | · | 35.68 | 0.013 | 36.82 | 59.21 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | eu_ibu | 19 | 4/14 | 3/10 | 0/170 | · | 0.00e+0 | 0.00e+0 | · | · | 0.00e+0 | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unknown | 23 | 2/14 | 4/10 | 0/170 | -730 | 1.23e-5 | · | 0.804 | · | · | 73.8 | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | eu_ibu | 18 | 10/14 | 7/10 | 63/170 | 96.3 | 1.38e-5 | · | · | · | 1600 | 1.09 | 1610 | 101 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | epd_international | 22 | 8/14 | 4/10 | 0/170 | 0.737 | · | · | · | · | 6.01 | · | 7.95 | 9.12 |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 225 | 4.14e-7 | 0.682 | 0.0593 | 9.37 | 1.02e-3 | 0.692 | 5140 | 558 |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unknown | 20 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | na | 9 | 8/14 | 7/10 | 20/170 | -1010 | · | 0.23 | 0.746 | · | 1110 | 0.413 | 1440 | 305 |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | eu_ibu | 18 | 10/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | epd_international | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | · | 7.31 | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | na | 4 | 7/14 | 1/10 | 0/170 | · | · | · | · | · | · | 8.05e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | unknown | 14 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | 44.2 | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | eu_ibu | 11 | 9/14 | 6/10 | 42/170 | -253 | 1.76e-6 | 0.412 | · | · | 1100 | · | 2160 | 3990 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | eu_ibu | 8 | 7/14 | 7/10 | 49/170 | 1.11 | 2.34e-13 | · | · | · | 31.3 | 8.40e-3 | 31.3 | 3.18 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | eu_ibu | 11 | 7/14 | 6/10 | 24/170 | 0.469 | 1.33e-11 | 1.54e-3 | · | · | 11.6 | 5.82e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | eu_ibu | 11 | 7/14 | 6/10 | 24/170 | 0.737 | 1.33e-11 | 2.50e-3 | · | · | 18.5 | 8.70e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | eu_ibu | 11 | 7/14 | 6/10 | 24/170 | 0.569 | 1.33e-11 | 2.00e-3 | · | · | 14.1 | 6.45e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | eu_ibu | 8 | 7/14 | 6/10 | 24/170 | 0.534 | 1.49e-11 | 1.47e-3 | · | · | 12.5 | 3.46e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | eu_ibu | 10 | 10/14 | 6/10 | 24/170 | 0.281 | 4.18e-12 | 1.08e-3 | · | · | 6.99 | 3.96e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | eu_ibu | 10 | 10/14 | 6/10 | 24/170 | 0.331 | 4.18e-12 | 1.28e-3 | · | · | 8.28 | 4.16e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | eu_ibu | 10 | 10/14 | 6/10 | 24/170 | 0.385 | 4.32e-12 | 1.49e-3 | · | · | 9.67 | 4.38e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 8/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | eu_ibu | 16 | 5/14 | 2/10 | 6/170 | 0.621 | · | · | · | · | · | 0.01658226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | eu_ibu | 16 | 4/14 | 2/10 | 6/170 | 0.543 | · | · | · | · | · | 0.01350226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | eu_ibu | 18 | 7/14 | 7/10 | 66/170 | 0.5285 | 3.54e-8 | · | 3.59e-4 | · | · | 7.23e-3 | 13.145 | 0.6950700000000001 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | eu_ibu | 17 | 5/14 | 7/10 | 66/170 | 0.41459999999999997 | 2.39e-8 | · | 2.93e-4 | · | · | 9.24e-3 | 10.540000000000001 | 0.59316 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | epd_international | 16 | 9/14 | 5/10 | 0/170 | 0.707 | 6.43e-8 | · | 7.29e-4 | · | 11.9 | 0.199 | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | eu_ibu | 10 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | nsf | 25 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | nsf | 30 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | na | 55 | 8/14 | 8/10 | 54/170 | 8.23e-3 | 2.65e-15 | · | 1.49e-4 | · | 10.29821 | 0.0388 | 10.298509999999998 | 0.8022100000000001 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | na | 13 | 11/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | na | 14 | 11/14 | 3/10 | 9/170 | 443.8 | · | 2.199 | 0.1674 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | eu_ibu | 6 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | na | 9 | 9/14 | 5/10 | 2/170 | 0.3 | · | · | 2.43e-4 | · | 8.61 | 2.88e-5 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | eu_ibu | 11 | 10/14 | 8/10 | 18/170 | 0.00e+0 | 1.35e+7 | 110 | 1120 | · | 0.00e+0 | 0.00e+0 | 0.00e+0 | 0.00e+0 |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | unknown | 27 | 3/14 | 4/10 | 40/170 | 7.8100000000000005 | · | · | · | 0.02286 | · | 0.027100000000000003 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | na | 17 | 8/14 | 7/10 | 12/170 | 6.7 | 1.16e-6 | 0.028359999999999996 | 9.81e-3 | 0.0898 | · | · | 72 | 1 |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | eu_ibu | 18 | 10/14 | 7/10 | 63/170 | 80 | 1.34e-5 | · | · | · | 1380 | 0.998 | 1380 | 81.2 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | na | 16 | 8/14 | 7/10 | 8/170 | 5.1 | 1.20e-7 | 0.029 | 4.00e-3 | 0.3 | · | · | 145.6 | 0.06 |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unknown | 19 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | na | 19 | 11/14 | 7/10 | 6/170 | 282 | 4.35e-7 | 0.996 | 0.0807 | 15.9 | 819 | 0.76 | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unknown | 20 | 3/14 | 2/10 | 8/170 | · | · | · | · | 0.0169 | · | 0.0213 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | eu_ibu | 10 | 7/14 | 6/10 | 24/170 | 0.535 | 9.04e-12 | 1.77e-3 | · | · | 13.4 | 6.86e-3 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | eu_ibu | 15 | 10/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | unknown | 32 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | unknown | 18 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | na | 27 | 12/14 | 5/10 | 0/170 | 3.51 | 4.49e-6 | · | 0.0996 | · | · | 3.64 | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 280 | 5.37e-7 | 0.848 | 0.0765 | 11.7 | 5970 | 0.775 | 5920 | 531 |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | na | 19 | 11/14 | 5/10 | 20/170 | 7.24 | · | 0.0226 | 2.56e-3 | · | 12.5 | 3.14e-4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | na | 20 | 11/14 | 9/10 | 0/170 | 1.2 | 9.57e-15 | 2.04e-3 | 1.97e-4 | 0.0377 | 2.16 | 4.21e-3 | 20 | 1.47 |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | eu_ibu | 8 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | eu_ibu | 8 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | epd_international | 21 | 10/14 | 6/10 | 21/170 | 0.373 | · | 1.15e-3 | 1.76e-4 | · | 3.68 | 1.61e-4 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | na | 21 | 12/14 | 3/10 | 0/170 | · | · | · | · | · | · | 3 | 1 | 0.00e+0 |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unknown | 8 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | na | 18 | 11/14 | 9/10 | 24/170 | 343 | 7.03e-7 | 1.02 | 0.0959 | 14.5 | 987 | 0.0467 | 7300 | 519 |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | na | 15 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | na | 17 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | na | 17 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | na | 17 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | na | 31 | 12/14 | 9/10 | 48/170 | 5.44 | 5.27e-7 | 0.0253 | 0.028 | 0.255 | 8.94 | 0.0371 | 71 | 1.54 |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 13.7 | 4.56e-14 | 0.0172 | 3.20e-3 | 0.437 | 228 | 6460 | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 9.32 | 4.41e-14 | 0.0111 | 2.11e-3 | 0.272 | 198 | 5920 | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | na | 47 | 11/14 | 7/10 | 44/170 | 0.4506 | 4.51e-14 | · | 3.67e-4 | · | · | 0.113 | 290.98 | 42.629999999999995 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | unknown | 10 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | na | 15 | 7/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | na | 18 | 11/14 | 9/10 | 6/170 | 299 | 5.76e-7 | 0.917 | 0.0842 | 12.4 | 906 | 1.01 | 6680 | 738 |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | na | 15 | 12/14 | 8/10 | 15/170 | 150.16 | 13.969999999999999 | 0.98 | 0.24 | · | 904.68 | 5.109999999999999 | 997.74 | 79.99 |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | na | 15 | 11/14 | 8/10 | 6/170 | 453 | · | 1.25 | 0.141 | 17.4 | 1330 | 2.39 | 9910 | 1180 |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | na | 16 | 12/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | eu_ibu | 10 | 10/14 | 7/10 | 98/170 | 11.324 | 6.59e-7 | 0.03444 | · | · | 112.57 | 0.011706999999999999 | 139.08 | 26.262999999999998 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | eu_ibu | 12 | 4/14 | 4/10 | 0/170 | -1.48e-3 | 7.81e-9 | · | 2.46e-4 | · | · | 0.289 | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | eu_ibu | 9 | 12/14 | 6/10 | 37/170 | 1.0950000000196 | 1.01e-66 | 6.20e-21 | · | · | 41.9 | 0.21474 | · | 0.6157 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | eu_ibu | 10 | 10/14 | 6/10 | 37/170 | 7.500000000019801 | 3.90e-71 | 3.09e-26 | · | · | 77.9 | 0.10596 | · | 0.905 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | 3 | · | · | · | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 3 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | 3 | · | · | 3 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | · | 8 | 8 | · | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | 5 | · | 5 | 5 | 5 | · | 5 | 5 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | 8 | · | 8 | 8 | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | 4 | · | · | 4 | 4 | · | 4 | · | 4 | · |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | 7 | 7 | 7 | · | · | · | 7 | 7 | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | 7 | 7 | 10 | · | · | · | 10 | · | 10 | 10 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | · | · | · | 1 | · | · | · | 1 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | 10 | 10 | · | · | · | 10 | · | 10 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | · | · | · | · | · | 4 | · | 4 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | 4 | · | · | 4 | 4 | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | 1 | · | · | 10 | · | · | · | 10 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | 6 | · | 6 | 6 | 6 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | 7 | · | 7 | 7 | 7 | 7 | 7 | 6 | · | · |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | 7 | 7 | 10 | · | · | · | · | · | 10 | 10 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | 14 | · | 14 | 14 | · | · | 14 | 14 | 14 | 14 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 38/116 | 33% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 11/116 | 9% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 35/116 | 30% |  |
+| 3 | `acidification_kgso2eq` — AP | 28/116 | 24% |  |
+| 4 | `eutrophication_kgneq` — EP | 39/116 | 34% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 26/116 | 22% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 42/116 | 36% |  |
+| 7 | `water_consumption_m3` — WDP | 7/116 | 6% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 11/116 | 9% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 11/116 | 9% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 3/116 | 3% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 0/116 | 0% | DEAD |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 0/116 | 0% | DEAD |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 17/116 | 15% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 1/116 | 1% | thin |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 0/116 | 0% | DEAD |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 2/116 | 2% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 0/116 | 0% | DEAD |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 0/116 | 0% | DEAD |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 0/116 | 0% | DEAD |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 0/116 | 0% | DEAD |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 0/116 | 0% | DEAD |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 29/116 | 25% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 26/116 | 22% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 24/116 | 21% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 14/116 | 12% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 24/116 | 21% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 26/116 | 22% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 24/116 | 21% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 51/116 | 44% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 87/116 | 75% |  |
+| 1 | `gwp_bio_kgco2e` | 16/116 | 14% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 64/116 | 55% |  |
+| 3 | `acidification_kgso2eq` | 84/116 | 72% |  |
+| 4 | `eutrophication_kgneq` | 74/116 | 64% |  |
+| 5 | `smog_kgo3eq` | 43/116 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 46/116 | 40% |  |
+| 7 | `water_consumption_m3` | 52/116 | 45% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 7/116 | 6% |  |
+| 9 | `primary_energy_renewable_mj` | 8/116 | 7% |  |
+| 10 | `gwp_kgco2e` | 21/116 | 18% |  |
+| 11 | `gwp_bio_kgco2e` | 8/116 | 7% |  |
+| 12 | `acidification_kgso2eq` | 14/116 | 12% |  |
+| 13 | `eutrophication_kgneq` | 4/116 | 3% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 22/116 | 19% |  |
+| 15 | `smog_kgo3eq` | 4/116 | 3% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 18/116 | 16% |  |
+| 17 | `water_consumption_m3` | 16/116 | 14% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 20/116 | 17% |  |
+| 19 | `primary_energy_renewable_mj` | 20/116 | 17% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 5/116 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 7/116 | 6% |  |
+| 2 | `acidification_kgso2eq` | 0/116 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/116 | 7% |  |
+| 4 | `smog_kgo3eq` | 0/116 | 0% | DEAD |
+| 5 | `abiotic_depletion_fossil_mj` | 0/116 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/116 | 1% | thin |
+
+## Catalogue parity check
+
+116 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 22/116 | 19% |
+| strong-multi | 12/116 | 10% |
+| medium | 10/116 | 9% |
+| medium-multi | 18/116 | 16% |
+| weak | 33/116 | 28% |
+| unmatched | 21/116 | 18% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 56 | 21 | 18 | 0 | 59% |
+| `classification.material_type` | 31 | 31 | 29 | 4 | 34% |
+| `manufacturer.name` | 28 | 37 | 28 | 2 | 30% |
+| `physical.density.value_kg_m3` | 4 | 42 | 45 | 4 | 4% |
+| `epd.id` | 43 | 26 | 24 | 2 | 46% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | weak | 40 | `bbb021` | Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm | disp(3/3) |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | strong | 90 | `osb003` | OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16" | epd.id, group |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | strong | 90 | `osb007` | OSB subflooring / LP / LP Legacy® Premium / 5/8" | epd.id, group |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | strong | 90 | `osb002` | OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side | epd.id, group |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | strong-multi | 90 | `osb004` (+1 more) | OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2" | epd.id, group |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | strong | 95 | `lp0001` | Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm) | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | strong | 120 | `lp0000` | Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm) | epd.id, disp(1/1) |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | medium | 55 | `www118` | Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | weak | 40 | `s12345` | Ground screw / American Ground Screw / AGS IM3316 / 76 x 1600 mm | mfr |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | medium-multi | 55 | `www119` (+1 more) | Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | medium-multi | 50 | `bbb012` (+4 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, group |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | strong-multi | 80 | `bbb012` (+1 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, disp(2/2) |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | medium-multi | 75 | `ccf00x` (+1 more) | Cementitious Foam / R 3.5-inch [BEAM Avg] | epd.id |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | medium | 75 | `vrs000` | Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes | epd.id |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | strong | 115 | `stu000` | Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | strong | 115 | `vin002` | Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] / R-0.5 | epd.id, mfr |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | weak | 40 | `cbi000` | Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU] | mfr |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | strong | 120 | `ae7e1c` | Cork flooring / European Resilient Flooring Manufacturers' Institute [Industry Avg \| EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | medium | 75 | `www121` | Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | strong-multi | 80 | `lcp001` (+2 more) | Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU] | epd.id |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | strong | 90 | `rrr114` | Asphalt Shingles / Malarkey Roofing / Dura-Seal / | epd.id, group |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | strong | 160 | `cel000` | Cellulose / batt / Ekovilla / Ekovilla Slab / R3.7-inch [EU] | epd.id, mfr, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | medium | 60 | `bbb031` | Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | weak | 40 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | strong | 115 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | strong | 90 | `bbb025` | Int. Wall barrier, sheet / Isover / Vario KM Duplex / Moisture-variable / EU | epd.id, group |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | strong | 80 | `bbb026` | Int. Wall barrier, sheet / Isover / Vario XTRA / Moisture-variable / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | strong-multi | 107 | `ins022` (+2 more) | Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU] | epd.id, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | weak | 30 | `676103` | EPDM Roofing Membrane / Non-reinforced single ply / SPRI  [Industry Avg \| US] | disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | strong-multi | 80 | `bbb000` (+4 more) | Int. Wall & Ceiling Barrier, sheet / Rothoblaas / Vapor In Green 200 / Non-permeable / 0.35 mm / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | strong | 95 | `www116` | Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL\|TLF, 526, AA 6400\|6500, NX-300\|3000 / Projected & casement | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | strong-multi | 115 | `s12347` (+1 more) | Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | weak | 40 | `int007` | MgO board 1/2" / Sinh Build / MAGOXX boards / 1/2" [EU] | disp(2/2) |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | medium-multi | 50 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, group |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | medium | 75 | `www114` | Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | medium-multi | 70 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, disp(2/4), group |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | strong-multi | 90 | `rrr112` (+1 more) | Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | strong-multi | 115 | `ins013` (+2 more) | Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | strong | 90 | `rrr115` | Asphalt Shingles / Malarkey Roofing / Highlander NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | strong | 120 | `lvt012` | Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm | epd.id, disp(3/4), group |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | strong | 90 | `rrr116` | Asphalt Shingles / Malarkey Roofing / Legacy / | epd.id, group |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | strong | 120 | `ins004` | Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg \| N.America] | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | strong | 90 | `rrr117` | Asphalt Shingles / Malarkey Roofing / Vista / | epd.id, group |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | strong | 90 | `rrr118` | Asphalt Shingles / Malarkey Roofing / Windsor / | epd.id, group |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | strong | 120 | `8b5828` | Window - frame only / AluQuébec / Aluminum frame / Canada | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | weak | 40 | `bbb032` | Int. Wall & Ceiling Barrier, sheet / Synwer / Syn U 120 Sd 2 / Moisture-variable / EU | mfr |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | medium | 75 | `fib001` | Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU] | epd.id |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | unmatched | 0 | — | — | — |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-539 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-540 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf** (top: `bbb021` — Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm):
+- `manufacturer.name` — candidate `"the facility located in Michigan"` vs catalogue `"Soprema"`
+
+**EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf** (top: `osb003` — OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf** (top: `osb007` — OSB subflooring / LP / LP Legacy® Premium / 5/8"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf** (top: `osb002` — OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `678.28`
+
+**EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf** (top: `osb004` — OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf** (top: `lp0001` — Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm)):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered Wood siding"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf** (top: `lp0000` — Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm)):
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf** (top: `www118` — Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf** (top: `www119` — Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf** (top: `bbb012` — Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Barrier"`
+
+**EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"National Gypsum"`
+
+**EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"several defined by the functional"` vs catalogue `"CMS"`
+
+**EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf** (top: `ccf00x` — Cementitious Foam / R 3.5-inch [BEAM Avg]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"03"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Cementitious foam"`
+- `physical.density.value_kg_m3` — candidate `70` vs catalogue `80`
+
+**EPDs to consider for v1.1 update/Airkrete spray EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"Holcim"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `130` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf** (top: `vrs000` — Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"PU Foam"`
+- `manufacturer.name` — candidate `"the facility and no allocation"` vs catalogue `"Branch"`
+- `physical.density.value_kg_m3` — candidate `214.5` vs catalogue `32.6`
+
+**EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf** (top: `stu000` — Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Cement stucco"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `1600`
+
+**EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf** (top: `vin002` — Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg | US & CA] / R-0.5):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Vinyl"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `2.53`
+
+**EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf** (top: `cbi000` — Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU]):
+- `epd.id` — candidate `"EPD-AMO-20210078-ICA1-EN"` vs catalogue `"EPD HUB-0281"`
+
+**EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf** (top: `www121` — Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Triple pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf** (top: `lcp001` — Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU]):
+- `manufacturer.name` — candidate `"TDS"` vs catalogue `"Diasen"`
+
+**EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf** (top: `rrr114` — Asphalt Shingles / Malarkey Roofing / Dura-Seal /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-DE"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf** (top: `bbb031` — Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU):
+- `epd.id` — candidate `"EPD-SIG-20220186-CBA1-EN"` vs catalogue `"EPD-SIG-20220185-CBA1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210188-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210187-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210186-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `epd.id` — candidate `"EPD-DUP-20220250-CBA1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"HDPE"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `0.058`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210189-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210184-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf** (top: `ins022` — Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU]):
+- `manufacturer.name` — candidate `"Eden Renewable Innovations Limited"` vs catalogue `"Thermafleece"`
+
+**EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"IBU"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf** (top: `www116` — Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL|TLF, 526, AA 6400|6500, NX-300|3000 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Building Product Design Ltd"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf** (top: `s12347` — Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"31"`
+- `classification.material_type` — candidate `"Steel"` vs catalogue `"Ground screw"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `5.5`
+
+**EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-075 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf** (top: `www114` — Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-074 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf** (top: `rrr112` — Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210185-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf** (top: `ins013` — Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Hemp"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `230`
+
+**EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf** (top: `rrr115` — Asphalt Shingles / Malarkey Roofing / Highlander NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790545973.103.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"the United States and Canada."` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/LECA EPD 4.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `epd.id` — candidate `"S-P-04459"` vs catalogue `"EPD10792"`
+
+**EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf** (top: `lvt012` — Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"Co., Ltd"` vs catalogue `"Jiangsu Fuhua"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `7094.7`
+
+**EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf** (top: `rrr116` — Asphalt Shingles / Malarkey Roofing / Legacy /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf** (top: `ins004` — Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg | N.America]):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `57.6`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788986648.101.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.144.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.142.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"2021M10140 Registration Number EPDITALY0140"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"nor LCA practitioner."` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `280` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Vista asphalt shingles.pdf** (top: `rrr117` — Asphalt Shingles / Malarkey Roofing / Vista /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Wausau Window and Wall Systems, a part of Apogee"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"499"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf** (top: `rrr118` — Asphalt Shingles / Malarkey Roofing / Windsor /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Eternit GmbH"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"EPD-ELH-20180136-CAC1-EN"` vs catalogue `"EPD 034"`
+
+**EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf** (top: `fib001` — Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Fiber cement"`
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Equitone"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `1850`
+
+**EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-ETE-20190007-ICA1-EN"` vs catalogue `"4789365778.101.1"`
+

--- a/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-type.md
+++ b/docs/workplans/EPD-coverage-history/2026-05-19_v1.1_post-type.md
@@ -1,0 +1,788 @@
+# EPD-Parser regression coverage matrix
+
+Run: 2026-05-19T16:58:38.270Z
+Samples: 116 · metadata: 1049/1624 (64.6%) · impacts: 563/1160 (48.5%) · by_stage: 2280/19720 (11.6%)
+
+## Per-sample coverage
+
+| Sample | Format | Pages | Meta | Impacts | by_stage | GWP | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---|---:|---:|---:|---:|---|---|---|---|---|---|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | na | 9 | 13/14 | 7/10 | 12/170 | 688.8 | 1.15e-6 | 2.49 | 0.67374 | 25.88 | 116 | · | · | 11.6 |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | na | 9 | 13/14 | 6/10 | 9/170 | 692.65 | · | 0.15 | 0.5700000000000001 | 25.89 | 318 | · | · | 53.44 |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | na | 18 | 11/14 | 8/10 | 1/170 | 2.44 | 9.09e-5 | 4.30e-3 | 4.82e-4 | 0.038 | · | 0.0126 | 41.8 | 2.84 |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 264.52 | 1.17e-5 | 1.64 | 0.6 | 40.54 | 496.73 | 1.58 | 4146.4 | 3681.7 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 283.3 | 9.84e-6 | 29.34 | 1.49 | 0.52 | 666.43 | 1.41 | 4514.47 | 3712.72 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 333.48 | 2.76e-5 | 1.69 | 0.9 | 32.54 | 627.15 | 2.6 | 600.01 | 2008.65 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | na | 23 | 12/14 | 10/10 | 110/170 | 323.38 | 1.44e-5 | 1.57 | 0.62 | 42.86 | 699.46 | 2.83 | 921.15 | 5544.68 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | na | 26 | 13/14 | 10/10 | 102/170 | 487.03 | 1.21e-5 | 2.97 | 1.55 | 54.5 | 6479.68 | 2.53 | 72.07 | 43.16 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | na | 27 | 11/14 | 10/10 | 110/170 | 267.01 | 9.40e-6 | 2.23 | 0.32 | 48.77 | 628.16 | 2.37 | 43.89 | 47.96 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | na | 8 | 13/14 | 5/10 | 8/170 | 131.07 | 4.5 | 4.42 | · | · | · | · | 1514.61 | 309.87 |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | na | 15 | 11/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | na | 15 | 11/14 | 1/10 | 5/170 | · | 1.30e-5 | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | na | 13 | 7/14 | 4/10 | 12/170 | 1097.6 | 7.10e-6 | 0.622 | 0.106 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | na | 15 | 13/14 | 8/10 | 15/170 | 182.61 | 15.190000000000001 | 1.23 | 0.38 | · | 1056.05 | 5.0600000000000005 | 1161.92 | 116.05 |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | na | 20 | 13/14 | 8/10 | 1/170 | 5.85 | 4.46e-8 | 0.0162 | 2.13e-3 | 0.305 | · | 0.0223 | 141 | 2.09 |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | na | 24 | 14/14 | 8/10 | 1/170 | 1.78 | 1.89e-5 | 6.11e-3 | 2.29e-3 | 0.0961 | · | 0.011 | 28.8 | 1.39 |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | na | 18 | 14/14 | 8/10 | 1/170 | 5.34 | 8.46e-8 | 0.0167 | 3.20e-3 | 0.304 | · | 0.0262 | 85.8 | 2.95 |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | na | 20 | 14/14 | 8/10 | 1/170 | 2.51 | 9.47e-6 | 8.49e-3 | 1.53e-3 | 0.147 | · | 9.94e-3 | 45.9 | 1 |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | na | 17 | 11/14 | 8/10 | 1/170 | 0.969 | 2.32e-5 | 3.27e-3 | 2.06e-3 | 0.0433 | · | 0.013 | 2.76 | 1.07 |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | na | 10 | 9/14 | 1/10 | 0/170 | · | · | · | · | · | · | 0.0665 | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | eu_ibu | 7 | 12/14 | 7/10 | 42/170 | 45.59 | 1.05e-6 | 0.109 | · | · | 660.7 | 0.172 | 700.8 | 185.47 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unknown | 45 | 3/14 | 2/10 | 0/170 | · | · | · | · | · | 158 | 4.89 | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | eu_ibu | 11 | 11/14 | 8/10 | 48/170 | 40.7 | 2.06e+6 | · | 104 | · | 284 | 11.4 | 288 | 17 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | unknown | 12 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | · | 1.06 | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | unknown | 12 | 4/14 | 7/10 | 42/170 | 100 | 7.00e-6 | 0.7 | · | · | 747 | 8 | 3900 | 77000 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | na | 14 | 12/14 | 8/10 | 20/170 | 141 | 9.69e-7 | 0.424 | 0.0294 | 5.68 | · | 0.745 | 1770 | 296 |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unknown | 12 | 2/14 | 6/10 | 10/170 | -30.9 | 5.41e-7 | · | 3.28e-3 | · | · | 0.0279 | 850 | 7600 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unknown | 10 | 3/14 | 7/10 | 10/170 | -0.22 | 2.41e-7 | · | 0.0179 | · | · | 0.0161 | 890 | 110 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | eu_ibu | 12 | 13/14 | 6/10 | 30/170 | 0.433 | 3.01e-9 | 8.27e-4 | 1.46e-4 | · | 4.3 | 0.0253 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | na | 19 | 11/14 | 8/10 | 0/170 | 6.05 | 6.79e-7 | 0.0396 | 7.26e-3 | 0.288 | 21.6 | 0.0404 | · | 4.36 |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unknown | 12 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unknown | 8 | 3/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | eu_ibu | 11 | 9/14 | 7/10 | 42/170 | -13 | 9.53e-7 | 0.0504 | · | · | 203 | 0.194 | 209 | 31800 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | eu_ibu | 7 | 9/14 | 7/10 | 56/170 | -2.74 | 4.57e-12 | 4.84e-3 | · | · | 35.68 | 0.013 | 36.82 | 59.21 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | eu_ibu | 19 | 4/14 | 3/10 | 0/170 | · | 0.00e+0 | 0.00e+0 | · | · | 0.00e+0 | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unknown | 23 | 2/14 | 4/10 | 0/170 | -730 | 1.23e-5 | · | 0.804 | · | · | 73.8 | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 96.3 | 1.38e-5 | · | · | · | 1600 | 1.09 | 1610 | 101 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | epd_international | 22 | 8/14 | 4/10 | 0/170 | 0.737 | · | · | · | · | 6.01 | · | 7.95 | 9.12 |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 225 | 4.14e-7 | 0.682 | 0.0593 | 9.37 | 1.02e-3 | 0.692 | 5140 | 558 |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unknown | 20 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | na | 9 | 10/14 | 7/10 | 20/170 | -1010 | · | 0.23 | 0.746 | · | 1110 | 0.413 | 1440 | 305 |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | epd_international | 12 | 11/14 | 1/10 | 0/170 | · | · | · | · | · | · | 7.31 | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | na | 4 | 7/14 | 1/10 | 0/170 | · | · | · | · | · | · | 8.05e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | unknown | 14 | 5/14 | 1/10 | 0/170 | · | · | · | · | · | 44.2 | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unknown | 18 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | eu_ibu | 11 | 11/14 | 6/10 | 42/170 | -253 | 1.76e-6 | 0.412 | · | · | 1100 | · | 2160 | 3990 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | eu_ibu | 8 | 9/14 | 7/10 | 49/170 | 1.11 | 2.34e-13 | · | · | · | 31.3 | 8.40e-3 | 31.3 | 3.18 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.469 | 1.33e-11 | 1.54e-3 | · | · | 11.6 | 5.82e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.737 | 1.33e-11 | 2.50e-3 | · | · | 18.5 | 8.70e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | eu_ibu | 11 | 9/14 | 6/10 | 24/170 | 0.569 | 1.33e-11 | 2.00e-3 | · | · | 14.1 | 6.45e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | eu_ibu | 8 | 9/14 | 6/10 | 24/170 | 0.534 | 1.49e-11 | 1.47e-3 | · | · | 12.5 | 3.46e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.281 | 4.18e-12 | 1.08e-3 | · | · | 6.99 | 3.96e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.331 | 4.18e-12 | 1.28e-3 | · | · | 8.28 | 4.16e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | eu_ibu | 10 | 12/14 | 6/10 | 24/170 | 0.385 | 4.32e-12 | 1.49e-3 | · | · | 9.67 | 4.38e-3 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | na | 26 | 9/14 | 2/10 | 0/170 | · | · | 3 | · | · | · | · | · | 3 |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | eu_ibu | 16 | 5/14 | 2/10 | 6/170 | 0.621 | · | · | · | · | · | 0.01658226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | eu_ibu | 16 | 4/14 | 2/10 | 6/170 | 0.543 | · | · | · | · | · | 0.01350226 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | eu_ibu | 18 | 7/14 | 7/10 | 66/170 | 0.5285 | 3.54e-8 | · | 3.59e-4 | · | · | 7.23e-3 | 13.145 | 0.6950700000000001 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | eu_ibu | 17 | 5/14 | 7/10 | 66/170 | 0.41459999999999997 | 2.39e-8 | · | 2.93e-4 | · | · | 9.24e-3 | 10.540000000000001 | 0.59316 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | epd_international | 16 | 9/14 | 5/10 | 0/170 | 0.707 | 6.43e-8 | · | 7.29e-4 | · | 11.9 | 0.199 | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | eu_ibu | 10 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | nsf | 25 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | nsf | 30 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | na | 55 | 9/14 | 8/10 | 54/170 | 8.23e-3 | 2.65e-15 | · | 1.49e-4 | · | 10.29821 | 0.0388 | 10.298509999999998 | 0.8022100000000001 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | na | 13 | 12/14 | 3/10 | 9/170 | 375.8 | · | 1.8399999999999999 | 0.1428 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | na | 14 | 12/14 | 3/10 | 9/170 | 443.8 | · | 2.199 | 0.1674 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | eu_ibu | 6 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | na | 9 | 9/14 | 5/10 | 2/170 | 0.3 | · | · | 2.43e-4 | · | 8.61 | 2.88e-5 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | eu_ibu | 11 | 12/14 | 8/10 | 18/170 | 0.00e+0 | 1.35e+7 | 110 | 1120 | · | 0.00e+0 | 0.00e+0 | 0.00e+0 | 0.00e+0 |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | unknown | 27 | 3/14 | 4/10 | 40/170 | 7.8100000000000005 | · | · | · | 0.02286 | · | 0.027100000000000003 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | na | 17 | 11/14 | 7/10 | 12/170 | 6.7 | 1.16e-6 | 0.028359999999999996 | 9.81e-3 | 0.0898 | · | · | 72 | 1 |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | eu_ibu | 18 | 12/14 | 7/10 | 63/170 | 80 | 1.34e-5 | · | · | · | 1380 | 0.998 | 1380 | 81.2 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | na | 16 | 11/14 | 7/10 | 8/170 | 5.1 | 1.20e-7 | 0.029 | 4.00e-3 | 0.3 | · | · | 145.6 | 0.06 |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unknown | 19 | 2/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | na | 19 | 11/14 | 7/10 | 6/170 | 282 | 4.35e-7 | 0.996 | 0.0807 | 15.9 | 819 | 0.76 | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unknown | 20 | 3/14 | 2/10 | 8/170 | · | · | · | · | 0.0169 | · | 0.0213 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | eu_ibu | 10 | 9/14 | 6/10 | 24/170 | 0.535 | 9.04e-12 | 1.77e-3 | · | · | 13.4 | 6.86e-3 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | eu_ibu | 15 | 12/14 | 7/10 | 63/170 | 158 | 1.05e-5 | 0.825 | · | · | 2400 | 0.553 | 2920 | 152 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | na | 17 | 11/14 | 9/10 | 0/170 | 2340 | 4.42e-8 | 4.73 | 0.25 | 82.1 | 1890 | 11.2 | 28800 | 1630 |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | na | 18 | 11/14 | 9/10 | 0/170 | 2380 | 1.50e-7 | 5.23 | 0.261 | 84.2 | 1910 | 11.1 | 29200 | 1550 |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | unknown | 32 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | unknown | 18 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | epd_international | 18 | 11/14 | 3/10 | 11/170 | · | · | 4.15e-3 | 3.90e-3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | na | 27 | 12/14 | 5/10 | 0/170 | 3.51 | 4.49e-6 | · | 0.0996 | · | · | 3.64 | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | na | 19 | 11/14 | 9/10 | 0/170 | 280 | 5.37e-7 | 0.848 | 0.0765 | 11.7 | 5970 | 0.775 | 5920 | 531 |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | na | 19 | 12/14 | 5/10 | 20/170 | 7.24 | · | 0.0226 | 2.56e-3 | · | 12.5 | 3.14e-4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | na | 20 | 12/14 | 9/10 | 0/170 | 1.2 | 9.57e-15 | 2.04e-3 | 1.97e-4 | 0.0377 | 2.16 | 4.21e-3 | 20 | 1.47 |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | eu_ibu | 8 | 5/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | eu_ibu | 8 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | eu_ibu | 8 | 6/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | epd_international | 21 | 10/14 | 6/10 | 21/170 | 0.373 | · | 1.15e-3 | 1.76e-4 | · | 3.68 | 1.61e-4 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | na | 21 | 12/14 | 3/10 | 0/170 | · | · | · | · | · | · | 3 | 1 | 0.00e+0 |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unknown | 8 | 0/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | na | 18 | 11/14 | 9/10 | 24/170 | 343 | 7.03e-7 | 1.02 | 0.0959 | 14.5 | 987 | 0.0467 | 7300 | 519 |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | na | 15 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | na | 17 | 10/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | na | 31 | 12/14 | 9/10 | 48/170 | 5.44 | 5.27e-7 | 0.0253 | 0.028 | 0.255 | 8.94 | 0.0371 | 71 | 1.54 |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 13.7 | 4.56e-14 | 0.0172 | 3.20e-3 | 0.437 | 228 | 6460 | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | na | 15 | 11/14 | 7/10 | 0/170 | 9.32 | 4.41e-14 | 0.0111 | 2.11e-3 | 0.272 | 198 | 5920 | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | na | 47 | 12/14 | 7/10 | 44/170 | 0.4506 | 4.51e-14 | · | 3.67e-4 | · | · | 0.113 | 290.98 | 42.629999999999995 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | unknown | 10 | 4/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | na | 15 | 9/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | na | 18 | 11/14 | 9/10 | 6/170 | 299 | 5.76e-7 | 0.917 | 0.0842 | 12.4 | 906 | 1.01 | 6680 | 738 |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | na | 15 | 13/14 | 8/10 | 15/170 | 150.16 | 13.969999999999999 | 0.98 | 0.24 | · | 904.68 | 5.109999999999999 | 997.74 | 79.99 |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | na | 15 | 11/14 | 8/10 | 6/170 | 453 | · | 1.25 | 0.141 | 17.4 | 1330 | 2.39 | 9910 | 1180 |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | na | 16 | 12/14 | 0/10 | 0/170 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | eu_ibu | 10 | 12/14 | 7/10 | 98/170 | 11.324 | 6.59e-7 | 0.03444 | · | · | 112.57 | 0.011706999999999999 | 139.08 | 26.262999999999998 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | eu_ibu | 12 | 4/14 | 4/10 | 0/170 | -1.48e-3 | 7.81e-9 | · | 2.46e-4 | · | · | 0.289 | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | eu_ibu | 9 | 12/14 | 6/10 | 37/170 | 1.0950000000196 | 1.01e-66 | 6.20e-21 | · | · | 41.9 | 0.21474 | · | 0.6157 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | eu_ibu | 10 | 12/14 | 6/10 | 37/170 | 7.500000000019801 | 3.90e-71 | 3.09e-26 | · | · | 77.9 | 0.10596 | · | 0.905 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | na | 15 | 8/14 | 5/10 | 24/170 | 2.1 | 2.1 | 2.1 | 2.1 | · | · | 0.683 | · | · |
+
+## Per-stage matrix population (by indicator × sample)
+
+Each cell = number of populated stage cells out of 17 (A1, A2, A3, A4, A5, B1..B7, C1..C4, D).
+
+| Sample | GWP | GWP-bio | ODP | AP | EP | SFP | ADPf | WDP | PE-NR | PE-R |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | 3 | · | · | 3 | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | 3 | · | · | · | 3 | 3 | · | · | · | · |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 3 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | 3 | · | · | 3 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | 2 | · | 1 | 1 | 1 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | 1 | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | · | 8 | 8 | · | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | 4 | · | 4 | 4 | 4 | 4 | · | · | · | · |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | · | · | · | · | · | · | · | · | 5 | 5 |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | 5 | · | 5 | 5 | 5 | · | 5 | 5 | · | · |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | 6 | · | 6 | 6 | · | · | 6 | 6 | 6 | 6 |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | 8 | · | 8 | 8 | · | · | 8 | 8 | 8 | 8 |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | 4 | · | · | 4 | 4 | · | 4 | · | 4 | · |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | 7 | · | 7 | 7 | · | · | 7 | · | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | 7 | 7 | 7 | · | · | · | 7 | 7 | 7 | 7 |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | · | · | · | · | · | · | · | 6 | · | · |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | 11 | 11 | 11 | · | · | · | · | 11 | 11 | 11 |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | 7 | 7 | 10 | · | · | · | 10 | · | 10 | 10 |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | 3 | · | · | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | · | · | · | 1 | · | · | · | 1 | · | · |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | 3 | · | 3 | 3 | 3 | · | 3 | 3 | · | · |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | 10 | 10 | · | · | · | 10 | · | 10 | · | · |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | 3 | · | 3 | 3 | 3 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | 9 | 9 | 9 | · | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | 2 | · | 2 | 2 | 2 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | · | · | · | · | · | 4 | · | 4 | · | · |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | 4 | 4 | 4 | 4 | · | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | 9 | · | 9 | 9 | · | · | 9 | 9 | 9 | 9 |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | · | 3 | · | 4 | 4 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | 4 | · | · | 4 | 4 | · | 4 | 4 | · | · |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | 1 | · | · | 10 | · | · | · | 10 | · | · |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | 6 | · | 6 | 6 | 6 | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | 7 | · | 7 | 7 | 7 | 7 | 7 | 6 | · | · |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | 7 | 7 | 10 | · | · | · | · | · | 10 | 10 |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | 3 | · | 3 | 3 | 3 | · | · | 3 | · | · |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | · | · | · | 6 | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | 14 | · | 14 | 14 | · | · | 14 | 14 | 14 | 14 |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | · | · | · | · | · | · | · | · | · | · |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | 5 | · | 8 | 8 | · | · | 1 | 8 | 1 | 6 |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | 5 | · | 5 | 5 | 5 | · | · | 4 | · | · |
+
+## Per-pattern hit count — IMPACT_INDICATORS
+
+30 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` — GWP-fossil/total | 38/116 | 33% |  |
+| 1 | `gwp_bio_kgco2e` — GWP-biogenic | 11/116 | 9% |  |
+| 2 | `ozone_depletion_kgcfc11eq` — ODP | 35/116 | 30% |  |
+| 3 | `acidification_kgso2eq` — AP | 28/116 | 24% |  |
+| 4 | `eutrophication_kgneq` — EP | 39/116 | 34% |  |
+| 5 | `smog_kgo3eq` — POCP/SFP | 26/116 | 22% |  |
+| 6 | `abiotic_depletion_fossil_mj` — ADP-fossil | 42/116 | 36% |  |
+| 7 | `water_consumption_m3` — WDP | 7/116 | 6% |  |
+| 8 | `primary_energy_nonrenewable_mj` — PE-NR | 11/116 | 9% |  |
+| 9 | `primary_energy_renewable_mj` — PE-R | 11/116 | 9% |  |
+| 10 | `gwp_kgco2e` — GWP (English) | 3/116 | 3% |  |
+| 11 | `gwp_bio_kgco2e` — GWP-Biogenic (English em-dash) | 0/116 | 0% | DEAD |
+| 12 | `ozone_depletion_kgcfc11eq` — ODP (English) | 0/116 | 0% | DEAD |
+| 13 | `ozone_depletion_kgcfc11eq` — ODP (English label-only — wrapped unit) | 17/116 | 15% |  |
+| 14 | `eutrophication_kgneq` — EP (English) | 1/116 | 1% | thin |
+| 15 | `water_consumption_m3` — WDP (English Consumption of freshwater) | 0/116 | 0% | DEAD |
+| 16 | `acidification_kgso2eq` — AP (English long phrase) | 2/116 | 2% |  |
+| 17 | `smog_kgo3eq` — SFP (English Smog potential) | 0/116 | 0% | DEAD |
+| 18 | `smog_kgo3eq` — SFP (English Formation potential) | 0/116 | 0% | DEAD |
+| 19 | `abiotic_depletion_fossil_mj` — ADPf (English parenthetical) | 0/116 | 0% | DEAD |
+| 20 | `primary_energy_nonrenewable_mj` — PE-NR (English fossil) | 0/116 | 0% | DEAD |
+| 21 | `primary_energy_renewable_mj` — PE-R (English biomass) | 0/116 | 0% | DEAD |
+| 22 | `gwp_kgco2e` — GWP (EU/IBU bracketed) | 29/116 | 25% |  |
+| 23 | `ozone_depletion_kgcfc11eq` — ODP (EU/IBU long phrase) | 26/116 | 22% |  |
+| 24 | `acidification_kgso2eq` — AP (EU/IBU bracketed) | 24/116 | 21% |  |
+| 25 | `abiotic_depletion_fossil_mj` — ADPf (EU/IBU long phrase) | 14/116 | 12% |  |
+| 26 | `water_consumption_m3` — WDP (EU/IBU fresh-water phrase) | 24/116 | 21% |  |
+| 27 | `primary_energy_renewable_mj` — PE-R (RPR E / ISO 21930) | 26/116 | 22% |  |
+| 28 | `primary_energy_nonrenewable_mj` — PE-NR (NRPR E / ISO 21930) | 24/116 | 21% |  |
+| 29 | `water_consumption_m3` — WDP (FW / ISO 21930) | 51/116 | 44% |  |
+
+## Per-pattern hit count — _BYSTAGE_LABELS
+
+20 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 87/116 | 75% |  |
+| 1 | `gwp_bio_kgco2e` | 16/116 | 14% |  |
+| 2 | `ozone_depletion_kgcfc11eq` | 64/116 | 55% |  |
+| 3 | `acidification_kgso2eq` | 84/116 | 72% |  |
+| 4 | `eutrophication_kgneq` | 74/116 | 64% |  |
+| 5 | `smog_kgo3eq` | 43/116 | 37% |  |
+| 6 | `abiotic_depletion_fossil_mj` | 46/116 | 40% |  |
+| 7 | `water_consumption_m3` | 52/116 | 45% |  |
+| 8 | `primary_energy_nonrenewable_mj` | 7/116 | 6% |  |
+| 9 | `primary_energy_renewable_mj` | 8/116 | 7% |  |
+| 10 | `gwp_kgco2e` | 21/116 | 18% |  |
+| 11 | `gwp_bio_kgco2e` | 8/116 | 7% |  |
+| 12 | `acidification_kgso2eq` | 14/116 | 12% |  |
+| 13 | `eutrophication_kgneq` | 4/116 | 3% |  |
+| 14 | `ozone_depletion_kgcfc11eq` | 22/116 | 19% |  |
+| 15 | `smog_kgo3eq` | 4/116 | 3% |  |
+| 16 | `abiotic_depletion_fossil_mj` | 18/116 | 16% |  |
+| 17 | `water_consumption_m3` | 16/116 | 14% |  |
+| 18 | `primary_energy_nonrenewable_mj` | 20/116 | 17% |  |
+| 19 | `primary_energy_renewable_mj` | 20/116 | 17% |  |
+
+## Per-pattern hit count — _CISC_LABEL_PATTERNS
+
+7 patterns × 116 samples. `DEAD` = 0 hits, deprecation candidate.
+
+| # | Key / label | Hits | % | Status |
+|---:|---|---:|---:|---|
+| 0 | `gwp_kgco2e` | 5/116 | 4% |  |
+| 1 | `ozone_depletion_kgcfc11eq` | 7/116 | 6% |  |
+| 2 | `acidification_kgso2eq` | 0/116 | 0% | DEAD |
+| 3 | `eutrophication_kgneq` | 8/116 | 7% |  |
+| 4 | `smog_kgo3eq` | 0/116 | 0% | DEAD |
+| 5 | `abiotic_depletion_fossil_mj` | 0/116 | 0% | DEAD |
+| 6 | `water_consumption_m3` | 1/116 | 1% | thin |
+
+## Catalogue parity check
+
+116 candidates × 821 catalogue records.
+
+| Category | Count | % |
+|---|---:|---:|
+| strong | 22/116 | 19% |
+| strong-multi | 12/116 | 10% |
+| medium | 10/116 | 9% |
+| medium-multi | 18/116 | 16% |
+| weak | 33/116 | 28% |
+| unmatched | 21/116 | 18% |
+
+### Field diff on matched samples
+
+Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.
+
+| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |
+|---|---:|---:|---:|---:|---:|
+| `classification.group_prefix` | 56 | 21 | 18 | 0 | 59% |
+| `classification.material_type` | 31 | 31 | 29 | 4 | 34% |
+| `manufacturer.name` | 28 | 37 | 28 | 2 | 30% |
+| `physical.density.value_kg_m3` | 4 | 42 | 45 | 4 | 4% |
+| `epd.id` | 43 | 26 | 24 | 2 | 46% |
+
+### Per-sample top match
+
+| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |
+|---|---|---:|---|---|---|
+| EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf | strong-multi | 87 | `bri001` (+1 more) | Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | mfr, disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf | weak | 40 | `bbb021` | Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm | disp(3/3) |
+| EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf | strong | 90 | `osb003` | OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16" | epd.id, group |
+| EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf | strong | 90 | `osb007` | OSB subflooring / LP / LP Legacy® Premium / 5/8" | epd.id, group |
+| EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf | strong | 90 | `osb002` | OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side | epd.id, group |
+| EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf | strong-multi | 90 | `osb004` (+1 more) | OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2" | epd.id, group |
+| EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf | strong | 95 | `lp0001` | Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm) | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf | strong | 120 | `lp0000` | Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm) | epd.id, disp(1/1) |
+| EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf | medium | 55 | `www118` | Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf | medium-multi | 75 | `lp000x` (+4 more) | Engineered Wood Siding [BEAM Avg \| US & CA] | mfr, disp(3/3) |
+| EPDs to consider for v1.1 update/926.ASTM Helical Pier AGS EPD_Final_12.05.2023.pdf | weak | 40 | `s12345` | Ground screw / American Ground Screw / AGS IM3316 / 76 x 1600 mm | mfr |
+| EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf | medium-multi | 55 | `www119` (+1 more) | Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf | medium-multi | 50 | `bbb012` (+4 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, group |
+| EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/987.EPD_report_SOPRASEAL_STICK_VP.pdf | strong-multi | 80 | `bbb012` (+1 more) | Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm | mfr, disp(2/2) |
+| EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf | medium-multi | 75 | `ccf00x` (+1 more) | Cementitious Foam / R 3.5-inch [BEAM Avg] | epd.id |
+| EPDs to consider for v1.1 update/Airkrete insulation EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Airkrete spray EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Bamboo Plywood.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/Biogas brick EPD.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf | medium | 75 | `vrs000` | Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes | epd.id |
+| EPDs to consider for v1.1 update/Burnt wood ReUse cladding EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/BurntWood-EPD-2023.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf | strong | 115 | `stu000` | Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf | strong | 115 | `vin002` | Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg \| US & CA] / R-0.5 | epd.id, mfr |
+| EPDs to consider for v1.1 update/Clay roof tiles EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Clay roof tiles Germany EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf | weak | 40 | `cbi000` | Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU] | mfr |
+| EPDs to consider for v1.1 update/Cork floor tiles according to EN 12104.pdf | strong | 120 | `ae7e1c` | Cork flooring / European Resilient Flooring Manufacturers' Institute [Industry Avg \| EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Corques Liquid Lino EPD by 3rd party 28-01-2019 long version.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/DAP-GlobalEPD-EN15804-036_Honext-boards-1.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf | medium | 75 | `www121` | Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf | strong-multi | 80 | `lcp001` (+2 more) | Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU] | epd.id |
+| EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf | strong | 90 | `rrr114` | Asphalt Shingles / Malarkey Roofing / Dura-Seal / | epd.id, group |
+| EPDs to consider for v1.1 update/EArth block EPD France.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD 993.Biochar_SolidCarbon_EPD_20230625.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Ekovilla cellulose batt.pdf | strong | 160 | `cel000` | Cellulose / batt / Ekovilla / Ekovilla Slab / R3.7-inch [EU] | epd.id, mfr, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Greenfiber Cellullose AGGF_SANCTUARY_allpages.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD Isover barrier .pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Isover barrier UK_.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD PAVATEX Dry process wood fibre insulation 110-200 kgm.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf | medium | 60 | `bbb031` | Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU | mfr, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf | weak | 40 | `c630d2` | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf | strong | 115 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf | medium-multi | 50 | `c630d2` (+4 more) | Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch | mfr, group |
+| EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf | medium-multi | 75 | `a23458` (+1 more) | Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch | epd.id |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-KM-DUPLEX-UV.pdf.pdf | strong | 90 | `bbb025` | Int. Wall barrier, sheet / Isover / Vario KM Duplex / Moisture-variable / EU | epd.id, group |
+| EPDs to consider for v1.1 update/EPD-Isover-Ireland-VARIO-XTRA.pdf.pdf | strong | 80 | `bbb026` | Int. Wall barrier, sheet / Isover / Vario XTRA / Moisture-variable / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD-Partel-Vapour-Control-Membranes-18-07-2022-EPDIE-22-83.pdf | unmatched | 10 | — | — | — |
+| EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf | strong-multi | 107 | `ins022` (+2 more) | Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU] | epd.id, disp(2/3) |
+| EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD10568 Carlisle air barrier.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/EPD10572 Carlisle air barriers.pdf | weak | 30 | `676103` | EPDM Roofing Membrane / Non-reinforced single ply / SPRI  [Industry Avg \| US] | disp(1/2), group |
+| EPDs to consider for v1.1 update/EPD2-19-07-2021-v2 rothoblass.pdf | strong-multi | 80 | `bbb000` (+4 more) | Int. Wall & Ceiling Barrier, sheet / Rothoblaas / Vapor In Green 200 / Non-permeable / 0.35 mm / EU | epd.id |
+| EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf | strong | 95 | `www115` | Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400\|6500\|6600 / Hung & sliding | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf | strong | 95 | `www116` | Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL\|TLF, 526, AA 6400\|6500, NX-300\|3000 / Projected & casement | epd.id, disp(1/2) |
+| EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf | weak | 40 | `bri005` | Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf | medium-multi | 60 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(3/3), group, mat |
+| EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf | strong-multi | 115 | `s12347` (+1 more) | Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/EPD_Magoxx MGO board.pdf | weak | 40 | `int007` | MgO board 1/2" / Sinh Build / MAGOXX boards / 1/2" [EU] | disp(2/2) |
+| EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf | medium-multi | 50 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, group |
+| EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf | medium | 75 | `www114` | Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg \| EU] | epd.id |
+| EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf | medium-multi | 70 | `bbb011` (+4 more) | Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm | mfr, disp(2/4), group |
+| EPDs to consider for v1.1 update/Earth block EPD non load bearing.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf | strong-multi | 90 | `rrr112` (+1 more) | Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Ekopanely straw board EPD NOT 3rd PARTY VERIFIED.pdf | unmatched | 20 | — | — | — |
+| EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf | medium | 67 | `bbb009` | Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU | mfr, disp(2/3) |
+| EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf | weak | 40 | `mps000` | Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Framing, Traklock steel framing EPD.pdf | strong-multi | 120 | `e923k2` (+4 more) | Cold-formed steel floor joist assembly / ClarkDietrich / 12" o.c. spacing, 8" height, 18g (Joist: 800S162-43, Rim: 800S125-43) | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf | medium-multi | 50 | `ins041` (+4 more) | Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch | disp(3/4), group, mat |
+| EPDs to consider for v1.1 update/Gramitherm insulation EPD.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf | strong-multi | 90 | `hemp0x` (+1 more) | Hemp Fiber Batt / R 3.6-inch [BEAM Avg] | epd.id, group |
+| EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf | strong-multi | 115 | `ins013` (+2 more) | Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU] | epd.id, mfr |
+| EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf | strong | 90 | `rrr115` | Asphalt Shingles / Malarkey Roofing / Highlander NEX / | epd.id, group |
+| EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf | weak | 40 | `f03m68` | Fiberglass batt / R 3.6-inch [BEAM Avg] | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/LECA EPD 1.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 2.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 3.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/LECA EPD 4.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf | weak | 40 | `int000` | Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2" | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf | strong | 120 | `lvt012` | Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm | epd.id, disp(3/4), group |
+| EPDs to consider for v1.1 update/Majrex - EPD.pdf | unmatched | 0 | — | — | — |
+| EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf | strong | 90 | `rrr116` | Asphalt Shingles / Malarkey Roofing / Legacy / | epd.id, group |
+| EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf | strong | 120 | `ins004` | Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg \| N.America] | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf | weak | 47 | `4ld02f` | Mineral wool batt / [BEAM Avg] | disp(2/3), group, mat |
+| EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf | medium-multi | 50 | `ewf001` (+2 more) | Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm | disp(2/2), group |
+| EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/SIP-Specification-12Jan2021-2.pdf | medium-multi | 50 | `8ad79d` (+3 more) | TREATED WOOD FOUNDATION - 2x8 framing @ 16" OC, 3/4" plywood sheathing | disp(2/2), group |
+| EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf | weak | 40 | `967ad6` | Cellulose / batt / CMS / EcoCell / R 3.6-inch | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Vista asphalt shingles.pdf | strong | 90 | `rrr117` | Asphalt Shingles / Malarkey Roofing / Vista / | epd.id, group |
+| EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf | strong | 90 | `rrr118` | Asphalt Shingles / Malarkey Roofing / Windsor / | epd.id, group |
+| EPDs to consider for v1.1 update/dokumen.tips_environmental-product-declaration-aluminium-windows.pdf | strong | 120 | `8b5828` | Window - frame only / AluQuébec / Aluminum frame / Canada | epd.id, disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf | weak | 37 | `e0e76c` | Masonry Cement / Portland Cement Association [Industry Avg \| US & CA] | disp(2/3), group |
+| EPDs to consider for v1.1 update/epd Synwer barrier.pdf | weak | 40 | `bbb032` | Int. Wall & Ceiling Barrier, sheet / Synwer / Syn U 120 Sd 2 / Moisture-variable / EU | mfr |
+| EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf | medium | 75 | `fib001` | Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU] | epd.id |
+| EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf | weak | 40 | `mpa000` | Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge | disp(1/2), group, mat |
+| EPDs to consider for v1.1 update/tectum-epd 2022.pdf | unmatched | 0 | — | — | — |
+
+### Divergence detail (matched samples with at least one differing field)
+
+**EPDs to consider for v1.1 update/1012.MutualMaterialsClayBrickandClayBrickPavers_MicaWA.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-539 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1013.MutualMaterialsClayBrickandClayBrickPavers_GreshamOR.pdf** (top: `bri001` — Brick, Clay / Mutual Materials / Avg Face Brick (plant Avg) /  3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `960` vs catalogue `269`
+- `epd.id` — candidate `"EPD-540 Page"` vs catalogue `"EPD-540, EPD-539"`
+
+**EPDs to consider for v1.1 update/1014.EPD_report_SOPRASEAL_LM_204_VP.pdf** (top: `bbb021` — Ext. Wall Barrier, liquid applied / Soprema / SOPRASEAL LM 204 VP / 10-17 Perms / 0.6 mm):
+- `manufacturer.name` — candidate `"the facility located in Michigan"` vs catalogue `"Soprema"`
+
+**EPDs to consider for v1.1 update/1020.LP_Structural_Solutions_EPD-TopNotch350.pdf** (top: `osb003` — OSB sheathing / 7/16" / LP / TopNotch® 350 / 7/16"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1021.LP_Structural_Solutions_EPD-Legacy.pdf** (top: `osb007` — OSB subflooring / LP / LP Legacy® Premium / 5/8"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `662`
+
+**EPDs to consider for v1.1 update/1022.LP_Structural_Solutions_EPD-FlameBlock.pdf** (top: `osb002` — OSB sheathing / 7/16" / LP / FlameBlock® Fire-Rated / 7/16", coated 1 side):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `678.28`
+
+**EPDs to consider for v1.1 update/1023.LP_Structural_Solutions_EPD-WeatherLogic.pdf** (top: `osb004` — OSB sheathing / 1/2" / LP / WeatherLogic® Air & Water Barrier / 1/2"):
+- `manufacturer.name` — candidate `"Nashville, Tennessee USA"` vs catalogue `"LP"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `765`
+
+**EPDs to consider for v1.1 update/1067.LP_ExpertFinish_EPD.pdf** (top: `lp0001` — Engineered Wood Siding & Trim / LP / SmartSide ExpertFinish/ 3/8" (9.5 mm)):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered Wood siding"`
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/1068.LP_BuilderSeries_EPD.pdf** (top: `lp0000` — Engineered Wood Siding & Trim / LP / BuilderSeries® Lap Siding / 9/32" (7.3 mm)):
+- `manufacturer.name` — candidate `"Nashville, TN 37219 USA"` vs catalogue `"LP"`
+
+**EPDs to consider for v1.1 update/637.EPD_for_Arcadia_Projected_windows_12April2021.pdf** (top: `www118` — Window, double-glazed, aluminum frame / Arcadia / CV200, T200 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/873.E5_CLT_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/874.E5_Glulam_EPD.pdf** (top: `lp000x` — Engineered Wood Siding [BEAM Avg | US & CA]):
+- `classification.group_prefix` — candidate `"06"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Engineered wood"` vs catalogue `"Engineered Wood siding"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `654.554`
+
+**EPDs to consider for v1.1 update/955.EFCO_Fixed_Projected_Casement_Hung_Sliding_Window_EPD.pdf** (top: `www119` — Window, double-glazed, aluminum frame / EFCO / Xtherm, 5FXT, FX45, 6615, 6621, 6715, FX32, OG32, OG45 / Fixed):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+
+**EPDs to consider for v1.1 update/983.EPD_report_SOPRASEAL_LM_200 S_200 T_204_VP.pdf** (top: `bbb012` — Ext. Wall Barrier, adhesive / Soprema / SOPRASEAL STICK 1100 T / Non-permeable / 1.0 mm):
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Barrier"`
+
+**EPDs to consider for v1.1 update/984.EPD _SOPRASEAL_STICK_1100 T_SOPRASOLIN HD_SOPRAVAPR.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/985.EPD_report_SOPRASEAL_XPRESS_G.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"National Gypsum"`
+
+**EPDs to consider for v1.1 update/986.EPD_report_SOPRASEAL_STICK_130_130 S_SOPRASEAL 60_60 FF.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"mixing the appropriate proportions of"` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/AFT Cellulose EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"several defined by the functional"` vs catalogue `"CMS"`
+
+**EPDs to consider for v1.1 update/Airkrete insulation EPD 2.pdf** (top: `ccf00x` — Cementitious Foam / R 3.5-inch [BEAM Avg]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"03"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Cementitious foam"`
+- `physical.density.value_kg_m3` — candidate `70` vs catalogue `80`
+
+**EPDs to consider for v1.1 update/Airkrete spray EPD.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"Holcim"` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `130` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Branchclad stucco rainscreen system EPD.pdf** (top: `vrs000` — Ventilated rainscreen system / Branch / BranchClad Stucco / R1.3 / 6" / Avg. of all finishes):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"PU Foam"`
+- `manufacturer.name` — candidate `"the facility and no allocation"` vs catalogue `"Branch"`
+- `physical.density.value_kg_m3` — candidate `214.5` vs catalogue `32.6`
+
+**EPDs to consider for v1.1 update/Cement plaster Germany EPD.pdf** (top: `stu000` — Cement "Stucco" Plaster / Sto SE / Pre-mixed rendering & plastering mortar with reinforcing fiber / 1/2" [EU]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Cement stucco"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `1600`
+
+**EPDs to consider for v1.1 update/Cladding (insulation) 820.InsulatedVinylSiding_VSI.pdf** (top: `vin002` — Insulated Vinyl Siding / Vinyl Siding Institute / 0.040" Double 4.5" [Industry Avg | US & CA] / R-0.5):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Vinyl"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `2.53`
+
+**EPDs to consider for v1.1 update/Cork Flooring Floating Eco Decor.pdf** (top: `cbi000` — Cork board insulation / Amorim  / Expanded Insulation Corkboard (ICB) / R3.6-inch, 115 kg/m3 [EU]):
+- `epd.id` — candidate `"EPD-AMO-20210078-ICA1-EN"` vs catalogue `"EPD HUB-0281"`
+
+**EPDs to consider for v1.1 update/Deceuninck_EPD-EPPA-PVC-U-window-123-x-148-m-with-insulated-triple-glazing-EPD-QKE-20220156-IBG1-EN-15-09-2022.pdf** (top: `www121` — Window, triple-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Triple pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/Diathonite plaster new EPD.pdf** (top: `lcp001` — Lime/Cork Plaster (Ext. & Int.) / Diasen / Diathonite Evolution, R3.2-inch / 3/4" [EU]):
+- `manufacturer.name` — candidate `"TDS"` vs catalogue `"Diasen"`
+
+**EPDs to consider for v1.1 update/Duraseal asphalt shingles EPD.pdf** (top: `rrr114` — Asphalt Shingles / Malarkey Roofing / Dura-Seal /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/EPD EU triple pane real version.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-DE"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/EPD Isolena wool insulation.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD Siga stick down membrane.pdf** (top: `bbb031` — Int. Wall & Ceiling Barrier, sheet / SIGA / Majrex 200 / Moisture-variable / EU):
+- `epd.id` — candidate `"EPD-SIG-20220186-CBA1-EN"` vs catalogue `"EPD-SIG-20220185-CBA1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2508.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210188-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2524.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210187-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek 2604.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210186-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek Airguard.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `epd.id` — candidate `"EPD-DUP-20220250-CBA1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 60.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"HDPE"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `0.058`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer 70.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210189-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD Tyvek monolayer.pdf** (top: `c630d2` — Polyisocyanurate / Wall Boards / DuPont / Thermax / R 6.5/inch):
+- `classification.material_type` — candidate `"Mineral wool"` vs catalogue `"Polyisocyanurate"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `29.53`
+- `epd.id` — candidate `"EPD-DUP-20210184-IBC1-EN"` vs catalogue `"4789559274.103.1"`
+
+**EPDs to consider for v1.1 update/EPD-06489_EVERBOARD-DesMoines_082322.pdf** (top: `a23458` — Composite sheathing panel / Continuus Materials / Everboard / Fiberglass facing / 1/2-inch):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"09"`
+- `classification.material_type` — candidate `"Cellulose"` vs catalogue `"Recycled drinking boxes"`
+- `manufacturer.name` — candidate `"Des Moines"` vs catalogue `"Continuus Materials"`
+
+**EPDs to consider for v1.1 update/EPD-Partel-Breathable-Monolithic-18-07-2022-EPDIE-22-84.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD-Thermafleece wool insulation.pdf** (top: `ins022` — Wool batt / Thermafleece / Cosywool Slab / R3.8-inch [EU]):
+- `manufacturer.name` — candidate `"Eden Renewable Innovations Limited"` vs catalogue `"Thermafleece"`
+
+**EPDs to consider for v1.1 update/EPD-triple-glazing-uncertified-translation-1.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"IBU"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/EPD4789733794.104.1 Kawneer Windows.pdf** (top: `www115` — Window, double-glazed, aluminum frame / Kawneer / OptiQ AA5450, TR-9100, 8400TL, AA6400|6500|6600 / Hung & sliding):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD4789733794.106.1 Kawneer Windows.pdf** (top: `www116` — Window, double-glazed, aluminum frame / Kawneer / Optiq AA4325, 8225TL|TLF, 526, AA 6400|6500, NX-300|3000 / Projected & casement):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"the Cranberry facility was used"` vs catalogue `"Kawneer"`
+
+**EPDs to consider for v1.1 update/EPD_-_WasteBasedBrick.pdf** (top: `bri005` — Brick, Clay / SHAW / Avg Face Brick / 3-5/8" x 2-3/4" x 7-5/8" (92 x 70 x 194 mm) incl. 3/8" mortar):
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `269`
+
+**EPDs to consider for v1.1 update/EPD_Building_Product_Design_Ltd_Glidevale_Protect_TF200®_HUB-0233_2023-11-02.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `manufacturer.name` — candidate `"Building Product Design Ltd"` vs catalogue `"Wickham"`
+- `physical.density.value_kg_m3` — candidate `500` vs catalogue `9.97`
+
+**EPDs to consider for v1.1 update/EPD_KRINNER_Ground_Screws.pdf** (top: `s12347` — Ground screw / Krinner / E-Series E89x1000-E60 / 89 x 1000 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"31"`
+- `classification.material_type` — candidate `"Steel"` vs catalogue `"Ground screw"`
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `5.5`
+
+**EPDs to consider for v1.1 update/EPD_for_GCPAT_Preprufe.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-075 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/EPD_window_with_double_insulating_gass_unit_valid_to_052027.pdf** (top: `www114` — Window, double-glazed, PVC-U frame, tilt & turn / [Industry Avg | EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"08"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Double pane window"`
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"aluplast, Deceuninck, Caine, Gargiulo, Gealan, hapa, Internorm, profine, Rehau, Salamander, Schuco, TMP, VEKA"`
+
+**EPDs to consider for v1.1 update/EXPIRED - Barriers, 378.EPD_for_GCPAT_Perm-A-Barrier.pdf** (top: `bbb011` — Ext. Wall barrier, adhesive / GCP / Perm-a-Barrier / Non-permeable, 1 mm):
+- `epd.id` — candidate `"EPD-074 EPD Information"` vs catalogue `"EPD10787"`
+
+**EPDs to consider for v1.1 update/Ecoasis asphalt shingle EPD.pdf** (top: `rrr112` — Asphalt Shingles / Malarkey Roofing /  Ecoasis NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Epd Tyvek 2507.pdf** (top: `bbb009` — Ext. Wall & Roof Barrier, sheet / Dupont / Tyvek Monolayer 60 / Permeable / EU):
+- `epd.id` — candidate `"EPD-DUP-20210185-IBC1-EN"` vs catalogue `"EPD-DUP-20210183-IBC1-EN"`
+
+**EPDs to consider for v1.1 update/Expired EPD_window_with_insulated_triple_glazing_valid_to_092027.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"QKE Qualit"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-QKE-20170001-IBG1-EN"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Framing, Tradeready steel joist EPD.pdf** (top: `mps000` — Metal Panels - Steel / Petersen Aluminum Corp / Pac-Clad, all profiles / 24 gauge):
+- `physical.density.value_kg_m3` — candidate `7800` vs catalogue `2.07`
+- `epd.id` — candidate `"4789752901.102.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Gramitherm BE-EPD-23.0183.001_00.01-EN-Gramitherm.pdf** (top: `ins041` — Spray polyurethane foam - Closed Cell (HFC gas) / Carlisle CSFI / SealTite PRO Closed Cell (HFC) / R 7.0-inch):
+- `physical.density.value_kg_m3` — candidate `30` vs catalogue `32`
+
+**EPDs to consider for v1.1 update/Hemp batt Sweden EPD_ S-P-01961.pdf** (top: `hemp0x` — Hemp Fiber Batt / R 3.6-inch [BEAM Avg]):
+- `classification.material_type` — candidate `"EPS Foam"` vs catalogue `"Hemp fiber"`
+- `physical.density.value_kg_m3` — candidate `25` vs catalogue `35`
+
+**EPDs to consider for v1.1 update/Hempcrete blocks Italy.pdf** (top: `ins013` — Hempcrete cast in place / Senini / Bio Beton Jet / R2.7-inch / 230 kg/m3 [EU]):
+- `classification.group_prefix` — candidate `"04"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Brick"` vs catalogue `"Hemp"`
+- `physical.density.value_kg_m3` — candidate `1500` vs catalogue `230`
+
+**EPDs to consider for v1.1 update/Highlander asphalt shingles EPD.pdf** (top: `rrr115` — Asphalt Shingles / Malarkey Roofing / Highlander NEX /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Insulation HVAC, Johns Manville fiberglass board EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4790545973.103.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Johns Manville fiberglass formaldehyde free EPD.pdf** (top: `f03m68` — Fiberglass batt / R 3.6-inch [BEAM Avg]):
+- `manufacturer.name` — candidate `"the United States and Canada."` vs catalogue `"DATABASE AVERAGE"`
+
+**EPDs to consider for v1.1 update/LECA EPD 4.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+
+**EPDs to consider for v1.1 update/Lime finish plaster UK EPD_ S-P-04459.pdf** (top: `int000` — Drywall 1/2" / National Gypsum / Gold Bond XP Gypsum Board / 1/2"):
+- `epd.id` — candidate `"S-P-04459"` vs catalogue `"EPD10792"`
+
+**EPDs to consider for v1.1 update/Luxury vinyl flooring EPD.pdf** (top: `lvt012` — Luxury Vinyl Tile (LVT) / Fuhua / FloraFloor / Click & Loose lay / 4.0 mm):
+- `classification.material_type` — candidate `"Luxury vinyl tile"` vs catalogue `"Vinyl"`
+- `manufacturer.name` — candidate `"Co., Ltd"` vs catalogue `"Jiangsu Fuhua"`
+- `physical.density.value_kg_m3` — candidate `1700` vs catalogue `7094.7`
+
+**EPDs to consider for v1.1 update/Malarkey ashpalt shingles EPD.pdf** (top: `rrr116` — Asphalt Shingles / Malarkey Roofing / Legacy /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/NAIMA Fiberglass Board NAIMA.pdf** (top: `ins004` — Fiberglass board / NAIMA / R-3.2-inch  [Industry Avg | N.America]):
+- `physical.density.value_kg_m3` — candidate `23` vs catalogue `57.6`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Heavy Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Light Density Board Product.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/NAIMA Mineral Wool Insulation Industry Average EPD _ Loose-Fill.pdf** (top: `4ld02f` — Mineral wool batt / [BEAM Avg]):
+- `classification.group_prefix` — candidate `"07"` vs catalogue `"06"`
+- `manufacturer.name` — candidate `"sale on the market."` vs catalogue `"American Wood Council & Canadian Wood Council"`
+- `physical.density.value_kg_m3` — candidate `50` vs catalogue `460`
+
+**EPDs to consider for v1.1 update/Owens Corning fiberglass board faced EPD.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"the following locations"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"4788986648.101.1"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Residential broadloom carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.144.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Residential floor carpet EPD.pdf** (top: `ewf001` — Engineered Wood flooring / Wickham / Engineered Hardwood / 16 mm):
+- `classification.material_type` — candidate `"Hardwood"` vs catalogue `"Engineered wood"`
+- `manufacturer.name` — candidate `"the United States. Primary data"` vs catalogue `"Wickham"`
+- `epd.id` — candidate `"4789796942.142.1"` vs catalogue `"6742-7944"`
+
+**EPDs to consider for v1.1 update/Rothoblas PRJ2003785-RB_EPD1 02-07-2021 v5 - Title.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"2021M10140 Registration Number EPDITALY0140"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/VestaEco-EPD-Strawboards 280.pdf** (top: `967ad6` — Cellulose / batt / CMS / EcoCell / R 3.6-inch):
+- `manufacturer.name` — candidate `"nor LCA practitioner."` vs catalogue `"CMS"`
+- `physical.density.value_kg_m3` — candidate `280` vs catalogue `40`
+
+**EPDs to consider for v1.1 update/Vista asphalt shingles.pdf** (top: `rrr117` — Asphalt Shingles / Malarkey Roofing / Vista /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/Wausau-Fixed,-Projected,-Casement,-Hung,-and-Sliding-Windows-EPD-Final.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Wausau Window and Wall Systems, a part of Apogee"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"499"` vs catalogue `"4789365778.101.1"`
+
+**EPDs to consider for v1.1 update/Windsor Scotchguard asphalt shingle EPD.pdf** (top: `rrr118` — Asphalt Shingles / Malarkey Roofing / Windsor /):
+- `classification.material_type` — candidate `"Fiberglass"` vs catalogue `"Asphalt Shingles"`
+
+**EPDs to consider for v1.1 update/en_epd_equitone_natura_textura_2019_2024.pdf** (top: `e0e76c` — Masonry Cement / Portland Cement Association [Industry Avg | US & CA]):
+- `manufacturer.name` — candidate `"Eternit GmbH"` vs catalogue `"Portland Cement Association"`
+- `epd.id` — candidate `"EPD-ELH-20180136-CAC1-EN"` vs catalogue `"EPD 034"`
+
+**EPDs to consider for v1.1 update/equitone-natura-pro-pictura-epd-ete_20190179_ccc1_en.pdf** (top: `fib001` — Fiber Cement siding / Equitone / Pictura, Natura Pro, sheets / 8 mm [EU]):
+- `classification.group_prefix` — candidate `"05"` vs catalogue `"07"`
+- `classification.material_type` — candidate `"Aluminum"` vs catalogue `"Fiber cement"`
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Equitone"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `1850`
+
+**EPDs to consider for v1.1 update/equitone-tectiva-epd-ete_20190007_ica1_en.pdf** (top: `mpa000` — Metal Panels - Aluminum / Petersen Aluminum Corp / Pac-Clad, all profiles / 20 gauge):
+- `manufacturer.name` — candidate `"Eternit NV"` vs catalogue `"Petersen Aluminum Corp"`
+- `physical.density.value_kg_m3` — candidate `2800` vs catalogue `2.07`
+- `epd.id` — candidate `"EPD-ETE-20190007-ICA1-EN"` vs catalogue `"4789365778.101.1"`
+

--- a/docs/workplans/melanie-review-draft-2026-05-19.md
+++ b/docs/workplans/melanie-review-draft-2026-05-19.md
@@ -1,0 +1,148 @@
+---
+status: DRAFT — for Andy's review before sending
+intended recipient: Mélanie Tessier
+purpose: confirm §11.10 open items so EPD-Parser C-fb6 (Tier-10 biogenic) can ship
+context: follow-up to Mélanie's 2026-05-05 answers (workplan EPD-Parser.md §11.8)
+---
+
+# Draft message — biogenic methodology follow-up
+
+Hi Mélanie,
+
+Thank you again for your 2026-05-05 answers on the biogenic-carbon flow — they substantially expanded our understanding of the BfCA methodology and meaningfully revised the scope of C-fb6 (the Tier-10 calculations layer that lands BEAM-normalized biogenic values into the parser output).
+
+We've worked through the six remaining items in §11.10 and have working answers for most of them. The structure below is "here's what we're going with — please flag anything that doesn't match your model." For Q3 (the Phyllis 2 lookup) we've drafted a starter shortlist; your red-line on that is the gating item before C-fb6.2 ships.
+
+---
+
+## Q1 — Schema field locations  · going with `methodology.beam_calc.*`
+
+The Tier-10 calculation output lives under `methodology.beam_calc.*`:
+
+```
+methodology.beam_calc.full_c_kgco2e          [number]   — calculated full biogenic carbon (per declared unit)
+methodology.beam_calc.stored_kgco2e          [number]   — full_C × storage_factor
+methodology.beam_calc.biogenic_source        [enum]     — "epd_gwp_bio" | "epd_bcrp" | "calculated_from_material_content"
+methodology.beam_calc.storage_cycle          [enum]     — "long_cycle" | "short_cycle"  (see Q2)
+methodology.beam_calc.storage_factor         [number]   — 0.9 by convention when long_cycle; 0 when not applicable
+methodology.beam_calc.inputs[]               [array]    — provenance chain (e.g. "physical.density.value_kg_m3 (epd_direct)")
+```
+
+Material Content (the table where EPDs list "70% wood + 30% adhesive" etc., per your Q2 answer) lives separately under `classification.material_content[]`.
+
+Reasoning: methodology houses the policy choices (`biogenic_source`, `storage_cycle`, `storage_factor`); the calc outputs derive from those choices. Physical houses the raw measurable inputs (density today; thickness eventually, but BEAMweb provides that — not EPD-Parser). In the form pane, the audit-trail UI explicitly draws an arrow from `physical.density` → `methodology.beam_calc.full_c_kgco2e` so the dependency is visible across the two sections.
+
+## Q2 — `storage_cycle` enum  · `"long_cycle" | "short_cycle"`, one open future item
+
+Final enum: `"long_cycle" | "short_cycle"`.
+
+We dropped the `"none"` option we'd considered — a numeric `storage_factor: 0` says the same thing without a string sentinel, and one less enum value to maintain.
+
+**Open future item** (not blocking C-fb6): **medium_cycle as a project-level pro-rating mechanism.** Andy raised the case of a building designed for 100-year service life that's demolished after 10 years — the long-cycle storage credit should be pro-rated to reflect actual rather than design service life. This isn't a per-material property (the material's biology is the same regardless of how it's used downstream); it's a project-level override. We'll spec that separately and don't expect to need it for C-fb6. For now every biogenic material defaults to `long_cycle` and the per-project pro-rating logic comes later.  `// flag if you think this needs a per-material slot rather than a project-level override`
+
+## Q3 — Phyllis 2 lookup  · draft below, please red-line
+
+We've drafted a starter shortlist of ~20 biomass types we expect to encounter in BfCA materials. **The carbon-content values are guesses from common LCA defaults**, not from direct Phyllis 2 lookups — happy to anchor each to a specific Phyllis 2 record ID once you've reviewed the categories. Storage-cycle assignments assume default in-building use; the asterisks call out the ones we're least sure about.
+
+| # | material_type key            | C content (kgC/kg dry) | storage_cycle | notes / questions for you                                            |
+|---|------------------------------|------------------------:|---------------|-----------------------------------------------------------------------|
+| 1 | `softwood_solid`             | 0.50                    | long_cycle    | Pine / spruce / fir / SPF — solid dimension lumber baseline.          |
+| 2 | `hardwood_solid`             | 0.49                    | long_cycle    | Oak / maple / birch / etc. `// is 0.49 right, or should it match 0.50?` |
+| 3 | `softwood_engineered_wood`   | 0.48                    | long_cycle    | Glulam / CLT / GLT — solid wood diluted slightly by adhesive content. `// what % adhesive do you typically assume?` |
+| 4 | `LVL`                        | 0.48                    | long_cycle    | Veneer + phenolic adhesive.                                            |
+| 5 | `LSL_PSL`                    | 0.48                    | long_cycle    | Strands + adhesive.                                                    |
+| 6 | `plywood`                    | 0.48                    | long_cycle    | Veneer + adhesive.                                                     |
+| 7 | `OSB`                        | 0.48                    | long_cycle    | Strands + adhesive.                                                    |
+| 8 | `wood_fiberboard`            | 0.48                    | long_cycle    | MDF / hardboard / wood-fibre insulation panels.                        |
+| 9 | `bamboo`                     | 0.524                   | long_cycle    | Your figure from Q3.                                                   |
+| 10 | `cellulose_insulation`      | 0.45                    | long_cycle    | Treated recycled paper feedstock — lower C due to ash + flame retardants. `// confirm 0.45?` |
+| 11 | `straw`                     | 0.48                    | long_cycle    | Wheat / oat in straw-bale construction. Long-cycle when in-wall.       |
+| 12 | `hemp_fiber`                | 0.48                    | long_cycle    | Insulation panels; also fiber input to hempcrete.                      |
+| 13 | `hempcrete`                 | 0.20                    | long_cycle    | Composite: hemp fiber + lime binder. Lower effective C due to dilution. `// best guess — would value a real number from your records` |
+| 14 | `cork`                      | 0.55                    | long_cycle    | Cork-board insulation. Higher C content (oak-bark suberin).            |
+| 15 | `sheep_wool_insulation`     | 0.50                    | long_cycle    | Wool batt insulation.                                                  |
+| 16 | `cotton_insulation`         | 0.43                    | long_cycle    | Recycled denim batt.                                                   |
+| 17 | `flax`                      | 0.48                    | long_cycle    | Insulation panels; less common in North America.                       |
+| 18 | `coir`                      | 0.48                    | long_cycle    | Coconut-husk insulation.                                               |
+| 19 | `jute`                      | 0.48                    | long_cycle    | Included for completeness; rare in N.A. construction.                  |
+| 20 | `bagasse`                   | 0.48                    | short_cycle   | Sugar-cane residue — packaging / temporary boards. `// long if it's structural, short if temporary — your call` |
+
+**Open questions for you:**
+- Are any material categories missing that BfCA encounters regularly?
+- Are there any you'd remove as unrealistic for the Canadian construction context?
+- Do you want me to pull specific Phyllis 2 record IDs to anchor each row, or would BfCA-curated round numbers (like above) suit better?
+
+## Q5 — Legacy 821-record migration  · `legacy_unknown` flag, your timeline
+
+For the existing 821 records, `biogenic_source` defaults to `"legacy_unknown"`. From now on, every new EPD-Parser commit attributes `biogenic_source` correctly based on what the original EPD published — explicit `gwp_bio` per stage, `BCRP` from the biogenic-inventory table, or `calculated_from_material_content` when no biogenic value is published.
+
+For the legacy 821, we propose:
+- **No bulk re-attribution required from you.** The legacy_unknown tag is honest about state — practitioners querying the catalogue will see that those records' biogenic_source is unattributed.
+- **When you have time**, we can set up a side workflow where you flag entries in small batches (10 at a time, say) and we apply the attribution. No pressure on timeline.
+- Records where the original EPD is archived in the repo can be auto-attributed by re-running the parser; the others stay `legacy_unknown` until source recovery makes attribution possible.
+
+### Helpful side-effect — the parser surfaces records that may benefit from review
+
+While running EPD-Parser against the 208-EPD archive BfCA shared with us today, we also wired a "catalogue parity" check that matches each extracted record against the 821-row catalogue and diffs the safely-comparable fields (group prefix, material type, manufacturer, density, EPD id). The intent was to verify the parser's fidelity against authoritative values, but it had a useful by-product: it surfaced a handful of catalogue rows whose density values appear to be in different units than the rest. For example:
+
+- `mpa000` (Aluminum panels) — catalogue density `2.07 kg/m³` (aluminum is ~2700 kg/m³; looks like a per-area panel weight got stored in the volumetric slot)
+- `1f3cc3` (CertainTeed fiberglass batt) — catalogue density `0.488 kg/m³` (fiberglass batt is typically 10–30 kg/m³; looks like a lb/ft³ value stored without unit conversion)
+
+These aren't errors per se — more like inheritance from the original BEAM-spreadsheet → JSON import where some columns blurred imperial/metric or per-area/per-volume conventions. The parser now provides a clean way to flag these for review.
+
+We can produce two lists for you:
+
+1. **Historic** — every catalogue row where the existing-archive EPD-Parser run diverges from the catalogued value by a unit-conversion-shaped factor (≥10× difference in density, for instance). These are likely unit-misencoded and worth a quick review.
+2. **Go-forward** — every new EPD-Parser commit will report parity status against the catalogue in the snapshot, so any future drift gets flagged the same way.
+
+Happy to ship the historic list as a markdown table for you to red-line whenever it's convenient. Independent of C-fb6 timeline — useful housekeeping that the tooling does almost for free now that the matcher exists.
+
+## Q6 — Validation tolerance  · two-tier ±0.1% / ±5%
+
+Two distinct tolerance bars for two distinct tests:
+
+| Test                    | Tolerance | What it measures                                                                  |
+|-------------------------|-----------|-----------------------------------------------------------------------------------|
+| **Formula unit-test**   | ±0.1%     | Given identical synthetic inputs on both sides, do we produce the same full_C as your spreadsheet? Catches formula bugs. |
+| **End-to-end pipeline** | ±5%       | EPD-Parser-extracted inputs → Tier-10 calc → compared against your BEAM CSV col 31 ("Full C value"). Tolerates legitimate input variance (parser extracts 482 kg/m³ where you typed 480) without false-flagging. |
+
+Both passing = formula and pipeline integrity.
+
+`// is ±5% too loose for your liking? If so we can tighten — happy to go ±3% on the pipeline if you'd prefer.`
+
+**A small empirical note** from the 208-sample parity run: where the parser and catalogue both have a non-null density value AND the catalogue's units look correct, the values agree within 5% on essentially every check. The headline 8% match rate we measured today is dragged down by the unit-encoding issues described in Q5, not by formula or parser drift. So if your spreadsheet's col 31 values are unit-clean, ±5% is likely a comfortable bar in practice. We'll know more once C-fb6 lands and we can re-run the comparison on `methodology.beam_calc.full_c_kgco2e` directly.
+
+## Q4 — Material Content table extraction  · deferred
+
+This depends on a separate architecture decision Andy is working through (parser-wide — how to handle per-format table extraction generically rather than as a regex per program operator). Once that lands, Material Content extraction follows as a parameterization of the chosen architecture. We'll loop you back when there's something concrete to review.
+
+---
+
+## Practical next steps
+
+1. **You review the Phyllis 2 draft (Q3).** Even if all you do is "yes / no / swap row 13" we can publish v1 and iterate.
+2. **C-fb6 begins** once Q3 lands. Estimated ~10 hours of work spread across schema bump, Phyllis 2 JSON, Tier-10 formula implementation, audit-trail UI render, and validation harness.
+3. **Legacy migration kicks off whenever you want.** Independent of C-fb6.
+4. **Unit-review list (optional, anytime).** We can ship a tabular list of the ~10–20 catalogue rows whose density values currently look unit-misencoded. You red-line which ones need correcting; we patch and re-snapshot. Zero pressure on timeline — useful housekeeping that the parity matcher does almost for free.
+
+Whenever you have time for a 30-minute call (or just async on this doc), let's pick it up.
+
+Thanks Mélanie — the depth of your 2026-05-05 answers is exactly what we needed to keep this on a sound methodological footing rather than improvising.
+
+—Andy
+
+---
+
+## Andy's review notes
+
+Use this section before sending. Things to look at:
+
+- [ ] Q1 — methodology.beam_calc.* — flag if you want different naming
+- [ ] Q2 — long/short only; medium deferred. Do you want medium added now anyway, in case the pro-rating spec comes sooner?
+- [ ] Q3 — Phyllis 2 table — anything obviously wrong? Bagasse should be long_cycle if it's structural in the BfCA catalogue (e.g. bagasse-panel sheathing) — flip to long_cycle if so.
+- [ ] Q5 — legacy_unknown phrasing — is "no bulk re-attribution required from you" too soft? You said off-record that it's her mess to unravel; this draft is the polite version.
+- [ ] Q5 unit-mismatch note — the new "helpful side-effect" paragraph reframes the catalogue-side density issues as housekeeping the parser surfaces, not a complaint. Check the tone reads as a service offer.
+- [ ] Q6 — ±5% tolerance — happy with two-tier? The empirical note now backs the choice with parity-run data.
+- [ ] Practical step 4 (unit-review list) — should this be opt-in or auto-ship?
+- [ ] Tone — is it too "we" / too formal / too business-y?
+- [ ] Signature — "Andy" or different?

--- a/index.html
+++ b/index.html
@@ -84,6 +84,17 @@
           </p>
           <div class="landing-card-meta">planning · text-layer extraction · maps to materials schema</div>
         </a>
+
+        <a href="cclimb.html" class="landing-card" target="_blank" rel="noopener">
+          <div class="landing-card-icon"><i class="bi bi-graph-up-arrow"></i></div>
+          <h2 class="landing-card-title">CCLIMB <span class="landing-card-badge">Scaffolding</span></h2>
+          <p class="landing-card-desc">
+            Time-explicit climate response for carbon-storing building products. Compares Project Trajectory (PT —
+            carbon stored in the building) to Reference Trajectory (RT — counterfactual atmospheric release absent the
+            product) via a parallel-coordinates visualization. Implements the RMI-led CCLIMB methodology.
+          </p>
+          <div class="landing-card-meta">scaffolding · parallel coords ported from OBJECTIVE · methodology v1 in working-group review</div>
+        </a>
       </section>
 
       <section class="landing-footnote">

--- a/js/cclimb.mjs
+++ b/js/cclimb.mjs
@@ -1,0 +1,52 @@
+/**
+ * cclimb.mjs — ESM entry for the CCLIMB module
+ *
+ * Phase 0 — scaffolding only. Wires the form pane + parallel-coords container
+ * but does not yet run the climate calc (P1).
+ *
+ * Methodology: docs/RMI Work/CCLIMB-Workplan.md
+ * Implementation workplan: docs/RMI Work/CCLIMB-Workplan2.md
+ */
+
+import { LCA_MODULES, OUTPUT_AXES } from "./cclimb/chart-config.mjs";
+import { initParallelCoords } from "./cclimb/parallel-coords.mjs";
+import { computeClimateResponse } from "./cclimb/climate-model.mjs";
+import { getReferenceTrajectory } from "./cclimb/reference-trajectories.mjs";
+import { FEEDSTOCK_CATEGORIES } from "./cclimb/feedstock-categories.mjs";
+
+console.log("[CCLIMB] scaffold loaded. Modules:", LCA_MODULES.length, "axes");
+
+// ── Form binding (placeholder) ────────────────────────────────────────────
+//
+// In P1, this will read the form inputs, build a candidate record, and
+// dispatch to computeClimateResponse() → render via initParallelCoords().
+
+function bindForm() {
+  const computeBtn = document.getElementById("cclimb-compute");
+  if (!computeBtn) return;
+  computeBtn.addEventListener("click", () => {
+    console.log("[CCLIMB] compute clicked — P1 will wire this");
+    // TODO P1: read form fields, build inventory + RT spec, call computeClimateResponse
+  });
+}
+
+// ── Chart bootstrap (placeholder) ─────────────────────────────────────────
+//
+// P0 stubs the container; P1 replaces the placeholder with a real D3 render.
+
+function bootstrapChart() {
+  const container = document.getElementById("cclimb-pcg-container");
+  if (!container) return;
+  // P1: initParallelCoords(container, { modules: LCA_MODULES, outputAxes: OUTPUT_AXES, rt: [], pt: [] });
+  console.log(
+    "[CCLIMB] chart bootstrap deferred to P1. Axes ready:",
+    LCA_MODULES.map((m) => m.id).join(", "),
+    "→",
+    OUTPUT_AXES.map((a) => a.id).join(", ")
+  );
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  bindForm();
+  bootstrapChart();
+});

--- a/js/cclimb/chart-config.mjs
+++ b/js/cclimb/chart-config.mjs
@@ -1,0 +1,66 @@
+/**
+ * chart-config.mjs — Parallel-coordinates axis definitions for CCLIMB
+ *
+ * One axis per EN 15804+A2 life-cycle module (PT inventory + RT counterfactual),
+ * then a divider, then output axes (calculated ΔCRF / ΔT / Completeness).
+ *
+ * Per Andy's 2026-05-19 clarification: "each axis is an ISO scoped carbon
+ * division — A1, A2, A3, etc." Phase grouping is visual (banded backgrounds)
+ * rather than per-axis label noise.
+ */
+
+// EN 15804+A2 life-cycle modules. Each becomes one editable axis on the chart.
+// Module ID, label, phase grouping (for visual banding), and unit.
+export const LCA_MODULES = [
+  // Product stage
+  { id: "A1", label: "A1 Raw materials", phase: "product", unit: "kgCO2e" },
+  { id: "A2", label: "A2 Transport", phase: "product", unit: "kgCO2e" },
+  { id: "A3", label: "A3 Manufacturing", phase: "product", unit: "kgCO2e" },
+  // Construction stage
+  { id: "A4", label: "A4 Transport to site", phase: "construction", unit: "kgCO2e" },
+  { id: "A5", label: "A5 Install / waste", phase: "construction", unit: "kgCO2e" },
+  // Use stage
+  { id: "B1", label: "B1 Use", phase: "use", unit: "kgCO2e" },
+  { id: "B2", label: "B2 Maintenance", phase: "use", unit: "kgCO2e" },
+  { id: "B3", label: "B3 Repair", phase: "use", unit: "kgCO2e" },
+  { id: "B4", label: "B4 Replacement", phase: "use", unit: "kgCO2e" },
+  { id: "B5", label: "B5 Refurbishment", phase: "use", unit: "kgCO2e" },
+  { id: "B6", label: "B6 Operational energy", phase: "use", unit: "kgCO2e" },
+  { id: "B7", label: "B7 Operational water", phase: "use", unit: "kgCO2e" },
+  // End-of-life stage
+  { id: "C1", label: "C1 Demolition", phase: "eol", unit: "kgCO2e" },
+  { id: "C2", label: "C2 Transport (EOL)", phase: "eol", unit: "kgCO2e" },
+  { id: "C3", label: "C3 Waste processing", phase: "eol", unit: "kgCO2e" },
+  { id: "C4", label: "C4 Disposal", phase: "eol", unit: "kgCO2e" },
+  // Beyond system boundary
+  { id: "D", label: "D Reuse / recovery credit", phase: "beyond", unit: "kgCO2e" }
+];
+
+// Calculated output axes (climate-response domain, not inventory domain).
+// Practitioner cannot drag these — they're outputs of the IRF convolution.
+export const OUTPUT_AXES = [
+  { id: "dCRF_20", label: "ΔCRF(20y)", phase: "response", unit: "W·m⁻²·yr", calculated: true },
+  { id: "dCRF_50", label: "ΔCRF(50y)", phase: "response", unit: "W·m⁻²·yr", calculated: true },
+  { id: "dCRF_100", label: "ΔCRF(100y)", phase: "response", unit: "W·m⁻²·yr", calculated: true },
+  { id: "dCRF_Tref", label: "ΔCRF(T_ref)", phase: "response", unit: "W·m⁻²·yr", calculated: true },
+  { id: "dT_100", label: "ΔT(100y)", phase: "response", unit: "°C·yr", calculated: true },
+  { id: "C_100", label: "Completeness(100)", phase: "response", unit: "—", calculated: true }
+];
+
+// Phase grouping for visual banding behind axis labels.
+export const PHASE_BANDS = {
+  product: { label: "Product stage (A1–A3)", color: "rgba(34, 139, 34, 0.12)" },
+  construction: { label: "Construction (A4–A5)", color: "rgba(255, 165, 0, 0.12)" },
+  use: { label: "Use stage (B1–B7)", color: "rgba(70, 130, 180, 0.12)" },
+  eol: { label: "End of life (C1–C4)", color: "rgba(178, 34, 34, 0.12)" },
+  beyond: { label: "Beyond (D)", color: "rgba(128, 128, 128, 0.12)" },
+  response: { label: "Climate response (calculated)", color: "rgba(40, 40, 40, 0.18)" }
+};
+
+// Provisional T_ref per CCLIMB §5 ("provisionally ~250 years"). Configurable
+// until working-group finalizes (see §7.2 of CCLIMB-Workplan2.md).
+export const DEFAULT_T_REF_YEARS = 250;
+
+// Default Tier 1 horizon. CCOB had 10 yr; CCLIMB second draft has both 5 and 10.
+// (See §7.1 + §11.3 of CCLIMB-Workplan2.md — working-group decision in flight.)
+export const DEFAULT_TIER1_HORIZON_YEARS = 5;

--- a/js/cclimb/climate-model.mjs
+++ b/js/cclimb/climate-model.mjs
@@ -1,0 +1,43 @@
+/**
+ * climate-model.mjs — Impulse-response convolution for CCLIMB
+ *
+ * P0 — placeholder. P1 implements:
+ *   - CO₂ Bern carbon-cycle IRF (4-exponential AR6 parameterization)
+ *   - CH₄ perturbation lifetime IRF (~11.8 yr AR6)
+ *   - RF(t) = ∫₀ᵗ E(τ) · IRF(t − τ) dτ (per-gas convolution)
+ *   - ΔT(t) from RF(t) via two-box temperature response (AR6 calibrated)
+ *
+ * Sources to cite in schema/lookups/ipcc-ar6-irf-params.json (P1):
+ *   - IPCC AR6 WG1 Chapter 7 — climate sensitivity + impulse response
+ *   - Joos et al. 2013 / AR6 — Bern carbon-cycle coefficients
+ *
+ * @see CCLIMB-Workplan2.md §4.2 — Climate model design
+ * @see CCLIMB-Workplan.md §4.2 — Methodology requirements
+ */
+
+/**
+ * Compute climate response for a project trajectory vs reference trajectory.
+ *
+ * @param {Object} pt - Project trajectory inventory (per-module + per-year flows)
+ * @param {Object} rt - Reference trajectory (counterfactual emissions over time)
+ * @param {Object} opts - { horizonYears: 100, tRefYears: 250 }
+ * @returns {Object} - { dCRF_20, dCRF_50, dCRF_100, dCRF_Tref, dT_100, completeness }
+ */
+export function computeClimateResponse(pt, rt, opts = {}) {
+  // P1 implementation goes here. For now, a placeholder that returns zeros
+  // so the chart can render structurally even without real math.
+  console.warn("[CCLIMB climate-model] P1 not yet implemented — returning zeros");
+  return {
+    dCRF_20: 0,
+    dCRF_50: 0,
+    dCRF_100: 0,
+    dCRF_Tref: 0,
+    dT_100: 0,
+    completeness: 0
+  };
+}
+
+// IRF placeholders for P1:
+// export function co2_irf(t) { ... Bern 4-exp ... }
+// export function ch4_irf(t) { ... AR6 perturbation lifetime ... }
+// export function convolve(emissions, irf, horizon) { ... }

--- a/js/cclimb/feedstock-categories.mjs
+++ b/js/cclimb/feedstock-categories.mjs
@@ -1,0 +1,65 @@
+/**
+ * feedstock-categories.mjs — Tier 1 sub-categories per CCLIMB §3.2
+ *
+ * Five Tier 1 sub-categories (A/B/C/D/E in CCLIMB second draft). Tier 2
+ * (timber) is deferred to v2.
+ *
+ * @see CCLIMB-Workplan.md §3.2 (Feedstock Categorization Framework)
+ * @see CCLIMB-Workplan2.md §3.5 (axis vocabulary per category) + §11.2 (cat refinement CCOB→CCLIMB)
+ */
+
+export const FEEDSTOCK_CATEGORIES = {
+  A: {
+    label: "Residues / waste streams",
+    tier: 1,
+    typical_counterfactual: "Near-term atmospheric release (decay / incineration)",
+    opportunity_cost: "None",
+    rt_default: "RT-A:default_5",
+    examples: ["Recycled paper", "Demolition wood", "Sawdust", "Slash", "Agricultural straw", "Food waste"],
+    notes: "Diversion does not materially reduce ongoing carbon sink capacity at ecosystem scale."
+  },
+  B: {
+    label: "Short-rotation crops",
+    tier: 1,
+    typical_counterfactual: "Continued short-cycle biological turnover",
+    opportunity_cost: "Minimal",
+    rt_default: "RT-A:default_1",
+    examples: ["Hemp", "Flax", "Switchgrass", "Algae"],
+    notes: "Carbon uptake + release largely reset each harvest cycle."
+  },
+  C: {
+    label: "Perennial regenerative systems",
+    tier: 1,
+    typical_counterfactual: "Continued uptake with minimal stock loss",
+    opportunity_cost: "Minimal",
+    rt_default: "RT-A:default_5",
+    examples: ["Bamboo", "Coppice", "Fast-growing willow"],
+    notes: "Root systems / perennial structures remain intact; continued net carbon uptake independent of harvest."
+  },
+  D: {
+    label: "Harvest without depletion (cork, rubber) — v2",
+    tier: 1,
+    typical_counterfactual: "Continuous harvest without depletion",
+    opportunity_cost: "Minimal",
+    rt_default: "RT-A:default_5",
+    examples: ["Cork", "Rubber", "Coconut fiber"],
+    notes: "v2 of CCLIMB-app — methodology second-draft refinement (split out of original C 'perennial systems')."
+  },
+  E: {
+    label: "Engineered atmospheric uptake",
+    tier: 1,
+    typical_counterfactual: "CO₂ remains in atmosphere absent engineered incorporation",
+    opportunity_cost: "None",
+    rt_default: "RT-A:default_5",
+    examples: ["Mineralized feedstocks (concrete carbonation)", "Captured-CO₂ polymers", "Biochar from CDR"],
+    notes: "Excludes ambient carbonation occurring during service life (per CCLIMB §1.2 scope)."
+  }
+};
+
+// Tier 2 — deferred to v2 of CCLIMB methodology (long-rotation timber: CLT,
+// glulam, LVL, dimension lumber). See §6 of CCLIMB-Workplan2.md.
+export const TIER_2_NOTE = {
+  label: "Virgin long-rotation timber (Category D in original CCLIMB)",
+  status: "Deferred to v2 — pending working-group governance for forest counterfactuals",
+  blocking_for: "Most structural mass-timber EPDs (CLT, glulam, LVL, framing lumber)"
+};

--- a/js/cclimb/parallel-coordinates.objective-source.js
+++ b/js/cclimb/parallel-coordinates.objective-source.js
@@ -1,0 +1,713 @@
+/**
+ * ParallelCoordinates.js (Refactored - Nov 30, 2025)
+ * Section 18 Interactive Parallel Coordinates Optimization Visualization
+ *
+ * Lightweight orchestrator that coordinates between:
+ * - pcConfig.js: Axis configuration and data fetching
+ * - pcRendering.js: D3 visualization and interaction
+ * - pcOptimization.js: Optimization preset handlers
+ * - pcFinancials.js: Financial calculations (optional Pro feature)
+ *
+ * Reduced from 3,199 lines to ~800 lines by extracting modules
+ *
+ * @agent NOVA - November 25, 2025
+ * @refactored November 30, 2025 - Module extraction pattern
+ */
+
+// Ensure namespace exists
+window.TEUI = window.TEUI || {};
+
+window.TEUI.ParallelCoordinates = (function () {
+  "use strict";
+
+  // ══════════════════════════════════════════════════════════════════════
+  // CONFIGURATION
+  // ══════════════════════════════════════════════════════════════════════
+
+  const CONFIG = {
+    // Layout
+    graphHeightPercent: 0.55, // 55% for graph
+    tableHeightPercent: 0.45, // 45% for table
+    margin: {
+      top: 60,
+      right: 55,
+      bottom: 20,
+      left: 115,
+    },
+
+    // Financial settings
+    roiTerm: 1, // Default ROI term in years
+
+    // Visual styling
+    colors: {
+      target: "#007bff", // Blue
+      reference: "#dc3545", // Red
+      axisLine: "#ccc",
+      axisText: "#333",
+      gridLine: "#eee",
+    },
+
+    // Line styling
+    lineWidth: 3,
+    lineWidthHover: 4,
+    lineOpacity: 0.9,
+    lineOpacityHover: 1,
+
+    // Animation
+    transitionDuration: 300,
+
+    // Container selectors
+    containerSelector: ".parallel-coordinates-container",
+    controlsSelector: ".parallel-coordinates-controls-wrapper",
+    infoSelector: ".parallel-coordinates-info-wrapper",
+  };
+
+  // ══════════════════════════════════════════════════════════════════════
+  // STATE MANAGEMENT
+  // ══════════════════════════════════════════════════════════════════════
+
+  let currentData = null;
+  let isFullscreen = false;
+  let isActivated = false;
+
+  // ══════════════════════════════════════════════════════════════════════
+  // UI INITIALIZATION & CONTROLS
+  // ══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Initialize the parallel coordinates visualization
+   */
+  function initialize() {
+    console.log("[ParallelCoordinates] Setting up initial state");
+
+    const container = document.querySelector(CONFIG.containerSelector);
+    const controlsWrapper = document.querySelector(CONFIG.controlsSelector);
+
+    if (!container || !controlsWrapper) {
+      console.warn("[ParallelCoordinates] Required containers not found");
+      return;
+    }
+
+    createInitialControlsRow(controlsWrapper);
+    createLoadingPlaceholder(container);
+
+    console.log("[ParallelCoordinates] Initial state ready");
+  }
+
+  /**
+   * Create initial controls row with activation button
+   */
+  function createInitialControlsRow(controlsWrapper) {
+    controlsWrapper.innerHTML = "";
+
+    const controlsContainer = document.createElement("div");
+    controlsContainer.className = "parallel-coordinates-controls";
+
+    const activateBtn = document.createElement("button");
+    activateBtn.id = "s18ActivateBtn";
+    activateBtn.className = "btn btn-primary btn-sm";
+    activateBtn.innerHTML =
+      '<i class="bi bi-shuffle"></i> Activate Optimization View';
+    activateBtn.addEventListener("click", activateVisualization);
+
+    const layoutContainer = document.createElement("div");
+
+    const refreshBtn = document.createElement("button");
+    refreshBtn.className = "btn btn-outline-secondary btn-sm";
+    refreshBtn.title = "Refresh Data";
+    refreshBtn.innerHTML = '<i class="bi bi-arrow-clockwise"></i>';
+    refreshBtn.disabled = true;
+
+    const exportBtn = document.createElement("button");
+    exportBtn.className = "btn btn-outline-secondary btn-sm";
+    exportBtn.title = "Export as PNG";
+    exportBtn.innerHTML = '<i class="bi bi-download"></i>';
+    exportBtn.disabled = true;
+
+    const settingsBtn = document.createElement("button");
+    settingsBtn.className = "btn btn-outline-secondary btn-sm";
+    settingsBtn.title = "Settings";
+    settingsBtn.innerHTML = '<i class="bi bi-gear"></i>';
+    settingsBtn.disabled = true;
+
+    const fullscreenBtn = document.createElement("button");
+    fullscreenBtn.className = "btn btn-outline-secondary btn-sm";
+    fullscreenBtn.title = "Toggle Fullscreen";
+    fullscreenBtn.innerHTML = '<i class="bi bi-arrows-fullscreen"></i>';
+    fullscreenBtn.disabled = true;
+
+    layoutContainer.appendChild(refreshBtn);
+    layoutContainer.appendChild(exportBtn);
+    layoutContainer.appendChild(settingsBtn);
+    layoutContainer.appendChild(fullscreenBtn);
+
+    controlsContainer.appendChild(activateBtn);
+    controlsContainer.appendChild(layoutContainer);
+
+    controlsWrapper.appendChild(controlsContainer);
+  }
+
+  /**
+   * Create loading placeholder message
+   */
+  function createLoadingPlaceholder(container) {
+    const placeholder = document.createElement("div");
+    placeholder.id = "s18LoadingPlaceholder";
+    placeholder.className = "teui-loading-placeholder";
+    placeholder.innerHTML =
+      "<p>Click 'Activate Optimization View' to visualize optimization paths between Target and Reference configurations.</p>";
+
+    container.innerHTML = "";
+    container.appendChild(placeholder);
+  }
+
+  /**
+   * Activate the visualization
+   */
+  function activateVisualization() {
+    console.log("[ParallelCoordinates] Activating visualization");
+
+    const container = document.querySelector(CONFIG.containerSelector);
+    const placeholder = document.getElementById("s18LoadingPlaceholder");
+
+    if (!container) return;
+
+    container.classList.add("activated");
+
+    if (placeholder) {
+      placeholder.style.display = "none";
+    }
+
+    isActivated = true;
+    initializeFullControls();
+    refresh();
+  }
+
+  /**
+   * Setup full control panel with enabled buttons
+   */
+  function initializeFullControls() {
+    const controlsWrapper = document.querySelector(CONFIG.controlsSelector);
+    if (!controlsWrapper) return;
+
+    const existingControls = controlsWrapper.querySelector(
+      ".parallel-coordinates-controls"
+    );
+    if (existingControls) {
+      existingControls.remove();
+    }
+
+    const controlsContainer = document.createElement("div");
+    controlsContainer.className = "parallel-coordinates-controls";
+
+    // Main button (Refresh when activated)
+    const mainBtn = document.createElement("button");
+    mainBtn.id = "s18ActivateBtn";
+    if (isActivated) {
+      mainBtn.className = "btn btn-outline-secondary btn-sm";
+      mainBtn.innerHTML = '<i class="bi bi-arrow-clockwise"></i> Refresh Graph';
+      mainBtn.addEventListener("click", refresh);
+    } else {
+      mainBtn.className = "btn btn-primary btn-sm";
+      mainBtn.innerHTML =
+        '<i class="bi bi-shuffle"></i> Activate Optimization View';
+      mainBtn.addEventListener("click", activateVisualization);
+    }
+
+    // Action buttons (only when activated)
+    let restoreBaselineBtn,
+      decarbonizeBtn,
+      optimizeBtn,
+      superOptimizeBtn,
+      passivhausBtn;
+
+    if (isActivated) {
+      restoreBaselineBtn = document.createElement("button");
+      restoreBaselineBtn.className = "btn btn-secondary btn-sm";
+      restoreBaselineBtn.innerHTML = "Restore Baseline";
+      restoreBaselineBtn.addEventListener("click", handleRestoreBaseline);
+
+      decarbonizeBtn = document.createElement("button");
+      decarbonizeBtn.className = "btn btn-success btn-sm pc-btn-decarbonize";
+      decarbonizeBtn.innerHTML = "Decarbonize";
+      decarbonizeBtn.addEventListener("click", handleDecarbonize);
+
+      optimizeBtn = document.createElement("button");
+      optimizeBtn.className = "btn btn-sm pc-btn-optimize";
+      optimizeBtn.innerHTML = "Optimize";
+      optimizeBtn.addEventListener("click", handleOptimize);
+
+      superOptimizeBtn = document.createElement("button");
+      superOptimizeBtn.className = "btn btn-sm pc-btn-super-optimize";
+      superOptimizeBtn.innerHTML = "Super Optimize";
+      superOptimizeBtn.addEventListener("click", handleSuperOptimize);
+
+      passivhausBtn = document.createElement("button");
+      passivhausBtn.className = "btn btn-sm pc-btn-passivhaus";
+      passivhausBtn.innerHTML = "PassivHaus-ify";
+      passivhausBtn.addEventListener("click", handlePassivHausIfy);
+
+      // Apply tooltips
+      const tooltipManager = window.TEUI?.TooltipManager;
+      if (tooltipManager) {
+        tooltipManager.applyTooltip(decarbonizeBtn, "s18_decarbonize");
+        tooltipManager.applyTooltip(optimizeBtn, "s18_optimize");
+        tooltipManager.applyTooltip(superOptimizeBtn, "s18_super_optimize");
+        tooltipManager.applyTooltip(passivhausBtn, "s18_passivhaus");
+      }
+    }
+
+    // Layout container for right-side buttons
+    const layoutContainer = document.createElement("div");
+
+    const refreshBtn = createButton(
+      "bi-arrow-clockwise",
+      "Refresh Data",
+      refresh
+    );
+    const exportBtn = createButton("bi-download", "Export as PNG", exportToPNG);
+    const settingsBtn = createButton("bi-gear", "Settings", showSettingsModal);
+
+    // Feedback console
+    const feedbackConsole = document.createElement("span");
+    feedbackConsole.id = "s18-feedback-console";
+
+    // Legend
+    const legendContainer = document.createElement("div");
+    legendContainer.className = "pc-legend-container";
+
+    const lineLegendContainer = document.createElement("div");
+    lineLegendContainer.className = "pc-line-legend";
+
+    const targetLineLegend = document.createElement("div");
+    targetLineLegend.className = "pc-legend-item";
+    targetLineLegend.innerHTML = `
+      <div style="width: 20px; height: 3px; background: ${CONFIG.colors.target};"></div>
+      <span style="font-size: 12px; font-weight: 500; color: ${CONFIG.colors.target};">Target</span>
+    `;
+
+    const referenceLineLegend = document.createElement("div");
+    referenceLineLegend.className = "pc-legend-item";
+    referenceLineLegend.innerHTML = `
+      <div style="width: 20px; height: 3px; background: ${CONFIG.colors.reference};"></div>
+      <span style="font-size: 12px; font-weight: 500; color: ${CONFIG.colors.reference};">Reference</span>
+    `;
+
+    lineLegendContainer.appendChild(targetLineLegend);
+    lineLegendContainer.appendChild(referenceLineLegend);
+
+    const nodeLegendContainer = document.createElement("div");
+    nodeLegendContainer.className = "pc-node-legend";
+
+    const calculatedNodeLegend = document.createElement("div");
+    calculatedNodeLegend.className = "pc-legend-item";
+    calculatedNodeLegend.innerHTML = `
+      <svg width="16" height="16" style="display: block;">
+        <circle cx="8" cy="8" r="3" fill="${CONFIG.colors.target}" stroke="white" stroke-width="1"></circle>
+      </svg>
+      <span style="font-size: 12px; color: #666;">Calculated</span>
+    `;
+
+    const editableNodeLegend = document.createElement("div");
+    editableNodeLegend.className = "pc-legend-item";
+    editableNodeLegend.innerHTML = `
+      <svg width="16" height="16" style="display: block;">
+        <circle cx="8" cy="8" r="6" fill="${CONFIG.colors.target}" stroke="white" stroke-width="1.5"></circle>
+      </svg>
+      <span style="font-size: 12px; color: #666;">Editable</span>
+    `;
+
+    nodeLegendContainer.appendChild(calculatedNodeLegend);
+    nodeLegendContainer.appendChild(editableNodeLegend);
+
+    legendContainer.appendChild(lineLegendContainer);
+    legendContainer.appendChild(nodeLegendContainer);
+
+    const fullscreenBtn = createButton(
+      "bi-arrows-fullscreen",
+      "Toggle Fullscreen",
+      toggleFullscreen
+    );
+
+    layoutContainer.appendChild(legendContainer);
+    layoutContainer.appendChild(refreshBtn);
+    layoutContainer.appendChild(exportBtn);
+    layoutContainer.appendChild(settingsBtn);
+    layoutContainer.appendChild(fullscreenBtn);
+
+    // Inject feedback console into section header
+    const sectionHeader = document.querySelector(
+      "#parallelCoordinates .section-header"
+    );
+    if (
+      sectionHeader &&
+      !sectionHeader.querySelector("#s18-feedback-console")
+    ) {
+      sectionHeader.appendChild(feedbackConsole);
+    }
+
+    // Assemble controls
+    controlsContainer.appendChild(mainBtn);
+
+    if (
+      isActivated &&
+      restoreBaselineBtn &&
+      decarbonizeBtn &&
+      optimizeBtn &&
+      superOptimizeBtn &&
+      passivhausBtn
+    ) {
+      controlsContainer.appendChild(restoreBaselineBtn);
+      controlsContainer.appendChild(decarbonizeBtn);
+      controlsContainer.appendChild(optimizeBtn);
+      controlsContainer.appendChild(superOptimizeBtn);
+      controlsContainer.appendChild(passivhausBtn);
+    }
+
+    controlsContainer.appendChild(layoutContainer);
+    controlsWrapper.appendChild(controlsContainer);
+  }
+
+  /**
+   * Helper to create a button with icon
+   */
+  function createButton(iconClass, tooltip, clickHandler) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-outline-secondary btn-sm";
+    btn.setAttribute("title", tooltip);
+    btn.innerHTML = `<i class="bi ${iconClass}"></i>`;
+    btn.addEventListener("click", clickHandler);
+    return btn;
+  }
+
+  /**
+   * Show settings modal for ROI Term
+   */
+  function showSettingsModal() {
+    const backdrop = document.createElement("div");
+    backdrop.className = "pc-modal-backdrop";
+
+    const modal = document.createElement("div");
+    modal.className = "pc-modal-dialog";
+
+    const header = document.createElement("h5");
+    header.textContent = "Financial Settings";
+    header.className = "pc-modal-header";
+
+    const label = document.createElement("label");
+    label.textContent = "ROI Term (Years):";
+    label.className = "pc-modal-label";
+
+    const select = document.createElement("select");
+    select.className = "form-select pc-modal-select";
+
+    const terms = [1, 2, 3, 4, 5, 10, 15, 20, 30, 40, 50];
+    terms.forEach(year => {
+      const option = document.createElement("option");
+      option.value = year;
+      option.textContent = `${year} year${year > 1 ? "s" : ""}`;
+      if (year === CONFIG.roiTerm) {
+        option.selected = true;
+      }
+      select.appendChild(option);
+    });
+
+    const btnContainer = document.createElement("div");
+    btnContainer.className = "pc-modal-actions";
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.className = "btn btn-outline-secondary";
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.addEventListener("click", () => {
+      document.body.removeChild(backdrop);
+    });
+
+    const applyBtn = document.createElement("button");
+    applyBtn.className = "btn btn-primary";
+    applyBtn.textContent = "Apply";
+    applyBtn.addEventListener("click", () => {
+      const newTerm = parseInt(select.value);
+      CONFIG.roiTerm = newTerm;
+      console.log(`[ParallelCoordinates] ROI Term updated to ${newTerm} years`);
+      refresh();
+      document.body.removeChild(backdrop);
+    });
+
+    btnContainer.appendChild(cancelBtn);
+    btnContainer.appendChild(applyBtn);
+
+    modal.appendChild(header);
+    modal.appendChild(label);
+    modal.appendChild(select);
+    modal.appendChild(btnContainer);
+
+    backdrop.appendChild(modal);
+    document.body.appendChild(backdrop);
+
+    backdrop.addEventListener("click", e => {
+      if (e.target === backdrop) {
+        document.body.removeChild(backdrop);
+      }
+    });
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // DATA MANAGEMENT
+  // ══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Fetch current data from StateManager via pcConfig
+   */
+  function fetchData() {
+    console.log("[ParallelCoordinates] Fetching data from StateManager");
+
+    if (!window.TEUI.getParallelCoordinatesData) {
+      console.error("[ParallelCoordinates] Config module not loaded");
+      return null;
+    }
+
+    const data = window.TEUI.getParallelCoordinatesData();
+
+    if (!data || !data.axes || data.axes.length === 0) {
+      console.warn("[ParallelCoordinates] No valid data available");
+      return null;
+    }
+
+    console.log(
+      "[ParallelCoordinates] Fetched data for",
+      data.axes.length,
+      "axes"
+    );
+    return data;
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // UTILITY FUNCTIONS
+  // ══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Show feedback message in S18 console
+   */
+  function showFeedback(message, duration = 5000) {
+    const console = document.getElementById("s18-feedback-console");
+    if (!console) return;
+
+    console.textContent = message;
+    console.style.opacity = "1";
+
+    setTimeout(() => {
+      console.style.transition = "opacity 1s";
+      console.style.opacity = "0";
+      setTimeout(() => {
+        console.textContent = "";
+        console.style.opacity = "1";
+        console.style.transition = "";
+      }, 1000);
+    }, duration);
+  }
+
+  /**
+   * Show error message
+   */
+  function showErrorMessage(message) {
+    const container = document.querySelector(CONFIG.containerSelector);
+    if (!container) return;
+
+    const errorDiv = document.createElement("div");
+    errorDiv.className = "alert alert-warning";
+    errorDiv.style.margin = "20px";
+    errorDiv.innerHTML = `<strong>Warning:</strong> ${message}`;
+
+    container.innerHTML = "";
+    container.appendChild(errorDiv);
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // RENDERING - Delegates to pcRendering.js module
+  // ══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Main refresh function
+   */
+  function refresh() {
+    console.log("[ParallelCoordinates] Refreshing visualization");
+
+    currentData = fetchData();
+
+    if (!currentData) {
+      console.warn("[ParallelCoordinates] Cannot render - no data available");
+      showErrorMessage(
+        "No data available. Please ensure all required fields are calculated."
+      );
+      return;
+    }
+
+    // Delegate to rendering module
+    if (!window.TEUI.PCRendering) {
+      console.error("[ParallelCoordinates] Rendering module not loaded");
+      return;
+    }
+
+    window.TEUI.PCRendering.renderGraph(currentData, CONFIG);
+    window.TEUI.PCRendering.renderTable(currentData, CONFIG);
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // EXPORT & FULLSCREEN
+  // ══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Toggle fullscreen mode
+   */
+  function toggleFullscreen() {
+    const section = document.getElementById("parallelCoordinates");
+    if (!section) return;
+
+    isFullscreen = !isFullscreen;
+    section.classList.toggle("pc-fullscreen", isFullscreen);
+
+    // Reset rendering cache and re-render
+    window.TEUI.PCRendering?.resetCache();
+    setTimeout(refresh, 100);
+
+    console.log("[ParallelCoordinates] Fullscreen:", isFullscreen);
+  }
+
+  /**
+   * Export visualization as PNG
+   */
+  function exportToPNG() {
+    console.log("[ParallelCoordinates] Exporting to PNG...");
+
+    const svgNode = document.querySelector(CONFIG.containerSelector + " svg");
+    if (!svgNode) {
+      alert("No graph to export");
+      return;
+    }
+
+    const serializer = new XMLSerializer();
+    const svgString = serializer.serializeToString(svgNode);
+
+    const canvas = document.createElement("canvas");
+    const bbox = svgNode.getBoundingClientRect();
+    canvas.width = bbox.width;
+    canvas.height = bbox.height;
+
+    const ctx = canvas.getContext("2d");
+    const img = new Image();
+
+    img.onload = function () {
+      ctx.drawImage(img, 0, 0);
+
+      canvas.toBlob(function (blob) {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "parallel-coordinates-optimization.png";
+        a.click();
+        URL.revokeObjectURL(url);
+        console.log("[ParallelCoordinates] PNG export complete");
+      });
+    };
+
+    img.src =
+      "data:image/svg+xml;base64," +
+      btoa(unescape(encodeURIComponent(svgString)));
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // ACTION HANDLERS - Delegates to pcOptimization.js module
+  // ══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Restore Baseline handler
+   */
+  function handleRestoreBaseline() {
+    console.log("[ParallelCoordinates] Restore Baseline action triggered");
+
+    if (window.TEUI?.StateManager?.resetTier1_UndoChanges) {
+      window.TEUI.StateManager.resetTier1_UndoChanges();
+      showFeedback("Baseline restored - reverted to imported data", 3000);
+
+      setTimeout(() => {
+        refresh();
+        console.log(
+          "[ParallelCoordinates] Graph auto-refreshed after baseline restore"
+        );
+      }, 200);
+    } else {
+      console.error(
+        "[ParallelCoordinates] StateManager.resetTier1_UndoChanges not found"
+      );
+      showFeedback("Error: Reset function not available", 3000);
+    }
+  }
+
+  /**
+   * Decarbonize handler - delegates to pcOptimization module
+   */
+  function handleDecarbonize() {
+    if (!window.TEUI.PCOptimization) {
+      console.error("[ParallelCoordinates] Optimization module not loaded");
+      return;
+    }
+    window.TEUI.PCOptimization.handleDecarbonize(showFeedback, refresh);
+  }
+
+  /**
+   * Optimize handler - delegates to pcOptimization module
+   */
+  function handleOptimize() {
+    if (!window.TEUI.PCOptimization) {
+      console.error("[ParallelCoordinates] Optimization module not loaded");
+      return;
+    }
+    window.TEUI.PCOptimization.handleOptimize(showFeedback, refresh);
+  }
+
+  /**
+   * Super Optimize handler - delegates to pcOptimization module
+   */
+  function handleSuperOptimize() {
+    if (!window.TEUI.PCOptimization) {
+      console.error("[ParallelCoordinates] Optimization module not loaded");
+      return;
+    }
+    window.TEUI.PCOptimization.handleSuperOptimize(showFeedback, refresh);
+  }
+
+  /**
+   * PassivHaus-ify handler - delegates to pcOptimization module
+   */
+  function handlePassivHausIfy() {
+    if (!window.TEUI.PCOptimization) {
+      console.error("[ParallelCoordinates] Optimization module not loaded");
+      return;
+    }
+    window.TEUI.PCOptimization.handlePassivHausIfy(showFeedback, refresh);
+  }
+
+  // ══════════════════════════════════════════════════════════════════════
+  // PUBLIC API
+  // ══════════════════════════════════════════════════════════════════════
+
+  return {
+    initialize: initialize,
+    refresh: refresh,
+    activate: activateVisualization,
+    isActivated: () => isActivated,
+  };
+})();
+
+// Auto-initialize when DOM is ready
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => {
+    window.TEUI.ParallelCoordinates.initialize();
+  });
+} else {
+  window.TEUI.ParallelCoordinates.initialize();
+}
+
+console.log("[ParallelCoordinates] Module loaded (Refactored Nov 30, 2025)");
+

--- a/js/cclimb/parallel-coords.mjs
+++ b/js/cclimb/parallel-coords.mjs
@@ -1,0 +1,39 @@
+/**
+ * parallel-coords.mjs — D3 parallel-coordinates widget for CCLIMB
+ *
+ * Ported from OBJECTIVE module 18 (src/core/ParallelCoordinates.js).
+ * Source reference at js/cclimb/parallel-coordinates.objective-source.js.
+ *
+ * @see CCLIMB-Workplan2.md §3 (Visualization design) + §4 (Implementation sketch)
+ *
+ * The full port from OBJECTIVE's IIFE (window.TEUI.ParallelCoordinates) to an
+ * ES-module export is a P1 task. P0 stubs the API surface so the entry point
+ * can wire to it without referencing-undefined.
+ */
+
+import { LCA_MODULES, OUTPUT_AXES, PHASE_BANDS } from "./chart-config.mjs";
+
+/**
+ * Initialize the parallel-coordinates chart inside a given container element.
+ *
+ * @param {HTMLElement} container - DOM node where the SVG will be rendered
+ * @param {Object} opts - { modules, outputAxes, rt: [{component, values}], pt: [{component, values}] }
+ * @returns {Object} - { update(rt, pt), destroy() }
+ */
+export function initParallelCoords(container, opts = {}) {
+  // P1: replicate the OBJECTIVE D3 logic adapted for CCLIMB axes.
+  // For now, log the intended axis layout and return a no-op handle.
+  console.log(
+    "[CCLIMB parallel-coords] Init placeholder. Axes:",
+    [...LCA_MODULES, ...OUTPUT_AXES].map((a) => a.id).join(" · ")
+  );
+
+  return {
+    update(rt, pt) {
+      console.log("[CCLIMB parallel-coords] update — P1 will render", { rt, pt });
+    },
+    destroy() {
+      console.log("[CCLIMB parallel-coords] destroy — P1 noop");
+    }
+  };
+}

--- a/js/cclimb/reference-trajectories.mjs
+++ b/js/cclimb/reference-trajectories.mjs
@@ -1,0 +1,62 @@
+/**
+ * reference-trajectories.mjs — RT-A defaults + RT-B custom
+ *
+ * Per CCLIMB §4.1 (Climate Interpretation – Reference Trajectory):
+ *
+ *   RT-A (Near-Term Emission, default for Tier 1):
+ *     E_RT(t) = C₀ · k · e^(−k·t),  where k = 1 / τ, τ within 5 yr (or 10 yr)
+ *
+ *   RT-B (Custom):
+ *     E_RT(t) = 0                              for t < t_d
+ *     E_RT(t) = C₀ · k · e^(−k·(t − t_d))      for t ≥ t_d
+ *
+ * @see CCLIMB-Workplan2.md §3.5 — Per-category input requirements (axis vocabulary)
+ */
+
+import { DEFAULT_TIER1_HORIZON_YEARS } from "./chart-config.mjs";
+
+// RT-A archetype parameters. The "default" string identifiers correspond to
+// the workflow diagram values: −1/+1, −5/+5. Custom is RT-B.
+export const RT_A_ARCHETYPES = {
+  default_1: {
+    label: "RT-A: −1/+1 default",
+    growth_years: 1,
+    decay_years: 1,
+    notes: "Annual-cycle counterfactual (Category B short-rotation crops, fastest return)"
+  },
+  default_5: {
+    label: "RT-A: −5/+5 default",
+    growth_years: 5,
+    decay_years: 5,
+    notes: "Within-5-year horizon (Category A waste / B perennial residues — CCLIMB v2 default)"
+  }
+  // Other defaults pending working-group decisions (see §7.1 of CCLIMB-Workplan2.md)
+};
+
+/**
+ * Compute a reference trajectory's per-year emission series.
+ *
+ * @param {string} type - "RT-A" or "RT-B"
+ * @param {Object} params - { archetype: "default_5" } for RT-A, or
+ *                          { growth_years: N, decay_years: M } for RT-B
+ * @param {number} C0 - Initial carbon stock (kgCO2e equivalent)
+ * @param {number} horizonYears - Number of years to compute (typically t_ref)
+ * @returns {Array<number>} Per-year emission series [year 0, year 1, ...]
+ */
+export function getReferenceTrajectory(type, params, C0, horizonYears) {
+  if (type === "RT-A") {
+    const arch = RT_A_ARCHETYPES[params.archetype || "default_5"];
+    const tau = arch.decay_years;
+    const k = 1 / tau;
+    return Array.from({ length: horizonYears + 1 }, (_, t) => C0 * k * Math.exp(-k * t));
+  }
+  if (type === "RT-B") {
+    const t_d = params.growth_years || 0;
+    const tau = params.decay_years || DEFAULT_TIER1_HORIZON_YEARS;
+    const k = 1 / tau;
+    return Array.from({ length: horizonYears + 1 }, (_, t) =>
+      t < t_d ? 0 : C0 * k * Math.exp(-k * (t - t_d))
+    );
+  }
+  throw new Error(`[CCLIMB reference-trajectories] Unknown RT type: ${type}`);
+}

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -1156,17 +1156,50 @@ function extractNA(text, rec) {
     text.match(/D\s*ECLARATION\s+H\s*OLDER\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/) ||
     text.match(/Manufacturer\s+name(?:\s+and\s+address)?\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/) ||
     text.match(/EPD\s+Commissioner\s+(?:and\s+)?Owner\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/i) ||
-    text.match(/Declaration\s+holder\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/i);
+    text.match(/Declaration\s+holder\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/i) ||
+    // New label patterns from 2026-05-19 scaling audit. EFCO uses
+    // "EPD HOLDER" (no colon), LP_ExpertFinish uses "DECLARATION OWNER"
+    // (no colon), Element5 uses "Owner of the EPD" (mixed case).
+    text.match(/EPD\s+HOLDER\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/) ||
+    text.match(/DECLARATION\s+OWNER\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/) ||
+    text.match(/Owner\s+of\s+the\s+EPD\s*[:\s]+([A-Z][A-Za-z0-9 &.,'\-]{2,80})/i);
   if (mfr) _setPath(rec, "manufacturer.name", _cleanLine(mfr[1]));
 
   // Title-prose fallback for layouts where spatial join breaks the
   // label-then-value relationship. Cover-page titles commonly read
   // "EPD for X produced by/at <CompanyName>", and the company name is
   // followed by lowercase words ("in", "for", "'s facility") which the
-  // capital-letter chain naturally stops on.
+  // capital-letter chain naturally stops on. Extended 2026-05-19 to
+  // also accept "in" (Mutual Materials: "produced in Mutual Material's
+  // Mica Plant") and "for" (LP: "PRODUCED BY LOUISIANA-PACIFIC"), to
+  // allow hyphens / dots / apostrophes in the company name, and to
+  // run case-insensitively for ALL-CAPS cover-page prose.
   if (!_get(rec, "manufacturer.name")) {
-    var prodBy = text.match(/produced\s+(?:by|at)\s+([A-Z][A-Za-z]+(?:'\w+)?(?:\s+[A-Z][A-Za-z]+){0,2})/);
+    var prodBy = text.match(/produced\s+(?:by|at|in|for)\s+([A-Z][A-Za-z0-9.\-]+(?:'\w+)?(?:\s+[A-Z][A-Za-z0-9.\-]+){0,4})/i);
     if (prodBy) _setPath(rec, "manufacturer.name", _cleanLine(prodBy[1]));
+  }
+
+  // Narrative-ownership fallback. "<X> is pleased to present this EPD"
+  // / "<X> presents this declaration" — common cover-page phrasing
+  // where no label-anchor exists (SOPRASEAL: "SOPREMA is pleased to
+  // present this Environmental Product Declaration"). Bounded by the
+  // narrative verb so the capture can't drift into body text.
+  if (!_get(rec, "manufacturer.name")) {
+    var present = text.match(/([A-Z][A-Za-z0-9 &.,'\-]{2,60}?)\s+(?:is\s+pleased\s+to\s+present|presents\s+this|hereby\s+presents)/);
+    if (present) _setPath(rec, "manufacturer.name", _cleanLine(present[1]));
+  }
+
+  // Corporate-suffix line fallback. Standalone line of the form
+  // "<X> Inc./Corp./LLC/LP/Ltd./GmbH/S.A./S.r.l." with no label.
+  // Element5 cover page ("ELEMENT5 LP – MODERN TIMBER BUILDINGS"),
+  // SOPRASEAL page 1 ("SOPREMA Inc."). Limited to the first 60 lines
+  // of the document (cover page + immediate front-matter) to avoid
+  // customer-reference bleed from body text. The capture stops at
+  // the suffix so the trailing tagline doesn't get included.
+  if (!_get(rec, "manufacturer.name")) {
+    var lines60 = text.split("\n").slice(0, 60).join("\n");
+    var suffix = lines60.match(/(?:^|\n)\s*([A-Z][A-Za-z0-9 &.,'\-]{1,60}\s+(?:Inc|Corp|Corporation|LLC|LLP|LP|Ltd|Limited|GmbH|S\.?\s?A\.?|S\.r\.l\.))\.?(?=\s|$|,|\n|–|—|-)/m);
+    if (suffix) _setPath(rec, "manufacturer.name", _cleanLine(suffix[1]));
   }
 
   // EPD ID / Declaration Number — allow embedded spaces in the value
@@ -1176,8 +1209,12 @@ function extractNA(text, rec) {
   // Glulam 3" → "EPD 296"). EPD IDs are 1-2 tokens of alphanumeric +
   // dashes/dots; anything after a known next-label word is column-bleed.
   var epdId =
-    text.match(/D\s*eclaration\s+N\s*umber\s*[#:\s]+([A-Z][A-Z0-9.\-#\s]{2,38}\d[A-Z0-9.\-#]{0,10})/i) ||
-    text.match(/EPD\s+(?:Registration\s+)?Number\s*[#:\s]+([A-Z0-9][A-Z0-9.\-#\s]{2,38}\d[A-Z0-9.\-#]{0,10})/i);
+    // First-char allows digits now (2026-05-19) so numeric-only ids
+    // like EFCO's "DECLARATION NUMBER 494" extract. Length floor
+    // dropped to 1 so "EPD 1" / "EPD 12" survive; the {2,38} body
+    // covers the typical 3-7-digit shapes.
+    text.match(/D\s*eclaration\s+N\s*umber\s*[#:\s]+([A-Z0-9][A-Z0-9.\-#\s]{1,38}\d?[A-Z0-9.\-#]{0,10})/i) ||
+    text.match(/EPD\s+(?:Registration\s+)?Number\s*[#:\s]+([A-Z0-9][A-Z0-9.\-#\s]{1,38}\d?[A-Z0-9.\-#]{0,10})/i);
   if (epdId) {
     var idRaw = epdId[1].split(
       /\s+(?=(?:Declared|Date|Period|Unit|Owner|Holder|Type|Scope|Reference|Markets|Description|Year|EPD\s+Type|EPD\s+Scope|Programme|Program|Issue|Valid|Publisher))/i

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -1305,13 +1305,38 @@ function extractNA(text, rec) {
     _findDateAfterLabel(text, /Expiry\s+date/i);
   if (expIso) _setPath(rec, "epd.expiry_date", expIso);
 
-  // EPD type
-  var typ = text.match(/EPD\s+type\s*[:\s]+([^\n\r]{4,40})/i);
+  // EPD type — label-anchored first ("EPD type: <value>" / "Declaration
+  // type:" / "EPD scope:"). The labels themselves are uncommon — only
+  // ~20% of EPDs publish an explicit type field — but when present they
+  // give the cleanest signal.
+  var typ =
+    text.match(/EPD\s+type\s*[:\s]+([^\n\r]{4,80})/i) ||
+    text.match(/Declaration\s+type\s*[:\s]+([^\n\r]{4,80})/i) ||
+    text.match(/Type\s+of\s+EPD\s*[:\s]+([^\n\r]{4,80})/i);
   if (typ) {
     var t = typ[1].toLowerCase();
     if (/product[-\s]*specific/.test(t)) _setPath(rec, "epd.type", "product_specific");
-    else if (/industry[-\s]*average/.test(t)) _setPath(rec, "epd.type", "industry_average");
+    else if (/(?:industry|business|sector)[-\s]*average/.test(t)) _setPath(rec, "epd.type", "industry_average");
+    else if (/company[-\s]*specific/.test(t)) _setPath(rec, "epd.type", "product_specific");
     else if (/generic/.test(t)) _setPath(rec, "epd.type", "generic");
+  }
+
+  // Prose-based fallback. Most NA / Wood EPDs declare type in title-prose
+  // ("A company-specific cradle-to-gate EPD for X", "product-specific
+  // Type III Environmental Product Declaration"). Scope to the first
+  // 100 lines + require the type keyword to sit within 60 chars of an
+  // EPD/Declaration/"Type III" anchor so body-text mentions of e.g.
+  // "industry-average data" don't false-positive into the type slot.
+  if (!_get(rec, "epd.type")) {
+    var head = text.split("\n").slice(0, 100).join("\n");
+    var anchored =
+      head.match(/(?:EPD|Declaration|Type\s*III)[^\n]{0,60}?(product[-\s]+specific|company[-\s]+specific|industry[-\s]+average|business[-\s]+average|sector[-\s]+average)/i) ||
+      head.match(/(product[-\s]+specific|company[-\s]+specific|industry[-\s]+average|business[-\s]+average|sector[-\s]+average)[^\n]{0,60}?(?:EPD|Declaration|Type\s*III)/i);
+    if (anchored) {
+      var phrase = anchored[1].toLowerCase();
+      if (/product[-\s]+specific|company[-\s]+specific/.test(phrase)) _setPath(rec, "epd.type", "product_specific");
+      else if (/(?:industry|business|sector)[-\s]+average/.test(phrase)) _setPath(rec, "epd.type", "industry_average");
+    }
   }
 
   // Markets of applicability
@@ -1321,6 +1346,31 @@ function extractNA(text, rec) {
   if (mkts) {
     var arr = _splitToCodes(mkts[1]);
     if (arr.length) _setPath(rec, "provenance.markets_of_applicability", arr);
+  }
+
+  // Validation type — runs for all formats (per-format extractors only
+  // see the subset where their format detection fires). Tries the
+  // verification-marker forms in order of specificity:
+  //   - "internally X externally"            — IBU adverb form
+  //   - "internal X external"                — adjective form (Arcadia)
+  //   - "X__ Externally" / "___ X external"  — underscore-noise from
+  //                                            checkbox-replacement layout (EFCO)
+  //   - "External verification" / "Independent verification" — prose
+  if (!_get(rec, "epd.validation.type")) {
+    var validationText = text.replace(/_+/g, " "); // collapse underscore checkbox-noise
+    if (/internally\s*[x✓]\s*externally/i.test(validationText)) {
+      _setPath(rec, "epd.validation.type", "external");
+    } else if (/internal\s*[x✓]\s*external/i.test(validationText)) {
+      _setPath(rec, "epd.validation.type", "external");
+    } else if (/[x✓]\s*externally/i.test(validationText) || /[x✓]\s*external\b/i.test(validationText)) {
+      _setPath(rec, "epd.validation.type", "external");
+    } else if (/[x✓]\s*internally/i.test(validationText) || /[x✓]\s*internal\b/i.test(validationText)) {
+      _setPath(rec, "epd.validation.type", "internal");
+    } else if (/(?:external|independent|third[-\s]+party)\s+verification/i.test(text)) {
+      _setPath(rec, "epd.validation.type", "external");
+    } else if (/internal\s+verification/i.test(text)) {
+      _setPath(rec, "epd.validation.type", "internal");
+    }
   }
 }
 

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -1282,16 +1282,24 @@ function extractNA(text, rec) {
     if (pcrLine) _setPath(rec, "methodology.pcr_guidelines", _cleanLine(pcrLine[1]));
   }
 
-  // Publication date — label-then-window
+  // Publication date — label-then-window. "Date of Issuance" added
+  // 2026-05-19 (Arcadia / EFCO-family use this variant), and a bare
+  // "Issuance date" form for completeness.
   var pubIso =
     _findDateAfterLabel(text, /Date\s+of\s+Issue\s*(?:&\s*Validity\s+Period)?/i) ||
+    _findDateAfterLabel(text, /Date\s+of\s+Issuance/i) ||
     _findDateAfterLabel(text, /Publication\s+date/i) ||
+    _findDateAfterLabel(text, /Issuance\s+date/i) ||
     _findDateAfterLabel(text, /Issue\s+date/i);
   if (pubIso) _setPath(rec, "epd.publication_date", pubIso);
 
-  // Expiry / validity
+  // Expiry / validity. "Valid through" added 2026-05-19 (Arcadia
+  // uses "Valid through April 11, 2026"); "Valid thru" / "Valid
+  // until" already supported.
   var expIso =
     _findDateAfterLabel(text, /Period\s+of\s+validity/i) ||
+    _findDateAfterLabel(text, /Valid\s+through/i) ||
+    _findDateAfterLabel(text, /Valid\s+thru/i) ||
     _findDateAfterLabel(text, /Valid\s+until/i) ||
     _findDateAfterLabel(text, /Valid\s+to/i) ||
     _findDateAfterLabel(text, /Expiry\s+date/i);
@@ -1597,6 +1605,18 @@ function _parseDate(s) {
   // DD/MM/YYYY (European)
   var eu = str.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
   if (eu) return eu[3] + "-" + _pad2(eu[2]) + "-" + _pad2(eu[1]);
+
+  // DD.MM.YYYY (German / European IBU convention — e.g. "08.06.2021"
+  // for "8 June 2021"). Order is unambiguous because the year is 4
+  // digits; the day-first / month-first ambiguity in DD/MM vs MM/DD
+  // doesn't apply to dot-separated dates outside North America.
+  var euDot = str.match(/(\d{1,2})\.(\d{1,2})\.(\d{4})/);
+  if (euDot) return euDot[3] + "-" + _pad2(euDot[2]) + "-" + _pad2(euDot[1]);
+
+  // DD-MM-YYYY (European dash). Same disambiguation logic as dots —
+  // 4-digit year locks the position regardless of separator.
+  var euDash = str.match(/^\s*(\d{1,2})-(\d{1,2})-(\d{4})\b/);
+  if (euDash) return euDash[3] + "-" + _pad2(euDash[2]) + "-" + _pad2(euDash[1]);
 
   // "DD Month YYYY" — tolerate weird whitespace around the comma
   var en = str.match(/(\d{1,2})\s+([A-Za-z]+)\s*,?\s*(\d{4})/);

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -1254,8 +1254,26 @@ function extractNA(text, rec) {
     if (dInLine) _setPath(rec, "physical.density.value_kg_m3", _toNum(dInLine[1].replace(/,/g, "")));
   }
   if (_get(rec, "physical.density.value_kg_m3") == null) {
-    var d = text.match(/density\s*(?:of\s+)?((?:\d{1,3}(?:,\d{3})+|\d{2,})(?:\.\d+)?)\s*kg\/m\s*[³^]?3?/i);
+    // density[:\s]* tolerates "Density: 25.214 kg/m^3" (AFT Cellulose,
+    // 2026-05-19 audit) — old regex required whitespace immediately
+    // after "density" and choked on the colon. Also added kg\s*\/\s*m
+    // to absorb pdf.js-inserted spaces around the slash.
+    var d = text.match(/density[\s:]*(?:of\s+)?((?:\d{1,3}(?:,\d{3})+|\d{2,})(?:\.\d+)?)\s*kg\s*\/\s*m\s*[³^]?3?/i);
     if (d) _setPath(rec, "physical.density.value_kg_m3", _toNum(d[1].replace(/,/g, "")));
+  }
+
+  // Specific gravity / relative density fallback. SOPRASEAL family
+  // publishes "Specific gravity 1.08 kg/L" — kg/L is numerically
+  // identical to g/cm³; multiplied by 1000 it gives kg/m³. Bounded
+  // to 0.1–25 to capture realistic building-material range
+  // (lightweight wood ~0.3 to steel ~7.85; cap at 25 leaves room
+  // for unusual cases without admitting wildly off values).
+  if (_get(rec, "physical.density.value_kg_m3") == null) {
+    var sg = text.match(/(?:specific\s+gravity|relative\s+density)\s*[:\s]+((?:\d{1,2})(?:\.\d+)?)\s*(?:kg\s*\/\s*L|g\s*\/\s*cm|\b)/i);
+    if (sg) {
+      var sgVal = parseFloat(sg[1]);
+      if (sgVal > 0.1 && sgVal < 25) _setPath(rec, "physical.density.value_kg_m3", Math.round(sgVal * 1000));
+    }
   }
   // Wood EPD product-properties table form: "Mass (including moisture)
   // kg <N>" where <N> is mass per the declared unit. For declared unit
@@ -1466,7 +1484,10 @@ function extractEuIbu(text, rec) {
     if (unitM) _setPath(rec, "carbon.stated.per_unit", _cleanLine(unitM[1]));
   }
   if (_get(rec, "physical.density.value_kg_m3") == null) {
-    var densM = text.match(/(?:average\s+weighted\s+)?density\s+of\s+((?:\d{1,3}(?:,\d{3})+|\d{2,})(?:\.\d+)?)\s*kg\/m\s*[³^]?3?/i);
+    // Tolerant variants (2026-05-19): "density: <N>" / "density <N>"
+    // (no `of`), pdf.js-inserted whitespace around the slash, optional
+    // "gross / dry / apparent / bulk" qualifiers preceding "density".
+    var densM = text.match(/(?:gross|dry|apparent|bulk|average\s+weighted)?\s*density[\s:]*(?:of\s+)?((?:\d{1,3}(?:,\d{3})+|\d{2,})(?:\.\d+)?)\s*kg\s*\/\s*m\s*[³^]?3?/i);
     if (densM) _setPath(rec, "physical.density.value_kg_m3", _toNum(densM[1].replace(/,/g, "")));
   }
 }

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -211,7 +211,23 @@ var _MATERIAL_TYPE_DISPLAY_KEYWORDS = [
   { rx: /\bfiberglass\b|\bfibreglass\b/i, type: "Fiberglass" },
   // Finishes
   { rx: /\bgypsum\b|\bdrywall\b/i, type: "Gypsum" },
-  { rx: /\bvinyl\s+(?:floor|tile|sheet)\b|\bLVT\b/i, type: "Luxury vinyl tile" }
+  { rx: /\bvinyl\s+(?:floor|tile|sheet)\b|\bLVT\b/i, type: "Luxury vinyl tile" },
+  // Membranes / barriers (added 2026-05-19). Captures vapour/vapor
+  // control membranes, weather-resistive barriers (WRB), air barriers,
+  // liquid-applied membranes, and self-adhered membranes — a large
+  // family in roofing/cladding/envelope EPDs.
+  { rx: /\bvapou?r\s+(?:control\s+)?membrane\b|\bWRB\b|\bweather[- ]?resistive\s+barrier\b|\bair\s+barrier\b/i, type: "Membrane" },
+  { rx: /\bself[- ]?adhered\s+membrane\b|\bstick[- ]?down\s+membrane\b|\bliquid[- ]?applied\s+membrane\b/i, type: "Membrane" },
+  { rx: /\bbituminous\s+membrane\b|\basphalt\s+(?:roll\s+)?roofing\b|\bAPP\s+modified\s+asphalt\b/i, type: "Bituminous membrane" },
+  // Wood fibre insulation (PAVATEX / GUTEX / Steico). Already partially
+  // covered by db-fallbacks "wood_fiberboard" alias, but the explicit
+  // keyword anchors the Tier-2 classifier so we don't drop to "unknown
+  // material_type" on dry-process insulation boards.
+  { rx: /\bwood\s+fib(?:re|er)(?:\s+(?:insulation|board))?\b/i, type: "Wood fiber insulation" },
+  // Sheep wool insulation (Thermafleece, Black Mountain, etc.).
+  { rx: /\bsheep['\s]?\s*wool(?:\s+insulation)?\b|\bThermafleece\b|\bnatural\s+wool\s+insulation\b/i, type: "Sheep wool insulation" },
+  // Concrete admixtures (BioLock, plasticizers, accelerators).
+  { rx: /\bconcrete\s+admixture\b|\bcement\s+admixture\b/i, type: "Admixture" }
 ];
 
 function extractType(text, rec) {
@@ -227,7 +243,7 @@ function extractType(text, rec) {
   // three separate one-letter-then-rest lines, each of which would
   // otherwise pass the picker as a 2-word title candidate.
   var skipPrefix =
-    /^(?:type\s+iii|e\s*nvironmental(?:\s+p\s*roduct\s+d\s*eclaration)?|p\s*roduct\s*$|d\s*eclaration\s*$|environmental\s+product\s+declaration|epd\b|in\s+accordance|as\s+per\b|according\s+to\b|programme|program\b|publisher\b|owner\s+of|declaration\s+number|issue\s+date|valid\s+to|valid\s+until|publication\s+date|page\s+\d|\d+\s*\/\s*\d+|—|–|-{2,})/i;
+    /^(?:type\s+iii|e\s*nvironmental(?:\s+p\s*roduct\s+d\s*eclaration)?|p\s*roduct\s*$|d\s*eclaration\s*$|environmental\s+product\s+declaration|epd\b|in\s+accordance|as\s+per\b|according\s+to\b|programme|program\b|publisher\b|owner[\s:]|holder[\s:]|deklarationsinhaber|herausgeber|owner\s+of|declaration\s+number|issue\s+date|valid\s+to|valid\s+until|publication\s+date|page\s+\d|\d+\s*\/\s*\d+|—|–|-{2,}|an\s+environmental\s+product\s+declaration|an\s+epd\b|product\s+declaration\b|report\s+for\s+review|fiche\s+de\s+d[ée]claration|eco\s+epd\s+ref|version\s+\d+\s*$)/i;
   // Standards-citation lines also need to be skipped — these often
   // appear right under the title block on EU/IBU layouts where the
   // line "as per ISO 14025 and EN 15804+A1" otherwise gets picked.

--- a/js/epd/extract.mjs
+++ b/js/epd/extract.mjs
@@ -488,7 +488,7 @@ function extractCommon(text, rec) {
 // harness 2026-04-27.
 var DATA_ROW_TAIL = "(?=\\s+-?\\s*\\d|\\s*[\\]\\)]|\\s*$)";
 
-var IMPACT_INDICATORS = [
+export var IMPACT_INDICATORS = [
   // GWP fossil / total — comes BEFORE the biogenic regex so the more
   // specific "BIO" alternation doesn't grab the fossil row.
   {
@@ -801,7 +801,7 @@ function _extractIndicatorTotals(text, rec) {
 // the labels EPDs actually use in tabular impact rows; reuses the same
 // vocabulary as the IMPACT_INDICATORS regexes for English forms but
 // strips the unit + value parts so the regex matches the row prefix.
-var _BYSTAGE_LABELS = [
+export var _BYSTAGE_LABELS = [
   // GWP fossil/total — guards against matching the Fossil/Biogenic
   // sub-rows by negative lookahead, same pattern as fix #5.
   {
@@ -929,7 +929,7 @@ function _tokenizeImpactNumbers(line) {
 // So for "1 mt" rows, label is at i+1 (forward 1).
 // For "1 ton" rows, label is at i-2 (back 2).
 // Try those two positions in order; first match wins.
-var _CISC_LABEL_PATTERNS = [
+export var _CISC_LABEL_PATTERNS = [
   { rx: /^\s*Global\s+warming\s*$/i, key: "gwp_kgco2e" },
   { rx: /^\s*Ozone\s+depletion\s*$/i, key: "ozone_depletion_kgcfc11eq" },
   { rx: /^\s*Acidification\s+of\s+land\s+and\s+water\s*$/i, key: "acidification_kgso2eq" },

--- a/schema/materials/03-concrete.json
+++ b/schema/materials/03-concrete.json
@@ -184,7 +184,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 10,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -375,7 +375,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 11,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -427,6 +427,8 @@
       },
       "physical": {
         "density": {
+          "value": 927,
+          "units": "kg/m3",
           "value_kg_m3": 927,
           "value_lb_ft3": 57.87,
           "source": "epd"
@@ -556,7 +558,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 128,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -607,6 +609,8 @@
       },
       "physical": {
         "density": {
+          "value": 921,
+          "units": "kg/m3",
           "value_kg_m3": 921,
           "value_lb_ft3": 57.5,
           "source": "epd"
@@ -736,7 +740,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 129,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -784,6 +788,11 @@
         "metallic": 0,
         "roughness": 0.85,
         "has_grain": false
+      },
+      "physical": {
+        "density": {
+          "units": "kg/m3"
+        }
       },
       "carbon": {
         "stated": {
@@ -909,12 +918,11 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 130,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
       },
-      "physical": {},
       "cost": {},
       "code_compliance": {}
     },
@@ -971,6 +979,8 @@
       },
       "physical": {
         "density": {
+          "value": 1722.56,
+          "units": "kg/m3",
           "value_kg_m3": 1722.56,
           "value_lb_ft3": 107.54,
           "source": "epd"
@@ -1123,7 +1133,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 136,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1184,6 +1194,8 @@
       },
       "physical": {
         "density": {
+          "value": 1722.56,
+          "units": "kg/m3",
           "value_kg_m3": 1722.56,
           "value_lb_ft3": 107.54,
           "source": "epd"
@@ -1336,7 +1348,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 137,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1397,6 +1409,8 @@
       },
       "physical": {
         "density": {
+          "value": 2186.12,
+          "units": "kg/m3",
           "value_kg_m3": 2186.12,
           "value_lb_ft3": 136.48,
           "source": "epd"
@@ -1550,7 +1564,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 138,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1611,6 +1625,8 @@
       },
       "physical": {
         "density": {
+          "value": 2186.12,
+          "units": "kg/m3",
           "value_kg_m3": 2186.12,
           "value_lb_ft3": 136.48,
           "source": "epd"
@@ -1764,7 +1780,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 139,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1815,6 +1831,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -1943,7 +1961,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 159,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1994,6 +2012,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -2122,7 +2142,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 160,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2173,6 +2193,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -2301,7 +2323,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 161,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2352,6 +2374,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -2480,7 +2504,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 162,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2531,6 +2555,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -2659,7 +2685,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 163,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2710,6 +2736,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -2838,7 +2866,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 164,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2889,6 +2917,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -3017,7 +3047,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 165,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3068,6 +3098,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -3196,7 +3228,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 166,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3247,6 +3279,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -3375,7 +3409,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 167,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3426,6 +3460,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -3554,7 +3590,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 168,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3605,6 +3641,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -3733,7 +3771,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 169,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3784,6 +3822,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -3912,7 +3952,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 170,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3963,6 +4003,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -4091,7 +4133,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 171,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4142,6 +4184,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -4270,7 +4314,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 172,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4321,6 +4365,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -4449,7 +4495,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 173,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4500,6 +4546,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -4628,7 +4676,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 174,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4679,6 +4727,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -4807,7 +4857,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 175,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4858,6 +4908,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -4986,7 +5038,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 176,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5037,6 +5089,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -5167,7 +5221,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 177,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5218,6 +5272,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -5348,7 +5404,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 178,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5399,6 +5455,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -5529,7 +5587,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 179,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5580,6 +5638,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -5710,7 +5770,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 180,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5761,6 +5821,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -5891,7 +5953,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 181,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5942,6 +6004,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -6072,7 +6136,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 182,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6123,6 +6187,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -6253,7 +6319,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 183,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6304,6 +6370,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -6434,7 +6502,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 184,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6485,6 +6553,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -6615,7 +6685,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 185,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6666,6 +6736,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -6796,7 +6868,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 186,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6847,6 +6919,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -6977,7 +7051,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 187,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7028,6 +7102,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -7158,7 +7234,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 188,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7209,6 +7285,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -7339,7 +7417,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 189,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7390,6 +7468,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -7520,7 +7600,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 190,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7571,6 +7651,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -7701,7 +7783,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 191,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7752,6 +7834,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -7882,7 +7966,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 192,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7933,6 +8017,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -8063,7 +8149,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 193,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8114,6 +8200,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -8244,7 +8332,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 194,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8295,6 +8383,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -8425,7 +8515,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 195,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8476,6 +8566,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -8606,7 +8698,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 196,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8658,6 +8750,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -8795,7 +8889,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 197,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8847,6 +8941,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -8984,7 +9080,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 198,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9036,6 +9132,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -9173,7 +9271,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 199,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9225,6 +9323,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -9362,7 +9462,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 200,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9414,6 +9514,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -9551,7 +9653,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 201,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9603,6 +9705,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -9740,7 +9844,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 202,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9792,6 +9896,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -9929,7 +10035,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 203,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9981,6 +10087,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -10118,7 +10226,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 204,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10170,6 +10278,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -10307,7 +10417,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 205,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10359,6 +10469,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -10496,7 +10608,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 206,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10548,6 +10660,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -10685,7 +10799,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 207,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10737,6 +10851,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -10874,7 +10990,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 208,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10926,6 +11042,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -11063,7 +11181,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 209,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11115,6 +11233,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -11252,7 +11372,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 210,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11304,6 +11424,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -11441,7 +11563,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 211,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11493,6 +11615,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -11630,7 +11754,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 212,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11682,6 +11806,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -11819,7 +11945,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 213,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11871,6 +11997,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -12008,7 +12136,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 214,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12060,6 +12188,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -12197,7 +12327,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 215,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12249,6 +12379,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -12386,7 +12518,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 216,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12438,6 +12570,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -12575,7 +12709,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 217,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12627,6 +12761,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -12764,7 +12900,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 218,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12816,6 +12952,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -12953,7 +13091,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 219,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13005,6 +13143,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -13142,7 +13282,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 220,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13194,6 +13334,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -13331,7 +13473,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 221,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13383,6 +13525,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -13520,7 +13664,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 222,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13572,6 +13716,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -13709,7 +13855,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 223,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13761,6 +13907,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -13898,7 +14046,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 224,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13950,6 +14098,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -14087,7 +14237,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 225,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14139,6 +14289,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -14276,7 +14428,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 226,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14328,6 +14480,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -14465,7 +14619,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 227,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14517,6 +14671,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -14654,7 +14810,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 228,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14706,6 +14862,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -14843,7 +15001,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 229,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14895,6 +15053,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -15032,7 +15192,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 230,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15084,6 +15244,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -15221,7 +15383,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 231,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15273,6 +15435,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -15410,7 +15574,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 232,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15462,6 +15626,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -15599,7 +15765,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 233,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15651,6 +15817,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -15788,7 +15956,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 234,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15840,6 +16008,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -15977,7 +16147,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 235,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16029,6 +16199,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -16166,7 +16338,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 236,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16218,6 +16390,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -16355,7 +16529,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 237,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16407,6 +16581,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -16544,7 +16720,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 238,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16596,6 +16772,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -16733,7 +16911,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 239,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16786,6 +16964,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -16923,7 +17103,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 240,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16975,6 +17155,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -17112,7 +17294,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 241,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17164,6 +17346,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -17301,7 +17485,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 242,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17353,6 +17537,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -17490,7 +17676,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 243,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17542,6 +17728,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -17679,7 +17867,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 244,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17731,6 +17919,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -17868,7 +18058,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 245,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17920,6 +18110,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -18057,7 +18249,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 246,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18109,6 +18301,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -18246,7 +18440,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 247,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18298,6 +18492,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -18435,7 +18631,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 248,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18487,6 +18683,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -18624,7 +18822,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 249,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18676,6 +18874,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -18813,7 +19013,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 250,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18865,6 +19065,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -19002,7 +19204,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 251,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19054,6 +19256,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -19191,7 +19395,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 252,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19243,6 +19447,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -19380,7 +19586,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 253,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19432,6 +19638,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -19569,7 +19777,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 254,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19621,6 +19829,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -19758,7 +19968,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 255,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19810,6 +20020,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -19947,7 +20159,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 256,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19999,6 +20211,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -20136,7 +20350,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 257,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20188,6 +20402,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -20325,7 +20541,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 258,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20377,6 +20593,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -20514,7 +20732,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 259,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20566,6 +20784,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -20703,7 +20923,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 260,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20755,6 +20975,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -20892,7 +21114,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 261,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20944,6 +21166,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -21081,7 +21305,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 262,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21133,6 +21357,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -21270,7 +21496,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 263,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21322,6 +21548,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -21459,7 +21687,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 264,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21511,6 +21739,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -21648,7 +21878,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 265,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21700,6 +21930,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -21837,7 +22069,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 266,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21889,6 +22121,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -22026,7 +22260,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 267,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22078,6 +22312,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -22215,7 +22451,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 268,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22267,6 +22503,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -22404,7 +22642,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 269,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22456,6 +22694,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -22593,7 +22833,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 270,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22645,6 +22885,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -22782,7 +23024,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 271,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22834,6 +23076,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -22971,7 +23215,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 272,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23023,6 +23267,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -23160,7 +23406,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 273,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23212,6 +23458,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -23349,7 +23597,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 274,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23401,6 +23649,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -23538,7 +23788,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 275,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23590,6 +23840,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -23727,7 +23979,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 276,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23779,6 +24031,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -23916,7 +24170,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 277,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23968,6 +24222,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -24105,7 +24361,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 278,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24157,6 +24413,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -24294,7 +24552,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 279,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24346,6 +24604,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -24483,7 +24743,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 280,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24535,6 +24795,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -24672,7 +24934,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 281,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24724,6 +24986,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -24861,7 +25125,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 282,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24913,6 +25177,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -25050,7 +25316,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 283,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25102,6 +25368,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -25239,7 +25507,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 284,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25291,6 +25559,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -25428,7 +25698,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 285,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25480,6 +25750,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -25617,7 +25889,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 286,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25669,6 +25941,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -25806,7 +26080,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 287,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25858,6 +26132,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -25995,7 +26271,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 288,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26047,6 +26323,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -26184,7 +26462,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 289,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26236,6 +26514,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -26373,7 +26653,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 290,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26425,6 +26705,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -26562,7 +26844,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 291,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26614,6 +26896,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -26751,7 +27035,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 292,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26803,6 +27087,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -26940,7 +27226,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 293,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26992,6 +27278,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -27129,7 +27417,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 294,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27181,6 +27469,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -27318,7 +27608,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 295,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27370,6 +27660,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -27507,7 +27799,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 296,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27559,6 +27851,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -27696,7 +27990,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 297,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27748,6 +28042,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -27885,7 +28181,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 298,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27937,6 +28233,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -28074,7 +28372,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 299,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28126,6 +28424,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -28263,7 +28563,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 300,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28315,6 +28615,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -28452,7 +28754,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 301,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28504,6 +28806,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -28641,7 +28945,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 302,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28693,6 +28997,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -28830,7 +29136,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 303,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28882,6 +29188,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -29019,7 +29327,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 304,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29071,6 +29379,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -29208,7 +29518,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 305,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29260,6 +29570,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -29397,7 +29709,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 306,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29449,6 +29761,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -29586,7 +29900,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 307,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29638,6 +29952,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -29775,7 +30091,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 308,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29827,6 +30143,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -29964,7 +30282,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 309,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30016,6 +30334,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -30153,7 +30473,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 310,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30205,6 +30525,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -30342,7 +30664,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 311,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30394,6 +30716,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -30531,7 +30855,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 312,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30583,6 +30907,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -30720,7 +31046,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 313,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30772,6 +31098,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -30909,7 +31237,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 314,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30961,6 +31289,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -31098,7 +31428,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 315,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31150,6 +31480,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -31287,7 +31619,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 316,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31339,6 +31671,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -31476,7 +31810,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 317,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31528,6 +31862,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -31665,7 +32001,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 318,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31717,6 +32053,8 @@
       },
       "physical": {
         "density": {
+          "value": 2305,
+          "units": "kg/m3",
           "value_kg_m3": 2305,
           "value_lb_ft3": 143.9,
           "source": "epd"
@@ -31854,7 +32192,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 319,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32008,7 +32346,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 364,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32060,8 +32398,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.335,
-          "value_lb_ft3": 0.65,
+          "value": 10.335,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -32196,7 +32534,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 365,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32247,8 +32585,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7.4,
-          "value_lb_ft3": 0.46,
+          "value": 7.4,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -32383,7 +32721,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 366,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32437,6 +32775,8 @@
       },
       "physical": {
         "density": {
+          "value": 1906,
+          "units": "kg/m3",
           "value_kg_m3": 1906,
           "value_lb_ft3": 118.99,
           "source": "epd"
@@ -32568,7 +32908,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 406,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32627,6 +32967,8 @@
       },
       "physical": {
         "density": {
+          "value": 1300,
+          "units": "kg/m3",
           "value_kg_m3": 1300,
           "value_lb_ft3": 81.16,
           "source": "epd"
@@ -32770,7 +33112,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 476,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32947,7 +33289,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 478,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33001,8 +33343,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3000,
-          "value_lb_ft3": 187.29,
+          "value": 3000,
+          "units": "kg/m3 masonry cement",
           "source": "epd"
         }
       },
@@ -33136,7 +33478,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 479,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33189,6 +33531,8 @@
       },
       "physical": {
         "density": {
+          "value": 3150,
+          "units": "kg/m3",
           "value_kg_m3": 3150,
           "value_lb_ft3": 196.65,
           "source": "epd"
@@ -33322,7 +33666,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 480,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33372,8 +33716,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 375,
-          "value_lb_ft3": 23.41,
+          "value": 375,
+          "units": "kg/m3 masonry cement",
           "source": "epd"
         },
         "additional_factor": {
@@ -33500,7 +33844,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 481,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33550,8 +33894,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.07,
-          "value_lb_ft3": 0.25,
+          "value": 4.07,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -33686,7 +34030,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 482,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33860,7 +34204,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 483,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33915,6 +34259,8 @@
       },
       "physical": {
         "density": {
+          "value": 80,
+          "units": "kg/m3",
           "value_kg_m3": 80,
           "value_lb_ft3": 4.99,
           "source": "epd"
@@ -34033,7 +34379,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 484,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34089,6 +34435,8 @@
       },
       "physical": {
         "density": {
+          "value": 100,
+          "units": "kg/m3",
           "value_kg_m3": 100,
           "value_lb_ft3": 6.24,
           "source": "epd"
@@ -34234,7 +34582,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 485,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34290,6 +34638,8 @@
       },
       "physical": {
         "density": {
+          "value": 70,
+          "units": "kg/m3",
           "value_kg_m3": 70,
           "value_lb_ft3": 4.37,
           "source": "epd"
@@ -34436,7 +34786,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 486,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34492,6 +34842,8 @@
       },
       "physical": {
         "density": {
+          "value": 70,
+          "units": "kg/m3",
           "value_kg_m3": 70,
           "value_lb_ft3": 4.37,
           "source": "epd"
@@ -34637,7 +34989,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 487,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34684,6 +35036,8 @@
       },
       "physical": {
         "density": {
+          "value": 1030,
+          "units": "kg/m3",
           "value_kg_m3": 1030,
           "value_lb_ft3": 64.3,
           "source": "epd"
@@ -34815,7 +35169,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 581,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34867,6 +35221,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -35011,7 +35367,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 596,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35062,6 +35418,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -35206,7 +35564,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 597,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35257,6 +35615,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -35401,7 +35761,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 598,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35452,6 +35812,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -35596,7 +35958,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 599,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35647,6 +36009,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -35791,7 +36155,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 600,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35842,6 +36206,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -35986,7 +36352,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 601,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36037,6 +36403,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -36181,7 +36549,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 602,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36232,6 +36600,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -36376,7 +36746,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 603,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36427,6 +36797,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -36571,7 +36943,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 604,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36623,6 +36995,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -36766,7 +37140,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 605,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36818,6 +37192,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -36961,7 +37337,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 606,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37013,6 +37389,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -37156,7 +37534,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 607,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37208,8 +37586,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 71,
-          "value_lb_ft3": 4.43,
+          "value": 71,
+          "units": "lb/ft2",
           "source": "epd"
         }
       },
@@ -37338,7 +37716,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 706,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37388,6 +37766,8 @@
       },
       "physical": {
         "density": {
+          "value": 550,
+          "units": "kg/m3",
           "value_kg_m3": 550,
           "value_lb_ft3": 34.34,
           "source": "epd"
@@ -37537,7 +37917,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 741,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37587,6 +37967,8 @@
       },
       "physical": {
         "density": {
+          "value": 550,
+          "units": "kg/m3",
           "value_kg_m3": 550,
           "value_lb_ft3": 34.34,
           "source": "epd"
@@ -37736,7 +38118,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 742,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37889,7 +38271,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 743,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38044,7 +38426,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 744,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38199,7 +38581,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 745,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38354,7 +38736,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 746,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/materials/04-masonry.json
+++ b/schema/materials/04-masonry.json
@@ -45,8 +45,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7.03,
-          "value_lb_ft3": 0.44,
+          "value": 7.03,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -177,7 +177,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 84,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -231,6 +231,8 @@
       },
       "physical": {
         "density": {
+          "value": 2120,
+          "units": "kg/m3",
           "value_kg_m3": 2120,
           "value_lb_ft3": 132.35,
           "source": "epd"
@@ -365,7 +367,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 85,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -418,8 +420,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -561,7 +563,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 86,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -615,8 +617,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -753,7 +755,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 87,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -810,6 +812,8 @@
       },
       "physical": {
         "density": {
+          "value": 1800,
+          "units": "kg/m3",
           "value_kg_m3": 1800,
           "value_lb_ft3": 112.37,
           "source": "epd"
@@ -962,7 +966,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 88,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1019,8 +1023,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -1165,7 +1169,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 89,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1222,8 +1226,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -1368,7 +1372,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 92,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1422,8 +1426,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -1547,7 +1551,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 93,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1604,8 +1608,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -1750,7 +1754,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 94,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1808,8 +1812,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -1946,7 +1950,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 97,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2003,8 +2007,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 269,
-          "value_lb_ft3": 16.79,
+          "value": 269,
+          "units": "kgCO2/m3 mortar",
           "source": "epd"
         },
         "dimensions": {
@@ -2149,7 +2153,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 98,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2206,6 +2210,8 @@
       },
       "physical": {
         "density": {
+          "value": 1800,
+          "units": "kg/m3",
           "value_kg_m3": 1800,
           "value_lb_ft3": 112.37,
           "source": "epd"
@@ -2354,7 +2360,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 99,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2532,7 +2538,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 100,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2592,8 +2598,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 89.78,
-          "value_lb_ft3": 5.6,
+          "value": 89.78,
+          "units": "kg/m2 installed stone, mortar, connectors, water",
           "source": "epd"
         },
         "additional_factor": {
@@ -2740,7 +2746,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 101,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2798,8 +2804,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 24.32,
-          "value_lb_ft3": 1.52,
+          "value": 24.32,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -2941,7 +2947,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 102,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2998,8 +3004,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 29.79,
-          "value_lb_ft3": 1.86,
+          "value": 29.79,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -3143,7 +3149,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 103,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3200,8 +3206,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 18.2,
-          "value_lb_ft3": 1.14,
+          "value": 18.2,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -3343,7 +3349,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 104,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3400,8 +3406,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 34.72,
-          "value_lb_ft3": 2.17,
+          "value": 34.72,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -3543,7 +3549,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 105,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3596,6 +3602,8 @@
       },
       "physical": {
         "density": {
+          "value": 1750,
+          "units": "kg/m3",
           "value_kg_m3": 1750,
           "value_lb_ft3": 109.25,
           "source": "epd"
@@ -3744,7 +3752,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 140,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3797,6 +3805,8 @@
       },
       "physical": {
         "density": {
+          "value": 2100,
+          "units": "kg/m3",
           "value_kg_m3": 2100,
           "value_lb_ft3": 131.1,
           "source": "epd"
@@ -3945,7 +3955,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 141,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3995,8 +4005,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 168.2,
-          "value_lb_ft3": 10.5,
+          "value": 168.2,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -4037,7 +4047,6 @@
           "storage_retention_pct": 0.9,
           "stored_kgco2e_per_common_unit": 2.79,
           "full_carbon_kgco2e_per_common_unit": 3.1,
-          "carbon_content_kgc_per_unit": 144.81,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -4140,7 +4149,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 142,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4189,6 +4198,8 @@
       },
       "physical": {
         "density": {
+          "value": 1222,
+          "units": "kg/m3",
           "value_kg_m3": 1222,
           "value_lb_ft3": 76.29,
           "source": "epd"
@@ -4334,7 +4345,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 143,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4392,8 +4403,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 535.695,
-          "value_lb_ft3": 33.44,
+          "value": 535.695,
+          "units": "kg/m2 @ 0.3m width",
           "source": "epd"
         },
         "dimensions": {
@@ -4539,7 +4550,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 150,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4597,8 +4608,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 160.053,
-          "value_lb_ft3": 9.99,
+          "value": 160.053,
+          "units": "kg/m2 @ 0.1m width",
           "source": "epd"
         },
         "dimensions": {
@@ -4744,7 +4755,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 151,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4795,6 +4806,8 @@
       },
       "physical": {
         "density": {
+          "value": 1900,
+          "units": "kg/m3",
           "value_kg_m3": 1900,
           "value_lb_ft3": 118.62,
           "source": "epd"
@@ -4927,7 +4940,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 152,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4979,6 +4992,8 @@
       },
       "physical": {
         "density": {
+          "value": 1900,
+          "units": "kg/m3",
           "value_kg_m3": 1900,
           "value_lb_ft3": 118.62,
           "source": "epd"
@@ -5111,7 +5126,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 153,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5168,6 +5183,8 @@
       },
       "physical": {
         "density": {
+          "value": 275,
+          "units": "kg/m3",
           "value_kg_m3": 275,
           "value_lb_ft3": 17.17,
           "source": "epd"
@@ -5312,7 +5329,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 385,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5369,6 +5386,8 @@
       },
       "physical": {
         "density": {
+          "value": 245,
+          "units": "kg/m3",
           "value_kg_m3": 245,
           "value_lb_ft3": 15.3,
           "source": "epd"
@@ -5513,7 +5532,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 386,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5570,6 +5589,8 @@
       },
       "physical": {
         "density": {
+          "value": 275,
+          "units": "kg/m3",
           "value_kg_m3": 275,
           "value_lb_ft3": 17.17,
           "source": "epd"
@@ -5714,7 +5735,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 387,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5772,6 +5793,8 @@
       },
       "physical": {
         "density": {
+          "value": 1550,
+          "units": "kg/m3",
           "value_kg_m3": 1550,
           "value_lb_ft3": 96.77,
           "source": "epd"
@@ -5909,7 +5932,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 467,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5966,6 +5989,8 @@
       },
       "physical": {
         "density": {
+          "value": 1550,
+          "units": "kg/m3",
           "value_kg_m3": 1550,
           "value_lb_ft3": 96.77,
           "source": "epd"
@@ -6103,7 +6128,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 468,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6305,7 +6330,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 469,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6486,7 +6511,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 470,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6542,6 +6567,8 @@
       },
       "physical": {
         "density": {
+          "value": 360,
+          "units": "kg/m3",
           "value_kg_m3": 360,
           "value_lb_ft3": 22.47,
           "source": "epd"
@@ -6700,7 +6727,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 471,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6756,6 +6783,8 @@
       },
       "physical": {
         "density": {
+          "value": 250,
+          "units": "kg/m3",
           "value_kg_m3": 250,
           "value_lb_ft3": 15.61,
           "source": "epd"
@@ -6914,7 +6943,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 472,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6970,6 +6999,8 @@
       },
       "physical": {
         "density": {
+          "value": 470,
+          "units": "kg/m3",
           "value_kg_m3": 470,
           "value_lb_ft3": 29.34,
           "source": "epd"
@@ -7128,7 +7159,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 473,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7325,7 +7356,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 474,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7383,6 +7414,8 @@
       },
       "physical": {
         "density": {
+          "value": 1992,
+          "units": "kg/m3",
           "value_kg_m3": 1992,
           "value_lb_ft3": 124.36,
           "source": "epd"
@@ -7520,7 +7553,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 477,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7571,6 +7604,8 @@
       },
       "physical": {
         "density": {
+          "value": 1900,
+          "units": "kg/m3",
           "value_kg_m3": 1900,
           "value_lb_ft3": 118.62,
           "source": "epd"
@@ -7703,7 +7738,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 584,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7753,6 +7788,8 @@
       },
       "physical": {
         "density": {
+          "value": 1900,
+          "units": "kg/m3",
           "value_kg_m3": 1900,
           "value_lb_ft3": 118.62,
           "source": "epd"
@@ -7884,7 +7921,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 585,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7934,6 +7971,8 @@
       },
       "physical": {
         "density": {
+          "value": 1900,
+          "units": "kg/m3",
           "value_kg_m3": 1900,
           "value_lb_ft3": 118.62,
           "source": "epd"
@@ -8065,7 +8104,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 586,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8116,8 +8155,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.4,
-          "value_lb_ft3": 0.52,
+          "value": 8.4,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8247,7 +8286,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 611,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/materials/05-metals.json
+++ b/schema/materials/05-metals.json
@@ -44,8 +44,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 105.39,
-          "value_lb_ft3": 6.58,
+          "value": 105.39,
+          "units": "kg/m",
           "source": "epd"
         }
       },
@@ -168,7 +168,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 334,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -219,6 +219,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -348,7 +350,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 424,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -498,7 +500,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 446,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -650,7 +652,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 447,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -703,6 +705,8 @@
       },
       "physical": {
         "density": {
+          "value": 2720,
+          "units": "kg/m3",
           "value_kg_m3": 2720,
           "value_lb_ft3": 169.81,
           "source": "epd"
@@ -831,7 +835,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 498,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -890,8 +894,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.07,
-          "value_lb_ft3": 0.13,
+          "value": 2.07,
+          "units": "kg/m2",
           "source": "epd"
         },
         "additional_factor": {
@@ -1040,7 +1044,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 499,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1097,8 +1101,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.49,
-          "value_lb_ft3": 0.65,
+          "value": 10.49,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -1241,7 +1245,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 500,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1298,8 +1302,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 13.62,
-          "value_lb_ft3": 0.85,
+          "value": 13.62,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -1442,7 +1446,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 501,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1494,8 +1498,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.91,
-          "value_lb_ft3": 0.31,
+          "value": 4.91,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -1624,7 +1628,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 502,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1676,6 +1680,8 @@
       },
       "physical": {
         "density": {
+          "value": 8030,
+          "units": "kg/m3",
           "value_kg_m3": 8030,
           "value_lb_ft3": 501.31,
           "source": "epd"
@@ -1808,7 +1814,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 503,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1869,8 +1875,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.07,
-          "value_lb_ft3": 0.13,
+          "value": 2.07,
+          "units": "kg/m2",
           "source": "epd"
         },
         "additional_factor": {
@@ -2019,7 +2025,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 504,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2080,8 +2086,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.73,
-          "value_lb_ft3": 0.3,
+          "value": 4.73,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -2228,7 +2234,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 505,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2286,6 +2292,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -2439,7 +2447,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 506,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2499,6 +2507,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -2648,7 +2658,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 507,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2708,6 +2718,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -2855,7 +2867,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 508,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2915,6 +2927,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -3064,7 +3078,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 587,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3124,6 +3138,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -3273,7 +3289,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 588,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3333,6 +3349,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -3482,7 +3500,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 589,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3542,6 +3560,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -3691,7 +3711,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 590,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3751,6 +3771,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -3900,7 +3922,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 591,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3960,6 +3982,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -4109,7 +4133,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 592,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4169,6 +4193,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -4318,7 +4344,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 593,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4378,6 +4404,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -4527,7 +4555,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 594,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4587,6 +4615,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -4736,7 +4766,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 595,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4796,6 +4826,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -4945,7 +4977,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 636,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5005,6 +5037,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -5154,7 +5188,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 637,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5214,6 +5248,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -5363,7 +5399,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 638,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5423,6 +5459,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -5572,7 +5610,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 639,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5632,6 +5670,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -5781,7 +5821,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 640,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5841,6 +5881,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -5990,7 +6032,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 641,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6050,6 +6092,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -6199,7 +6243,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 642,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6259,6 +6303,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -6408,7 +6454,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 643,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6468,6 +6514,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -6617,7 +6665,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 644,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6677,6 +6725,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -6826,7 +6876,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 645,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6886,6 +6936,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -7035,7 +7087,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 646,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7095,6 +7147,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -7244,7 +7298,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 647,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7304,6 +7358,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -7453,7 +7509,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 648,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7513,6 +7569,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -7662,7 +7720,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 649,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7722,6 +7780,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -7871,7 +7931,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 650,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7931,6 +7991,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -8080,7 +8142,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 651,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8140,6 +8202,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -8289,7 +8353,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 652,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8349,6 +8413,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -8498,7 +8564,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 653,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8558,6 +8624,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -8707,7 +8775,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 654,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8767,6 +8835,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -8916,7 +8986,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 655,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8976,6 +9046,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -9125,7 +9197,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 656,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9185,6 +9257,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -9334,7 +9408,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 657,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9394,6 +9468,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -9543,7 +9619,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 658,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9603,6 +9679,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -9752,7 +9830,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 659,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9812,6 +9890,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -9961,7 +10041,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 660,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10021,6 +10101,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -10170,7 +10252,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 661,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10230,6 +10312,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -10379,7 +10463,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 662,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10439,6 +10523,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -10588,7 +10674,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 663,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10648,6 +10734,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -10797,7 +10885,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 664,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10857,6 +10945,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -11006,7 +11096,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 665,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11066,6 +11156,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -11215,7 +11307,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 666,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11275,6 +11367,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -11424,7 +11518,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 667,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11484,6 +11578,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -11633,7 +11729,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 668,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11693,6 +11789,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -11842,7 +11940,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 669,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11902,6 +12000,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -12051,7 +12151,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 670,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12111,6 +12211,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -12260,7 +12362,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 671,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12320,6 +12422,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -12469,7 +12573,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 672,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12529,6 +12633,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -12678,7 +12784,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 673,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12738,6 +12844,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -12887,7 +12995,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 674,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12947,6 +13055,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -13096,7 +13206,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 675,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13156,6 +13266,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -13305,7 +13417,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 676,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13365,6 +13477,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -13514,7 +13628,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 677,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13574,6 +13688,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -13723,7 +13839,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 678,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13773,6 +13889,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -13902,7 +14020,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 679,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13962,6 +14080,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -14112,7 +14232,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 680,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14311,7 +14431,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 681,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14510,7 +14630,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 682,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14709,7 +14829,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 683,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14908,7 +15028,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 684,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15107,7 +15227,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 685,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15306,7 +15426,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 686,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15505,7 +15625,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 687,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15704,7 +15824,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 688,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15903,7 +16023,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 689,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16094,7 +16214,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 690,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16155,6 +16275,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -16290,7 +16412,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 691,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16352,6 +16474,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -16501,7 +16625,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 692,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16560,6 +16684,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -16701,7 +16827,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 693,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16761,6 +16887,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -16903,7 +17031,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 694,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16963,6 +17091,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -17097,7 +17227,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 695,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17156,6 +17286,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -17297,7 +17429,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 696,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17359,6 +17491,8 @@
       },
       "physical": {
         "density": {
+          "value": 7800,
+          "units": "kg/m3",
           "value_kg_m3": 7800,
           "value_lb_ft3": 486.95,
           "source": "epd"
@@ -17508,7 +17642,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 697,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17568,6 +17702,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -17710,7 +17846,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 698,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17770,6 +17906,8 @@
       },
       "physical": {
         "density": {
+          "value": 7850,
+          "units": "kg/m3",
           "value_kg_m3": 7850,
           "value_lb_ft3": 490.08,
           "source": "epd"
@@ -17904,7 +18042,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 699,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17962,8 +18100,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 62,
-          "value_lb_ft3": 3.87,
+          "value": 62,
+          "units": "lb/100ft2",
           "source": "epd"
         },
         "additional_factor": {
@@ -18110,7 +18248,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 718,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18168,8 +18306,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 42,
-          "value_lb_ft3": 2.62,
+          "value": 42,
+          "units": "lb/100ft2",
           "source": "epd"
         },
         "additional_factor": {
@@ -18316,7 +18454,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 719,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18479,7 +18617,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 723,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18644,7 +18782,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 739,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18827,7 +18965,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 740,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/materials/06-wood.json
+++ b/schema/materials/06-wood.json
@@ -168,7 +168,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 2,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -228,6 +228,8 @@
       },
       "physical": {
         "density": {
+          "value": 690,
+          "units": "kg/m3",
           "value_kg_m3": 690,
           "value_lb_ft3": 43.08,
           "source": "epd"
@@ -387,7 +389,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 71,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -446,6 +448,8 @@
       },
       "physical": {
         "density": {
+          "value": 690,
+          "units": "kg/m3",
           "value_kg_m3": 690,
           "value_lb_ft3": 43.08,
           "source": "epd"
@@ -605,7 +609,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 72,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -660,6 +664,8 @@
       },
       "physical": {
         "density": {
+          "value": 1059.75,
+          "units": "kg/m3",
           "value_kg_m3": 1059.75,
           "value_lb_ft3": 66.16,
           "source": "epd"
@@ -780,7 +786,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 73,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -839,6 +845,8 @@
       },
       "physical": {
         "density": {
+          "value": 1150,
+          "units": "kg/m3",
           "value_kg_m3": 1150,
           "value_lb_ft3": 71.79,
           "source": "epd"
@@ -993,7 +1001,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 74,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1052,6 +1060,8 @@
       },
       "physical": {
         "density": {
+          "value": 1250,
+          "units": "kg/m3",
           "value_kg_m3": 1250,
           "value_lb_ft3": 78.04,
           "source": "epd"
@@ -1206,7 +1216,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 75,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1264,6 +1274,8 @@
       },
       "physical": {
         "density": {
+          "value": 689,
+          "units": "kg/m3",
           "value_kg_m3": 689,
           "value_lb_ft3": 43.01,
           "source": "epd"
@@ -1427,7 +1439,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 76,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1485,6 +1497,8 @@
       },
       "physical": {
         "density": {
+          "value": 1150,
+          "units": "kg/m3",
           "value_kg_m3": 1150,
           "value_lb_ft3": 71.79,
           "source": "epd"
@@ -1629,7 +1643,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 77,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1684,6 +1698,8 @@
       },
       "physical": {
         "density": {
+          "value": 933.3333333,
+          "units": "kg/m3",
           "value_kg_m3": 933.3333333,
           "value_lb_ft3": 58.27,
           "source": "epd"
@@ -1801,7 +1817,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 78,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1858,6 +1874,8 @@
       },
       "physical": {
         "density": {
+          "value": 700,
+          "units": "kg/m3",
           "value_kg_m3": 700,
           "value_lb_ft3": 43.7,
           "source": "epd"
@@ -2015,7 +2033,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 79,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2072,6 +2090,8 @@
       },
       "physical": {
         "density": {
+          "value": 1050,
+          "units": "kg/m3",
           "value_kg_m3": 1050,
           "value_lb_ft3": 65.55,
           "source": "epd"
@@ -2229,7 +2249,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 80,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2286,6 +2306,8 @@
       },
       "physical": {
         "density": {
+          "value": 1050,
+          "units": "kg/m3",
           "value_kg_m3": 1050,
           "value_lb_ft3": 65.55,
           "source": "epd"
@@ -2443,7 +2465,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 81,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2500,6 +2522,8 @@
       },
       "physical": {
         "density": {
+          "value": 689,
+          "units": "kg/m3",
           "value_kg_m3": 689,
           "value_lb_ft3": 43.01,
           "source": "epd"
@@ -2655,7 +2679,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 82,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2711,6 +2735,8 @@
       },
       "physical": {
         "density": {
+          "value": 1050,
+          "units": "kg/m3",
           "value_kg_m3": 1050,
           "value_lb_ft3": 65.55,
           "source": "epd"
@@ -2853,7 +2879,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 83,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2904,6 +2930,8 @@
       },
       "physical": {
         "density": {
+          "value": 209,
+          "units": "kg/m3",
           "value_kg_m3": 209,
           "value_lb_ft3": 13.05,
           "source": "epd"
@@ -3049,7 +3077,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 118,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3105,6 +3133,8 @@
       },
       "physical": {
         "density": {
+          "value": 299,
+          "units": "kg/m3",
           "value_kg_m3": 299,
           "value_lb_ft3": 18.67,
           "source": "epd"
@@ -3224,7 +3254,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 154,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3282,6 +3312,8 @@
       },
       "physical": {
         "density": {
+          "value": 379,
+          "units": "kg/m3",
           "value_kg_m3": 379,
           "value_lb_ft3": 23.66,
           "source": "epd"
@@ -3434,7 +3466,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 155,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3492,6 +3524,8 @@
       },
       "physical": {
         "density": {
+          "value": 379,
+          "units": "kg/m3",
           "value_kg_m3": 379,
           "value_lb_ft3": 23.66,
           "source": "epd"
@@ -3644,7 +3678,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 156,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3844,7 +3878,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 157,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3901,6 +3935,8 @@
       },
       "physical": {
         "density": {
+          "value": 140,
+          "units": "kg/m3",
           "value_kg_m3": 140,
           "value_lb_ft3": 8.74,
           "source": "epd"
@@ -4051,7 +4087,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 158,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4106,6 +4142,8 @@
       },
       "physical": {
         "density": {
+          "value": 459.9166667,
+          "units": "kg/m3",
           "value_kg_m3": 459.9166667,
           "value_lb_ft3": 28.71,
           "source": "epd"
@@ -4223,7 +4261,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 325,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4283,6 +4321,8 @@
       },
       "physical": {
         "density": {
+          "value": 456,
+          "units": "kg/m3",
           "value_kg_m3": 456,
           "value_lb_ft3": 28.47,
           "source": "epd"
@@ -4444,7 +4484,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 326,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4504,6 +4544,8 @@
       },
       "physical": {
         "density": {
+          "value": 486,
+          "units": "kg/m3",
           "value_kg_m3": 486,
           "value_lb_ft3": 30.34,
           "source": "epd"
@@ -4665,7 +4707,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 327,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4724,6 +4766,8 @@
       },
       "physical": {
         "density": {
+          "value": 481,
+          "units": "kg/m3",
           "value_kg_m3": 481,
           "value_lb_ft3": 30.03,
           "source": "epd"
@@ -4869,7 +4913,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 328,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4928,6 +4972,8 @@
       },
       "physical": {
         "density": {
+          "value": 448,
+          "units": "kg/m3",
           "value_kg_m3": 448,
           "value_lb_ft3": 27.97,
           "source": "epd"
@@ -5077,7 +5123,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 329,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5136,6 +5182,8 @@
       },
       "physical": {
         "density": {
+          "value": 446,
+          "units": "kg/m3",
           "value_kg_m3": 446,
           "value_lb_ft3": 27.84,
           "source": "epd"
@@ -5285,7 +5333,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 330,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5344,6 +5392,8 @@
       },
       "physical": {
         "density": {
+          "value": 442.5,
+          "units": "kg/m3",
           "value_kg_m3": 442.5,
           "value_lb_ft3": 27.63,
           "source": "epd"
@@ -5493,7 +5543,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 331,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5552,6 +5602,8 @@
       },
       "physical": {
         "density": {
+          "value": 546,
+          "units": "kg/m3",
           "value_kg_m3": 546,
           "value_lb_ft3": 34.09,
           "source": "epd"
@@ -5702,7 +5754,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 332,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5763,6 +5815,8 @@
       },
       "physical": {
         "density": {
+          "value": 449,
+          "units": "kg/m3",
           "value_kg_m3": 449,
           "value_lb_ft3": 28.03,
           "source": "epd"
@@ -5915,7 +5969,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 335,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5965,6 +6019,8 @@
       },
       "physical": {
         "density": {
+          "value": 548,
+          "units": "kg/m3",
           "value_kg_m3": 548,
           "value_lb_ft3": 34.21,
           "source": "epd"
@@ -6108,7 +6164,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 398,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6158,6 +6214,8 @@
       },
       "physical": {
         "density": {
+          "value": 548,
+          "units": "kg/m3",
           "value_kg_m3": 548,
           "value_lb_ft3": 34.21,
           "source": "epd"
@@ -6301,7 +6359,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 399,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6352,6 +6410,8 @@
       },
       "physical": {
         "density": {
+          "value": 544,
+          "units": "kg/m3",
           "value_kg_m3": 544,
           "value_lb_ft3": 33.96,
           "source": "epd"
@@ -6494,7 +6554,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 400,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6552,6 +6612,8 @@
       },
       "physical": {
         "density": {
+          "value": 442.1,
+          "units": "kg/m3",
           "value_kg_m3": 442.1,
           "value_lb_ft3": 27.6,
           "source": "epd"
@@ -6698,7 +6760,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 401,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6757,6 +6819,8 @@
       },
       "physical": {
         "density": {
+          "value": 481.68,
+          "units": "kg/m3",
           "value_kg_m3": 481.68,
           "value_lb_ft3": 30.07,
           "source": "epd"
@@ -6903,7 +6967,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 402,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7099,7 +7163,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 403,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7296,7 +7360,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 404,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7356,6 +7420,8 @@
       },
       "physical": {
         "density": {
+          "value": 448,
+          "units": "kg/m3",
           "value_kg_m3": 448,
           "value_lb_ft3": 27.97,
           "source": "epd"
@@ -7502,7 +7568,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 405,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7554,8 +7620,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.44,
-          "value_lb_ft3": 0.53,
+          "value": 8.44,
+          "units": "kg/m2 at 5/8\"",
           "source": "epd"
         },
         "dimensions": {
@@ -7693,7 +7759,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 418,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7888,7 +7954,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 419,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7947,8 +8013,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.97,
-          "value_lb_ft3": 0.62,
+          "value": 9.97,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8094,7 +8160,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 420,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8146,8 +8212,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 12.287,
-          "value_lb_ft3": 0.77,
+          "value": 12.287,
+          "units": "kg/m2 at 3/4\"",
           "source": "epd"
         },
         "dimensions": {
@@ -8285,7 +8351,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 421,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8481,7 +8547,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 422,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8539,8 +8605,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 12.35,
-          "value_lb_ft3": 0.77,
+          "value": 12.35,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8686,7 +8752,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 423,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8744,6 +8810,8 @@
       },
       "physical": {
         "density": {
+          "value": 428.75,
+          "units": "kg/m3",
           "value_kg_m3": 428.75,
           "value_lb_ft3": 26.77,
           "source": "epd"
@@ -8858,7 +8926,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 429,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8919,6 +8987,8 @@
       },
       "physical": {
         "density": {
+          "value": 420,
+          "units": "kg/m3",
           "value_kg_m3": 420,
           "value_lb_ft3": 26.22,
           "source": "epd"
@@ -9073,7 +9143,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 430,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9133,6 +9203,8 @@
       },
       "physical": {
         "density": {
+          "value": 390,
+          "units": "kg/m3",
           "value_kg_m3": 390,
           "value_lb_ft3": 24.35,
           "source": "epd"
@@ -9277,7 +9349,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 431,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9337,6 +9409,8 @@
       },
       "physical": {
         "density": {
+          "value": 390,
+          "units": "kg/m3",
           "value_kg_m3": 390,
           "value_lb_ft3": 24.35,
           "source": "epd"
@@ -9481,7 +9555,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 432,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9541,6 +9615,8 @@
       },
       "physical": {
         "density": {
+          "value": 515,
+          "units": "kg/m3",
           "value_kg_m3": 515,
           "value_lb_ft3": 32.15,
           "source": "epd"
@@ -9686,7 +9762,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 433,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9747,8 +9823,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.5,
-          "value_lb_ft3": 0.66,
+          "value": 10.5,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -9899,7 +9975,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 434,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9958,6 +10034,8 @@
       },
       "physical": {
         "density": {
+          "value": 570.22,
+          "units": "kg/m3",
           "value_kg_m3": 570.22,
           "value_lb_ft3": 35.6,
           "source": "epd"
@@ -10101,7 +10179,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 462,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10160,6 +10238,8 @@
       },
       "physical": {
         "density": {
+          "value": 548,
+          "units": "kg/m3",
           "value_kg_m3": 548,
           "value_lb_ft3": 34.21,
           "source": "epd"
@@ -10298,7 +10378,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 463,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10355,6 +10435,8 @@
       },
       "physical": {
         "density": {
+          "value": 483.4,
+          "units": "kg/m3",
           "value_kg_m3": 483.4,
           "value_lb_ft3": 30.18,
           "source": "epd"
@@ -10501,7 +10583,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 464,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10561,6 +10643,8 @@
       },
       "physical": {
         "density": {
+          "value": 593,
+          "units": "kg/m3",
           "value_kg_m3": 593,
           "value_lb_ft3": 37.02,
           "source": "epd"
@@ -10713,7 +10797,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 465,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10773,6 +10857,8 @@
       },
       "physical": {
         "density": {
+          "value": 539,
+          "units": "kg/m3",
           "value_kg_m3": 539,
           "value_lb_ft3": 33.65,
           "source": "epd"
@@ -10911,7 +10997,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 466,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10962,6 +11048,8 @@
       },
       "physical": {
         "density": {
+          "value": 620,
+          "units": "kg/m3",
           "value_kg_m3": 620,
           "value_lb_ft3": 38.71,
           "source": "epd"
@@ -11105,7 +11193,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 537,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11156,6 +11244,8 @@
       },
       "physical": {
         "density": {
+          "value": 620,
+          "units": "kg/m3",
           "value_kg_m3": 620,
           "value_lb_ft3": 38.71,
           "source": "epd"
@@ -11299,7 +11389,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 538,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11350,6 +11440,8 @@
       },
       "physical": {
         "density": {
+          "value": 620,
+          "units": "kg/m3",
           "value_kg_m3": 620,
           "value_lb_ft3": 38.71,
           "source": "epd"
@@ -11493,7 +11585,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 539,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11544,6 +11636,8 @@
       },
       "physical": {
         "density": {
+          "value": 620,
+          "units": "kg/m3",
           "value_kg_m3": 620,
           "value_lb_ft3": 38.71,
           "source": "epd"
@@ -11687,7 +11781,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 540,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11738,6 +11832,8 @@
       },
       "physical": {
         "density": {
+          "value": 620,
+          "units": "kg/m3",
           "value_kg_m3": 620,
           "value_lb_ft3": 38.71,
           "source": "epd"
@@ -11881,7 +11977,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 541,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11939,6 +12035,8 @@
       },
       "physical": {
         "density": {
+          "value": 678.28,
+          "units": "kg/m3",
           "value_kg_m3": 678.28,
           "value_lb_ft3": 42.35,
           "source": "epd"
@@ -12095,7 +12193,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 542,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12153,6 +12251,8 @@
       },
       "physical": {
         "density": {
+          "value": 765,
+          "units": "kg/m3",
           "value_kg_m3": 765,
           "value_lb_ft3": 47.76,
           "source": "epd"
@@ -12303,7 +12403,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 543,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12361,6 +12461,8 @@
       },
       "physical": {
         "density": {
+          "value": 765,
+          "units": "kg/m3",
           "value_kg_m3": 765,
           "value_lb_ft3": 47.76,
           "source": "epd"
@@ -12511,7 +12613,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 544,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12569,6 +12671,8 @@
       },
       "physical": {
         "density": {
+          "value": 765,
+          "units": "kg/m3",
           "value_kg_m3": 765,
           "value_lb_ft3": 47.76,
           "source": "epd"
@@ -12719,7 +12823,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 545,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12771,6 +12875,8 @@
       },
       "physical": {
         "density": {
+          "value": 662,
+          "units": "kg/m3",
           "value_kg_m3": 662,
           "value_lb_ft3": 41.33,
           "source": "epd"
@@ -12922,7 +13028,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 546,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12975,6 +13081,8 @@
       },
       "physical": {
         "density": {
+          "value": 660,
+          "units": "kg/m3",
           "value_kg_m3": 660,
           "value_lb_ft3": 41.2,
           "source": "epd"
@@ -13132,7 +13240,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 547,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13185,6 +13293,8 @@
       },
       "physical": {
         "density": {
+          "value": 660,
+          "units": "kg/m3",
           "value_kg_m3": 660,
           "value_lb_ft3": 41.2,
           "source": "epd"
@@ -13342,7 +13452,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 548,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13395,6 +13505,8 @@
       },
       "physical": {
         "density": {
+          "value": 660,
+          "units": "kg/m3",
           "value_kg_m3": 660,
           "value_lb_ft3": 41.2,
           "source": "epd"
@@ -13552,7 +13664,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 549,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13605,6 +13717,8 @@
       },
       "physical": {
         "density": {
+          "value": 223,
+          "units": "kg/m3",
           "value_kg_m3": 223,
           "value_lb_ft3": 13.92,
           "source": "epd"
@@ -13754,7 +13868,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 550,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13807,6 +13921,8 @@
       },
       "physical": {
         "density": {
+          "value": 223,
+          "units": "kg/m3",
           "value_kg_m3": 223,
           "value_lb_ft3": 13.92,
           "source": "epd"
@@ -13956,7 +14072,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 551,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14009,6 +14125,8 @@
       },
       "physical": {
         "density": {
+          "value": 223,
+          "units": "kg/m3",
           "value_kg_m3": 223,
           "value_lb_ft3": 13.92,
           "source": "epd"
@@ -14158,7 +14276,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 552,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14211,6 +14329,8 @@
       },
       "physical": {
         "density": {
+          "value": 325,
+          "units": "kg/m3",
           "value_kg_m3": 325,
           "value_lb_ft3": 20.29,
           "source": "epd"
@@ -14360,7 +14480,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 553,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14418,6 +14538,8 @@
       },
       "physical": {
         "density": {
+          "value": 670,
+          "units": "kg/m3",
           "value_kg_m3": 670,
           "value_lb_ft3": 41.83,
           "source": "epd"
@@ -14568,7 +14690,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 554,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14626,6 +14748,8 @@
       },
       "physical": {
         "density": {
+          "value": 662,
+          "units": "kg/m3",
           "value_kg_m3": 662,
           "value_lb_ft3": 41.33,
           "source": "epd"
@@ -14776,7 +14900,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 555,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14827,6 +14951,8 @@
       },
       "physical": {
         "density": {
+          "value": 484,
+          "units": "kg/m3",
           "value_kg_m3": 484,
           "value_lb_ft3": 30.22,
           "source": "epd"
@@ -14970,7 +15096,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 556,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15021,6 +15147,8 @@
       },
       "physical": {
         "density": {
+          "value": 484,
+          "units": "kg/m3",
           "value_kg_m3": 484,
           "value_lb_ft3": 30.22,
           "source": "epd"
@@ -15164,7 +15292,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 557,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15215,6 +15343,8 @@
       },
       "physical": {
         "density": {
+          "value": 484,
+          "units": "kg/m3",
           "value_kg_m3": 484,
           "value_lb_ft3": 30.22,
           "source": "epd"
@@ -15358,7 +15488,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 558,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15417,6 +15547,8 @@
       },
       "physical": {
         "density": {
+          "value": 477.33,
+          "units": "kg/m3",
           "value_kg_m3": 477.33,
           "value_lb_ft3": 29.8,
           "source": "epd"
@@ -15562,7 +15694,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 559,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15621,6 +15753,8 @@
       },
       "physical": {
         "density": {
+          "value": 477.33,
+          "units": "kg/m3",
           "value_kg_m3": 477.33,
           "value_lb_ft3": 29.8,
           "source": "epd"
@@ -15766,7 +15900,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 560,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15825,6 +15959,8 @@
       },
       "physical": {
         "density": {
+          "value": 477.33,
+          "units": "kg/m3",
           "value_kg_m3": 477.33,
           "value_lb_ft3": 29.8,
           "source": "epd"
@@ -15970,7 +16106,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 561,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16029,8 +16165,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.9,
-          "value_lb_ft3": 0.56,
+          "value": 8.9,
+          "units": "kg/m2 at 3/4\"",
           "source": "epd"
         }
       },
@@ -16177,7 +16313,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 562,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16236,8 +16372,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.38,
-          "value_lb_ft3": 0.27,
+          "value": 4.38,
+          "units": "kg/m2 at 3/8\"",
           "source": "epd"
         }
       },
@@ -16384,7 +16520,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 563,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16443,8 +16579,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.38,
-          "value_lb_ft3": 0.27,
+          "value": 4.38,
+          "units": "kg/m2 at 3/8\"",
           "source": "epd"
         }
       },
@@ -16591,7 +16727,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 564,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16748,7 +16884,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 612,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16906,7 +17042,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 613,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17064,7 +17200,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 614,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17222,7 +17358,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 615,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17380,7 +17516,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 616,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17439,6 +17575,8 @@
       },
       "physical": {
         "density": {
+          "value": 100,
+          "units": "kg/m3",
           "value_kg_m3": 100,
           "value_lb_ft3": 6.24,
           "source": "epd"
@@ -17593,7 +17731,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 700,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17650,6 +17788,8 @@
       },
       "physical": {
         "density": {
+          "value": 100,
+          "units": "kg/m3",
           "value_kg_m3": 100,
           "value_lb_ft3": 6.24,
           "source": "epd"
@@ -17801,7 +17941,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 701,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17860,8 +18000,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 110,
-          "value_lb_ft3": 6.87,
+          "value": 110,
+          "units": "kg/m2",
           "source": "epd"
         },
         "thermal": {
@@ -18013,7 +18153,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 702,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18070,6 +18210,8 @@
       },
       "physical": {
         "density": {
+          "value": 280,
+          "units": "kg/m3",
           "value_kg_m3": 280,
           "value_lb_ft3": 17.48,
           "source": "epd"
@@ -18216,7 +18358,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 703,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18274,6 +18416,8 @@
       },
       "physical": {
         "density": {
+          "value": 379,
+          "units": "kg/m3",
           "value_kg_m3": 379,
           "value_lb_ft3": 23.66,
           "source": "epd"
@@ -18423,7 +18567,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 704,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18480,8 +18624,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 18.5,
-          "value_lb_ft3": 1.15,
+          "value": 18.5,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -18621,7 +18765,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 705,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18775,7 +18919,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 710,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18931,7 +19075,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 711,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19099,7 +19243,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 722,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19266,7 +19410,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 738,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19326,6 +19470,8 @@
       },
       "physical": {
         "density": {
+          "value": 35,
+          "units": "kg/m3",
           "value_kg_m3": 35,
           "value_lb_ft3": 2.19,
           "source": "epd"
@@ -19480,7 +19626,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 747,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19643,7 +19789,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 748,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19702,6 +19848,8 @@
       },
       "physical": {
         "density": {
+          "value": 50,
+          "units": "kg/m3",
           "value_kg_m3": 50,
           "value_lb_ft3": 3.12,
           "source": "epd"
@@ -19849,7 +19997,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 749,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19906,6 +20054,8 @@
       },
       "physical": {
         "density": {
+          "value": 55,
+          "units": "kg/m3",
           "value_kg_m3": 55,
           "value_lb_ft3": 3.43,
           "source": "epd"
@@ -20052,7 +20202,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 750,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20109,6 +20259,8 @@
       },
       "physical": {
         "density": {
+          "value": 254,
+          "units": "kg/m3",
           "value_kg_m3": 254,
           "value_lb_ft3": 15.86,
           "source": "epd"
@@ -20256,7 +20408,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 751,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20312,6 +20464,8 @@
       },
       "physical": {
         "density": {
+          "value": 254,
+          "units": "kg/m3",
           "value_kg_m3": 254,
           "value_lb_ft3": 15.86,
           "source": "epd"
@@ -20458,7 +20612,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 752,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20516,6 +20670,8 @@
       },
       "physical": {
         "density": {
+          "value": 210,
+          "units": "kg/m3",
           "value_kg_m3": 210,
           "value_lb_ft3": 13.11,
           "source": "epd"
@@ -20664,7 +20820,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 753,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20722,6 +20878,8 @@
       },
       "physical": {
         "density": {
+          "value": 140,
+          "units": "kg/m3",
           "value_kg_m3": 140,
           "value_lb_ft3": 8.74,
           "source": "epd"
@@ -20870,7 +21028,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 754,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20928,6 +21086,8 @@
       },
       "physical": {
         "density": {
+          "value": 110,
+          "units": "kg/m3",
           "value_kg_m3": 110,
           "value_lb_ft3": 6.87,
           "source": "epd"
@@ -21076,7 +21236,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 755,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21134,6 +21294,8 @@
       },
       "physical": {
         "density": {
+          "value": 200,
+          "units": "kg/m3",
           "value_kg_m3": 200,
           "value_lb_ft3": 12.49,
           "source": "epd"
@@ -21285,7 +21447,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 756,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21343,6 +21505,8 @@
       },
       "physical": {
         "density": {
+          "value": 140,
+          "units": "kg/m3",
           "value_kg_m3": 140,
           "value_lb_ft3": 8.74,
           "source": "epd"
@@ -21496,7 +21660,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 757,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21554,6 +21718,8 @@
       },
       "physical": {
         "density": {
+          "value": 130,
+          "units": "kg/m3",
           "value_kg_m3": 130,
           "value_lb_ft3": 8.12,
           "source": "epd"
@@ -21705,7 +21871,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 758,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21763,6 +21929,8 @@
       },
       "physical": {
         "density": {
+          "value": 115,
+          "units": "kg/m3",
           "value_kg_m3": 115,
           "value_lb_ft3": 7.18,
           "source": "epd"
@@ -21914,7 +22082,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 759,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21972,6 +22140,8 @@
       },
       "physical": {
         "density": {
+          "value": 110,
+          "units": "kg/m3",
           "value_kg_m3": 110,
           "value_lb_ft3": 6.87,
           "source": "epd"
@@ -22123,7 +22293,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 760,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22176,6 +22346,8 @@
       },
       "physical": {
         "density": {
+          "value": 417,
+          "units": "kg/m3",
           "value_kg_m3": 417,
           "value_lb_ft3": 26.03,
           "source": "epd"
@@ -22321,7 +22493,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 761,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22377,8 +22549,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.6,
-          "value_lb_ft3": 0.35,
+          "value": 5.6,
+          "units": "kg/m",
           "source": "epd"
         }
       },
@@ -22528,7 +22700,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 762,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22584,8 +22756,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7.05,
-          "value_lb_ft3": 0.44,
+          "value": 7.05,
+          "units": "kg/m",
           "source": "epd"
         }
       },
@@ -22735,7 +22907,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 763,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22791,8 +22963,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 6.7,
-          "value_lb_ft3": 0.42,
+          "value": 6.7,
+          "units": "kg/m",
           "source": "epd"
         }
       },
@@ -22942,7 +23114,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 764,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23096,7 +23268,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 765,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23148,6 +23320,8 @@
       },
       "physical": {
         "density": {
+          "value": 456,
+          "units": "kg/m3",
           "value_kg_m3": 456,
           "value_lb_ft3": 28.47,
           "source": "epd"
@@ -23284,7 +23458,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 766,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23335,6 +23509,8 @@
       },
       "physical": {
         "density": {
+          "value": 456,
+          "units": "kg/m3",
           "value_kg_m3": 456,
           "value_lb_ft3": 28.47,
           "source": "epd"
@@ -23471,7 +23647,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 767,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23522,6 +23698,8 @@
       },
       "physical": {
         "density": {
+          "value": 456,
+          "units": "kg/m3",
           "value_kg_m3": 456,
           "value_lb_ft3": 28.47,
           "source": "epd"
@@ -23662,7 +23840,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 768,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23713,6 +23891,8 @@
       },
       "physical": {
         "density": {
+          "value": 456,
+          "units": "kg/m3",
           "value_kg_m3": 456,
           "value_lb_ft3": 28.47,
           "source": "epd"
@@ -23853,7 +24033,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 769,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23904,6 +24084,8 @@
       },
       "physical": {
         "density": {
+          "value": 456,
+          "units": "kg/m3",
           "value_kg_m3": 456,
           "value_lb_ft3": 28.47,
           "source": "epd"
@@ -24044,7 +24226,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 770,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24095,6 +24277,8 @@
       },
       "physical": {
         "density": {
+          "value": 456,
+          "units": "kg/m3",
           "value_kg_m3": 456,
           "value_lb_ft3": 28.47,
           "source": "epd"
@@ -24234,7 +24418,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 771,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24293,6 +24477,8 @@
       },
       "physical": {
         "density": {
+          "value": 462.91,
+          "units": "kg/m3",
           "value_kg_m3": 462.91,
           "value_lb_ft3": 28.9,
           "source": "epd"
@@ -24444,7 +24630,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 772,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24503,6 +24689,8 @@
       },
       "physical": {
         "density": {
+          "value": 462.91,
+          "units": "kg/m3",
           "value_kg_m3": 462.91,
           "value_lb_ft3": 28.9,
           "source": "epd"
@@ -24654,7 +24842,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 773,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24713,6 +24901,8 @@
       },
       "physical": {
         "density": {
+          "value": 462.91,
+          "units": "kg/m3",
           "value_kg_m3": 462.91,
           "value_lb_ft3": 28.9,
           "source": "epd"
@@ -24864,7 +25054,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 774,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24915,6 +25105,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -25058,7 +25250,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 775,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25109,6 +25301,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -25252,7 +25446,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 776,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25303,6 +25497,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -25446,7 +25642,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 777,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25497,6 +25693,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -25640,7 +25838,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 778,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25691,6 +25889,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -25834,7 +26034,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 779,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25885,6 +26085,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -26028,7 +26230,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 780,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26079,6 +26281,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -26222,7 +26426,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 781,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26273,6 +26477,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -26416,7 +26622,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 782,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26467,6 +26673,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -26610,7 +26818,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 783,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26661,6 +26869,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -26804,7 +27014,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 784,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26855,6 +27065,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -26998,7 +27210,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 785,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27049,6 +27261,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -27192,7 +27406,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 786,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27243,6 +27457,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -27386,7 +27602,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 787,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27436,6 +27652,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -27577,7 +27795,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 788,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27627,6 +27845,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -27768,7 +27988,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 789,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27818,6 +28038,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -27959,7 +28181,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 790,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28009,6 +28231,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -28150,7 +28374,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 791,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28200,6 +28424,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -28341,7 +28567,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 792,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28391,6 +28617,8 @@
       },
       "physical": {
         "density": {
+          "value": 460,
+          "units": "kg/m3",
           "value_kg_m3": 460,
           "value_lb_ft3": 28.72,
           "source": "epd"
@@ -28532,7 +28760,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 793,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28583,8 +28811,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.34,
-          "value_lb_ft3": 0.27,
+          "value": 4.34,
+          "units": "kg/m at avg depth",
           "source": "epd"
         },
         "additional_factor": {
@@ -28718,7 +28946,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 794,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28769,8 +28997,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.018,
-          "value_lb_ft3": 0.25,
+          "value": 4.018,
+          "units": "kg/m at depth",
           "source": "epd"
         },
         "additional_factor": {
@@ -28907,7 +29135,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 795,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28958,8 +29186,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.464,
-          "value_lb_ft3": 0.28,
+          "value": 4.464,
+          "units": "kg/m at depth",
           "source": "epd"
         },
         "additional_factor": {
@@ -28994,7 +29222,6 @@
           "biogenic_factor": 0.975,
           "storage_retention_pct": 0.9,
           "wwf_storage_factor_kgco2e_per_kgc": 8.01,
-          "carbon_content_kgc_per_unit": 2.24,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -29101,7 +29328,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 796,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29152,8 +29379,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.911,
-          "value_lb_ft3": 0.31,
+          "value": 4.911,
+          "units": "kg/m at depth",
           "source": "epd"
         },
         "additional_factor": {
@@ -29290,7 +29517,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 797,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29341,8 +29568,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.209,
-          "value_lb_ft3": 0.33,
+          "value": 5.209,
+          "units": "kg/m at depth",
           "source": "epd"
         },
         "additional_factor": {
@@ -29479,7 +29706,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 798,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29530,8 +29757,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3.9,
-          "value_lb_ft3": 0.24,
+          "value": 3.9,
+          "units": "kg/m",
           "source": "epd"
         }
       },
@@ -29666,7 +29893,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 799,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29876,7 +30103,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 800,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30086,7 +30313,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 801,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30296,7 +30523,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 802,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30506,7 +30733,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 803,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30716,7 +30943,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 804,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30926,7 +31153,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 805,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30978,6 +31205,8 @@
       },
       "physical": {
         "density": {
+          "value": 417,
+          "units": "kg/m3",
           "value_kg_m3": 417,
           "value_lb_ft3": 26.03,
           "source": "epd"
@@ -31119,7 +31348,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 807,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31177,8 +31406,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.09,
-          "value_lb_ft3": 1.07,
+          "value": 17.09,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -31329,7 +31558,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 808,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31388,6 +31617,8 @@
       },
       "physical": {
         "density": {
+          "value": 400,
+          "units": "kg/m3",
           "value_kg_m3": 400,
           "value_lb_ft3": 24.97,
           "source": "epd"
@@ -31534,7 +31765,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 809,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31593,6 +31824,8 @@
       },
       "physical": {
         "density": {
+          "value": 400,
+          "units": "kg/m3",
           "value_kg_m3": 400,
           "value_lb_ft3": 24.97,
           "source": "epd"
@@ -31737,7 +31970,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 810,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/materials/07-thermal.json
+++ b/schema/materials/07-thermal.json
@@ -49,6 +49,8 @@
       },
       "physical": {
         "density": {
+          "value": 150,
+          "units": "kg/m3",
           "value_kg_m3": 150,
           "value_lb_ft3": 9.36,
           "source": "epd"
@@ -179,7 +181,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 12,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -331,7 +333,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 14,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -484,7 +486,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 15,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -637,7 +639,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 16,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -790,7 +792,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 17,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -943,7 +945,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 18,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1096,7 +1098,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 19,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1249,7 +1251,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 20,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1402,7 +1404,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 21,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1462,8 +1464,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 200,
-          "value_lb_ft3": 12.49,
+          "value": 200,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -1604,7 +1606,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 22,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1663,8 +1665,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 160,
-          "value_lb_ft3": 9.99,
+          "value": 160,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -1801,7 +1803,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 23,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1860,8 +1862,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 160,
-          "value_lb_ft3": 9.99,
+          "value": 160,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -1998,7 +2000,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 24,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2057,8 +2059,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 225,
-          "value_lb_ft3": 14.05,
+          "value": 225,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -2195,7 +2197,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 25,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2254,8 +2256,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 112,
-          "value_lb_ft3": 6.99,
+          "value": 112,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -2392,7 +2394,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 26,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2451,8 +2453,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 210,
-          "value_lb_ft3": 13.11,
+          "value": 210,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -2589,7 +2591,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 27,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2648,8 +2650,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 360,
-          "value_lb_ft3": 22.47,
+          "value": 360,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -2786,7 +2788,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 28,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2845,8 +2847,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 250,
-          "value_lb_ft3": 15.61,
+          "value": 250,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -2983,7 +2985,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 29,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3043,8 +3045,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.498,
-          "value_lb_ft3": 0.09,
+          "value": 1.498,
+          "units": "m2/kg",
           "source": "epd"
         }
       },
@@ -3183,7 +3185,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 30,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3242,8 +3244,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 150,
-          "value_lb_ft3": 9.36,
+          "value": 150,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -3380,7 +3382,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 32,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3565,7 +3567,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 33,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3625,8 +3627,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.975,
-          "value_lb_ft3": 0.06,
+          "value": 0.975,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -3765,7 +3767,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 34,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3824,8 +3826,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.346,
-          "value_lb_ft3": 0.02,
+          "value": 0.346,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -3964,7 +3966,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 35,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4023,8 +4025,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.025,
-          "value_lb_ft3": 0.06,
+          "value": 1.025,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -4163,7 +4165,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 36,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4222,8 +4224,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.763,
-          "value_lb_ft3": 0.05,
+          "value": 0.763,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -4362,7 +4364,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 37,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4416,8 +4418,10 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.4,
-          "value_lb_ft3": 0.09,
+          "value": 1.4,
+          "units": "g/cm3",
+          "value_kg_m3": 1400,
+          "value_lb_ft3": 87.4,
           "source": "epd"
         },
         "dimensions": {
@@ -4555,7 +4559,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 38,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4609,8 +4613,10 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.4,
-          "value_lb_ft3": 0.09,
+          "value": 1.4,
+          "units": "g/cm3",
+          "value_kg_m3": 1400,
+          "value_lb_ft3": 87.4,
           "source": "epd"
         },
         "dimensions": {
@@ -4748,7 +4754,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 39,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4802,8 +4808,10 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.4,
-          "value_lb_ft3": 0.09,
+          "value": 1.4,
+          "units": "g/cm3",
+          "value_kg_m3": 1400,
+          "value_lb_ft3": 87.4,
           "source": "epd"
         },
         "dimensions": {
@@ -4941,7 +4949,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 40,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4995,8 +5003,10 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.4,
-          "value_lb_ft3": 0.09,
+          "value": 1.4,
+          "units": "g/cm3",
+          "value_kg_m3": 1400,
+          "value_lb_ft3": 87.4,
           "source": "epd"
         },
         "dimensions": {
@@ -5134,7 +5144,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 41,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5193,8 +5203,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.014,
-          "value_lb_ft3": 0.13,
+          "value": 2.014,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -5333,7 +5343,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 42,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5392,8 +5402,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.569,
-          "value_lb_ft3": 0.04,
+          "value": 0.569,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -5532,7 +5542,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 43,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5591,8 +5601,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.1,
-          "value_lb_ft3": 0.01,
+          "value": 0.1,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -5728,7 +5738,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 44,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5787,8 +5797,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.471,
-          "value_lb_ft3": 0.03,
+          "value": 0.471,
+          "units": "m2/kg",
           "source": "epd"
         }
       },
@@ -5927,7 +5937,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 45,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5986,8 +5996,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.484,
-          "value_lb_ft3": 0.03,
+          "value": 0.484,
+          "units": "m2/kg",
           "source": "epd"
         }
       },
@@ -6126,7 +6136,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 46,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6186,8 +6196,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 80,
-          "value_lb_ft3": 4.99,
+          "value": 80,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -6324,7 +6334,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 47,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6384,8 +6394,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 80,
-          "value_lb_ft3": 4.99,
+          "value": 80,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -6522,7 +6532,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 48,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6581,8 +6591,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 120,
-          "value_lb_ft3": 7.49,
+          "value": 120,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -6719,7 +6729,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 49,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6778,8 +6788,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 120,
-          "value_lb_ft3": 7.49,
+          "value": 120,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -6916,7 +6926,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 50,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6975,8 +6985,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 80,
-          "value_lb_ft3": 4.99,
+          "value": 80,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -7113,7 +7123,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 51,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7172,8 +7182,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 140,
-          "value_lb_ft3": 8.74,
+          "value": 140,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -7310,7 +7320,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 52,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7369,8 +7379,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.15,
-          "value_lb_ft3": 0.01,
+          "value": 0.15,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -7505,7 +7515,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 53,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7564,8 +7574,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 120,
-          "value_lb_ft3": 7.49,
+          "value": 120,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -7701,7 +7711,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 54,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7761,8 +7771,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.233,
-          "value_lb_ft3": 0.01,
+          "value": 0.233,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -7889,7 +7899,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 55,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7949,8 +7959,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.147,
-          "value_lb_ft3": 0.01,
+          "value": 0.147,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8077,7 +8087,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 56,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8130,8 +8140,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.83,
-          "value_lb_ft3": 0.61,
+          "value": 9.83,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8256,7 +8266,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 57,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8307,8 +8317,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 12.7,
-          "value_lb_ft3": 0.79,
+          "value": 12.7,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8434,7 +8444,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 58,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8491,8 +8501,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 12.39,
-          "value_lb_ft3": 0.77,
+          "value": 12.39,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8633,7 +8643,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 59,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8684,8 +8694,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.12,
-          "value_lb_ft3": 0.63,
+          "value": 10.12,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8810,7 +8820,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 60,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8861,8 +8871,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.93,
-          "value_lb_ft3": 0.62,
+          "value": 9.93,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8987,7 +8997,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 61,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9038,8 +9048,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.26,
-          "value_lb_ft3": 0.58,
+          "value": 9.26,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -9164,7 +9174,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 62,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9221,8 +9231,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.12,
-          "value_lb_ft3": 0.63,
+          "value": 10.12,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -9358,7 +9368,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 63,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9547,7 +9557,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 64,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9737,7 +9747,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 65,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9927,7 +9937,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 66,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10117,7 +10127,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 67,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10307,7 +10317,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 68,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10497,7 +10507,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 69,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10687,7 +10697,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 70,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10849,7 +10859,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 106,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10908,8 +10918,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3.621,
-          "value_lb_ft3": 0.23,
+          "value": 3.621,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -11049,7 +11059,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 114,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11100,6 +11110,8 @@
       },
       "physical": {
         "density": {
+          "value": 209,
+          "units": "kg/m3",
           "value_kg_m3": 209,
           "value_lb_ft3": 13.05,
           "source": "epd"
@@ -11242,7 +11254,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 117,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11299,6 +11311,8 @@
       },
       "physical": {
         "density": {
+          "value": 40,
+          "units": "kg/m3",
           "value_kg_m3": 40,
           "value_lb_ft3": 2.5,
           "source": "epd"
@@ -11442,7 +11456,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 119,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11499,6 +11513,8 @@
       },
       "physical": {
         "density": {
+          "value": 40,
+          "units": "kg/m3",
           "value_kg_m3": 40,
           "value_lb_ft3": 2.5,
           "source": "epd"
@@ -11645,7 +11661,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 120,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11703,6 +11719,8 @@
       },
       "physical": {
         "density": {
+          "value": 56,
+          "units": "kg/m3",
           "value_kg_m3": 56,
           "value_lb_ft3": 3.5,
           "source": "epd"
@@ -11850,7 +11868,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 121,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11908,6 +11926,8 @@
       },
       "physical": {
         "density": {
+          "value": 24.4,
+          "units": "kg/m3",
           "value_kg_m3": 24.4,
           "value_lb_ft3": 1.52,
           "source": "epd"
@@ -12060,7 +12080,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 122,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12118,6 +12138,8 @@
       },
       "physical": {
         "density": {
+          "value": 56,
+          "units": "kg/m3",
           "value_kg_m3": 56,
           "value_lb_ft3": 3.5,
           "source": "epd"
@@ -12276,7 +12298,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 123,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12334,6 +12356,8 @@
       },
       "physical": {
         "density": {
+          "value": 25.214,
+          "units": "kg/m3",
           "value_kg_m3": 25.214,
           "value_lb_ft3": 1.57,
           "source": "epd"
@@ -12492,7 +12516,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 124,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12550,6 +12574,8 @@
       },
       "physical": {
         "density": {
+          "value": 56.1,
+          "units": "kg/m3",
           "value_kg_m3": 56.1,
           "value_lb_ft3": 3.5,
           "source": "epd"
@@ -12710,7 +12736,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 125,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12768,6 +12794,8 @@
       },
       "physical": {
         "density": {
+          "value": 17.1,
+          "units": "kg/m3",
           "value_kg_m3": 17.1,
           "value_lb_ft3": 1.07,
           "source": "epd"
@@ -12928,7 +12956,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 126,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12986,6 +13014,8 @@
       },
       "physical": {
         "density": {
+          "value": 54.5,
+          "units": "kg/m3",
           "value_kg_m3": 54.5,
           "value_lb_ft3": 3.4,
           "source": "epd"
@@ -13127,7 +13157,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 127,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13177,8 +13207,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 56,
-          "value_lb_ft3": 3.5,
+          "value": 56,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -13306,7 +13336,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 135,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13360,6 +13390,11 @@
         "metallic": 0,
         "roughness": 0.9,
         "has_grain": false
+      },
+      "physical": {
+        "density": {
+          "units": "kg/m3"
+        }
       },
       "carbon": {
         "stated": {
@@ -13499,12 +13534,11 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 145,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
       },
-      "physical": {},
       "cost": {},
       "fire": {},
       "code_compliance": {}
@@ -13558,8 +13592,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 62.47,
-          "value_lb_ft3": 3.9,
+          "value": 62.47,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -13697,7 +13731,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 148,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13755,8 +13789,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 12.38,
-          "value_lb_ft3": 0.77,
+          "value": 12.38,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -13894,7 +13928,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 149,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13952,6 +13986,8 @@
       },
       "physical": {
         "density": {
+          "value": 115,
+          "units": "kg/m3",
           "value_kg_m3": 115,
           "value_lb_ft3": 7.18,
           "source": "epd"
@@ -14107,7 +14143,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 320,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14165,6 +14201,8 @@
       },
       "physical": {
         "density": {
+          "value": 133,
+          "units": "kg/m3",
           "value_kg_m3": 133,
           "value_lb_ft3": 8.3,
           "source": "epd"
@@ -14296,7 +14334,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 323,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14353,6 +14391,8 @@
       },
       "physical": {
         "density": {
+          "value": 40,
+          "units": "kg/m3",
           "value_kg_m3": 40,
           "value_lb_ft3": 2.5,
           "source": "epd"
@@ -14499,7 +14539,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 324,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14554,6 +14594,8 @@
       },
       "physical": {
         "density": {
+          "value": 654.554,
+          "units": "kg/m3",
           "value_kg_m3": 654.554,
           "value_lb_ft3": 40.86,
           "source": "epd"
@@ -14671,7 +14713,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 349,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14729,6 +14771,8 @@
       },
       "physical": {
         "density": {
+          "value": 657,
+          "units": "kg/m3",
           "value_kg_m3": 657,
           "value_lb_ft3": 41.02,
           "source": "epd"
@@ -14873,7 +14917,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 350,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14931,6 +14975,8 @@
       },
       "physical": {
         "density": {
+          "value": 657,
+          "units": "kg/m3",
           "value_kg_m3": 657,
           "value_lb_ft3": 41.02,
           "source": "epd"
@@ -15075,7 +15121,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 351,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15133,6 +15179,8 @@
       },
       "physical": {
         "density": {
+          "value": 657,
+          "units": "kg/m3",
           "value_kg_m3": 657,
           "value_lb_ft3": 41.02,
           "source": "epd"
@@ -15277,7 +15325,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 352,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15336,6 +15384,8 @@
       },
       "physical": {
         "density": {
+          "value": 644.77,
+          "units": "kg/m3",
           "value_kg_m3": 644.77,
           "value_lb_ft3": 40.25,
           "source": "epd"
@@ -15485,7 +15535,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 353,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15544,6 +15594,8 @@
       },
       "physical": {
         "density": {
+          "value": 657,
+          "units": "kg/m3",
           "value_kg_m3": 657,
           "value_lb_ft3": 41.02,
           "source": "epd"
@@ -15692,7 +15744,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 354,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15744,8 +15796,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.07,
-          "value_lb_ft3": 0.13,
+          "value": 2.07,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -15877,7 +15929,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 355,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15935,6 +15987,8 @@
       },
       "physical": {
         "density": {
+          "value": 14.4,
+          "units": "kg/m3",
           "value_kg_m3": 14.4,
           "value_lb_ft3": 0.9,
           "source": "epd"
@@ -16082,7 +16136,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 356,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16140,6 +16194,8 @@
       },
       "physical": {
         "density": {
+          "value": 21.6,
+          "units": "kg/m3",
           "value_kg_m3": 21.6,
           "value_lb_ft3": 1.35,
           "source": "epd"
@@ -16292,7 +16348,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 357,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16350,6 +16406,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.8,
+          "units": "kg/m3",
           "value_kg_m3": 28.8,
           "value_lb_ft3": 1.8,
           "source": "epd"
@@ -16502,7 +16560,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 358,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16560,6 +16618,8 @@
       },
       "physical": {
         "density": {
+          "value": 48.1,
+          "units": "kg/m3",
           "value_kg_m3": 48.1,
           "value_lb_ft3": 3,
           "source": "epd"
@@ -16712,7 +16772,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 359,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16771,6 +16831,8 @@
       },
       "physical": {
         "density": {
+          "value": 21.62,
+          "units": "kg/m3",
           "value_kg_m3": 21.62,
           "value_lb_ft3": 1.35,
           "source": "epd"
@@ -16917,7 +16979,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 360,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -16976,6 +17038,8 @@
       },
       "physical": {
         "density": {
+          "value": 14.42,
+          "units": "kg/m3",
           "value_kg_m3": 14.42,
           "value_lb_ft3": 0.9,
           "source": "epd"
@@ -17122,7 +17186,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 361,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17180,6 +17244,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.8,
+          "units": "kg/m3",
           "value_kg_m3": 28.8,
           "value_lb_ft3": 1.8,
           "source": "epd"
@@ -17324,7 +17390,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 362,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17382,6 +17448,8 @@
       },
       "physical": {
         "density": {
+          "value": 21.6,
+          "units": "kg/m3",
           "value_kg_m3": 21.6,
           "value_lb_ft3": 1.35,
           "source": "epd"
@@ -17526,7 +17594,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 363,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17581,6 +17649,8 @@
       },
       "physical": {
         "density": {
+          "value": 11.1,
+          "units": "kg/m3",
           "value_kg_m3": 11.1,
           "value_lb_ft3": 0.69,
           "source": "epd"
@@ -17695,7 +17765,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 367,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17754,8 +17824,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 16.5,
-          "value_lb_ft3": 1.03,
+          "value": 16.5,
+          "units": "kg/m2 at 10mm",
           "source": "epd"
         }
       },
@@ -17899,7 +17969,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 368,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -17958,6 +18028,8 @@
       },
       "physical": {
         "density": {
+          "value": 1850,
+          "units": "kg/m3",
           "value_kg_m3": 1850,
           "value_lb_ft3": 115.5,
           "source": "epd"
@@ -18109,7 +18181,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 369,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18167,8 +18239,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.79,
-          "value_lb_ft3": 0.61,
+          "value": 9.79,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -18311,7 +18383,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 370,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18369,8 +18441,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.79,
-          "value_lb_ft3": 0.61,
+          "value": 9.79,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -18513,7 +18585,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 371,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18571,8 +18643,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7.86,
-          "value_lb_ft3": 0.49,
+          "value": 7.86,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -18715,7 +18787,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 372,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -18773,8 +18845,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7.86,
-          "value_lb_ft3": 0.49,
+          "value": 7.86,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -18917,7 +18989,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 373,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19085,7 +19157,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 374,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19142,6 +19214,8 @@
       },
       "physical": {
         "density": {
+          "value": 12.01,
+          "units": "kg/m3",
           "value_kg_m3": 12.01,
           "value_lb_ft3": 0.75,
           "source": "epd"
@@ -19288,7 +19362,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 375,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19484,7 +19558,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 376,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19677,7 +19751,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 377,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -19735,8 +19809,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.488,
-          "value_lb_ft3": 0.03,
+          "value": 0.488,
+          "units": "kg/m2 at RSI 1",
           "source": "epd"
         },
         "thermal": {
@@ -19865,7 +19939,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 378,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20033,7 +20107,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 379,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20090,6 +20164,8 @@
       },
       "physical": {
         "density": {
+          "value": 6.89,
+          "units": "kg/m3",
           "value_kg_m3": 6.89,
           "value_lb_ft3": 0.43,
           "source": "epd"
@@ -20236,7 +20312,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 380,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20293,8 +20369,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.46,
-          "value_lb_ft3": 0.03,
+          "value": 0.46,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -20432,7 +20508,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 381,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20489,8 +20565,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.574,
-          "value_lb_ft3": 0.04,
+          "value": 0.574,
+          "units": "kg/m2 at RSI 1",
           "source": "epd"
         },
         "thermal": {
@@ -20619,7 +20695,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 382,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20676,8 +20752,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.567,
-          "value_lb_ft3": 0.04,
+          "value": 0.567,
+          "units": "kg/m2 at RSI 1",
           "source": "epd"
         },
         "thermal": {
@@ -20827,7 +20903,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 383,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -20884,6 +20960,8 @@
       },
       "physical": {
         "density": {
+          "value": 57.6,
+          "units": "kg/m3",
           "value_kg_m3": 57.6,
           "value_lb_ft3": 3.6,
           "source": "epd"
@@ -21028,7 +21106,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 384,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21085,6 +21163,8 @@
       },
       "physical": {
         "density": {
+          "value": 180,
+          "units": "kg/m3",
           "value_kg_m3": 180,
           "value_lb_ft3": 11.24,
           "source": "epd"
@@ -21215,7 +21295,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 388,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21272,6 +21352,8 @@
       },
       "physical": {
         "density": {
+          "value": 180,
+          "units": "kg/m3",
           "value_kg_m3": 180,
           "value_lb_ft3": 11.24,
           "source": "epd"
@@ -21402,7 +21484,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 389,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21460,6 +21542,8 @@
       },
       "physical": {
         "density": {
+          "value": 130,
+          "units": "kg/m3",
           "value_kg_m3": 130,
           "value_lb_ft3": 8.12,
           "source": "epd"
@@ -21590,7 +21674,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 390,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21648,6 +21732,8 @@
       },
       "physical": {
         "density": {
+          "value": 125,
+          "units": "kg/m3",
           "value_kg_m3": 125,
           "value_lb_ft3": 7.8,
           "source": "epd"
@@ -21770,7 +21856,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 391,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -21828,6 +21914,8 @@
       },
       "physical": {
         "density": {
+          "value": 165,
+          "units": "kg/m3",
           "value_kg_m3": 165,
           "value_lb_ft3": 10.3,
           "source": "epd"
@@ -21962,7 +22050,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 392,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22020,6 +22108,8 @@
       },
       "physical": {
         "density": {
+          "value": 130,
+          "units": "kg/m3",
           "value_kg_m3": 130,
           "value_lb_ft3": 8.12,
           "source": "epd"
@@ -22154,7 +22244,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 393,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22212,6 +22302,8 @@
       },
       "physical": {
         "density": {
+          "value": 95,
+          "units": "kg/m3",
           "value_kg_m3": 95,
           "value_lb_ft3": 5.93,
           "source": "epd"
@@ -22346,7 +22438,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 394,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22404,6 +22496,8 @@
       },
       "physical": {
         "density": {
+          "value": 110,
+          "units": "kg/m3",
           "value_kg_m3": 110,
           "value_lb_ft3": 6.87,
           "source": "epd"
@@ -22538,7 +22632,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 395,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22596,6 +22690,8 @@
       },
       "physical": {
         "density": {
+          "value": 115,
+          "units": "kg/m3",
           "value_kg_m3": 115,
           "value_lb_ft3": 7.18,
           "source": "epd"
@@ -22726,7 +22822,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 396,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22784,6 +22880,8 @@
       },
       "physical": {
         "density": {
+          "value": 100,
+          "units": "kg/m3",
           "value_kg_m3": 100,
           "value_lb_ft3": 6.24,
           "source": "epd"
@@ -22914,7 +23012,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 397,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -22971,8 +23069,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 57.55,
-          "value_lb_ft3": 3.59,
+          "value": 57.55,
+          "units": "kg/m2 saturated",
           "source": "epd"
         },
         "additional_factor": {
@@ -23113,7 +23211,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 415,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23300,7 +23398,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 416,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23358,8 +23456,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 163,
-          "value_lb_ft3": 10.18,
+          "value": 163,
+          "units": "kg/m2 saturated",
           "source": "epd"
         },
         "additional_factor": {
@@ -23500,7 +23598,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 417,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23555,6 +23653,8 @@
       },
       "physical": {
         "density": {
+          "value": 35,
+          "units": "kg/m3",
           "value_kg_m3": 35,
           "value_lb_ft3": 2.19,
           "source": "epd"
@@ -23671,7 +23771,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 435,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23728,6 +23828,8 @@
       },
       "physical": {
         "density": {
+          "value": 35,
+          "units": "kg/m3",
           "value_kg_m3": 35,
           "value_lb_ft3": 2.19,
           "source": "epd"
@@ -23869,7 +23971,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 436,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -23926,6 +24028,8 @@
       },
       "physical": {
         "density": {
+          "value": 35,
+          "units": "kg/m3",
           "value_kg_m3": 35,
           "value_lb_ft3": 2.19,
           "source": "epd"
@@ -24074,7 +24178,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 437,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24131,6 +24235,8 @@
       },
       "physical": {
         "density": {
+          "value": 35,
+          "units": "kg/m3",
           "value_kg_m3": 35,
           "value_lb_ft3": 2.19,
           "source": "epd"
@@ -24276,7 +24382,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 438,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24333,6 +24439,8 @@
       },
       "physical": {
         "density": {
+          "value": 255,
+          "units": "kg/m3",
           "value_kg_m3": 255,
           "value_lb_ft3": 15.92,
           "source": "epd"
@@ -24449,7 +24557,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 439,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24508,6 +24616,8 @@
       },
       "physical": {
         "density": {
+          "value": 300,
+          "units": "kg/m3",
           "value_kg_m3": 300,
           "value_lb_ft3": 18.73,
           "source": "epd"
@@ -24650,7 +24760,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 440,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24709,6 +24819,8 @@
       },
       "physical": {
         "density": {
+          "value": 300,
+          "units": "kg/m3",
           "value_kg_m3": 300,
           "value_lb_ft3": 18.73,
           "source": "epd"
@@ -24850,7 +24962,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 441,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -24909,6 +25021,8 @@
       },
       "physical": {
         "density": {
+          "value": 230,
+          "units": "kg/m3",
           "value_kg_m3": 230,
           "value_lb_ft3": 14.36,
           "source": "epd"
@@ -25055,7 +25169,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 442,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25114,6 +25228,8 @@
       },
       "physical": {
         "density": {
+          "value": 190,
+          "units": "kg/m3",
           "value_kg_m3": 190,
           "value_lb_ft3": 11.86,
           "source": "epd"
@@ -25260,7 +25376,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 443,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25320,6 +25436,8 @@
       },
       "physical": {
         "density": {
+          "value": 330,
+          "units": "kg/m3",
           "value_kg_m3": 330,
           "value_lb_ft3": 20.6,
           "source": "epd"
@@ -25466,7 +25584,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 444,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25527,6 +25645,8 @@
       },
       "physical": {
         "density": {
+          "value": 340,
+          "units": "kg/m3",
           "value_kg_m3": 340,
           "value_lb_ft3": 21.23,
           "source": "epd"
@@ -25689,7 +25809,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 445,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -25854,7 +25974,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 512,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26025,7 +26145,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 513,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26223,7 +26343,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 514,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26421,7 +26541,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 515,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26616,7 +26736,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 516,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -26814,7 +26934,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 517,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27012,7 +27132,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 518,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27207,7 +27327,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 519,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27402,7 +27522,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 520,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27597,7 +27717,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 521,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27792,7 +27912,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 522,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -27962,7 +28082,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 523,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28020,6 +28140,8 @@
       },
       "physical": {
         "density": {
+          "value": 40,
+          "units": "kg/m3",
           "value_kg_m3": 40,
           "value_lb_ft3": 2.5,
           "source": "epd"
@@ -28167,7 +28289,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 524,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28362,7 +28484,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 525,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28557,7 +28679,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 526,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28752,7 +28874,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 527,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -28944,7 +29066,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 528,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29128,7 +29250,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 529,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29186,6 +29308,8 @@
       },
       "physical": {
         "density": {
+          "value": 128,
+          "units": "kg/m3",
           "value_kg_m3": 128,
           "value_lb_ft3": 7.99,
           "source": "epd"
@@ -29317,7 +29441,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 530,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29501,7 +29625,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 531,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29685,7 +29809,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 532,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29744,6 +29868,8 @@
       },
       "physical": {
         "density": {
+          "value": 99.9,
+          "units": "kg/m3",
           "value_kg_m3": 99.9,
           "value_lb_ft3": 6.24,
           "source": "epd"
@@ -29889,7 +30015,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 533,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -29948,6 +30074,8 @@
       },
       "physical": {
         "density": {
+          "value": 38.3,
+          "units": "kg/m3",
           "value_kg_m3": 38.3,
           "value_lb_ft3": 2.39,
           "source": "epd"
@@ -30093,7 +30221,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 534,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30152,6 +30280,8 @@
       },
       "physical": {
         "density": {
+          "value": 32.1,
+          "units": "kg/m3",
           "value_kg_m3": 32.1,
           "value_lb_ft3": 2,
           "source": "epd"
@@ -30297,7 +30427,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 535,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30354,6 +30484,8 @@
       },
       "physical": {
         "density": {
+          "value": 121,
+          "units": "kg/m3",
           "value_kg_m3": 121,
           "value_lb_ft3": 7.55,
           "source": "epd"
@@ -30493,7 +30625,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 536,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30552,6 +30684,8 @@
       },
       "physical": {
         "density": {
+          "value": 37.64,
+          "units": "kg/m3",
           "value_kg_m3": 37.64,
           "value_lb_ft3": 2.35,
           "source": "epd"
@@ -30685,7 +30819,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 565,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30744,6 +30878,8 @@
       },
       "physical": {
         "density": {
+          "value": 37.64,
+          "units": "kg/m3",
           "value_kg_m3": 37.64,
           "value_lb_ft3": 2.35,
           "source": "epd"
@@ -30877,7 +31013,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 566,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -30936,6 +31072,8 @@
       },
       "physical": {
         "density": {
+          "value": 37.64,
+          "units": "kg/m3",
           "value_kg_m3": 37.64,
           "value_lb_ft3": 2.35,
           "source": "epd"
@@ -31069,7 +31207,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 567,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31126,6 +31264,8 @@
       },
       "physical": {
         "density": {
+          "value": 49.09,
+          "units": "kg/m3",
           "value_kg_m3": 49.09,
           "value_lb_ft3": 3.06,
           "source": "epd"
@@ -31263,7 +31403,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 568,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31320,6 +31460,8 @@
       },
       "physical": {
         "density": {
+          "value": 29.53,
+          "units": "kg/m3",
           "value_kg_m3": 29.53,
           "value_lb_ft3": 1.84,
           "source": "epd"
@@ -31451,7 +31593,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 569,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31647,7 +31789,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 570,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31704,6 +31846,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.92,
+          "units": "kg/m3",
           "value_kg_m3": 28.92,
           "value_lb_ft3": 1.81,
           "source": "epd"
@@ -31846,7 +31990,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 571,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -31903,6 +32047,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.92,
+          "units": "kg/m3",
           "value_kg_m3": 28.92,
           "value_lb_ft3": 1.81,
           "source": "epd"
@@ -32045,7 +32191,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 572,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32241,7 +32387,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 573,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32298,6 +32444,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.92,
+          "units": "kg/m3",
           "value_kg_m3": 28.92,
           "value_lb_ft3": 1.81,
           "source": "epd"
@@ -32440,7 +32588,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 574,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32497,6 +32645,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.92,
+          "units": "kg/m3",
           "value_kg_m3": 28.92,
           "value_lb_ft3": 1.81,
           "source": "epd"
@@ -32639,7 +32789,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 575,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32696,6 +32846,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.92,
+          "units": "kg/m3",
           "value_kg_m3": 28.92,
           "value_lb_ft3": 1.81,
           "source": "epd"
@@ -32838,7 +32990,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 576,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -32895,6 +33047,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.92,
+          "units": "kg/m3",
           "value_kg_m3": 28.92,
           "value_lb_ft3": 1.81,
           "source": "epd"
@@ -33037,7 +33191,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 577,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33094,6 +33248,8 @@
       },
       "physical": {
         "density": {
+          "value": 28.92,
+          "units": "kg/m3",
           "value_kg_m3": 28.92,
           "value_lb_ft3": 1.81,
           "source": "epd"
@@ -33236,7 +33392,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 578,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33432,7 +33588,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 579,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33489,6 +33645,8 @@
       },
       "physical": {
         "density": {
+          "value": 33.73,
+          "units": "kg/m3",
           "value_kg_m3": 33.73,
           "value_lb_ft3": 2.11,
           "source": "epd"
@@ -33631,7 +33789,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 580,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33688,6 +33846,8 @@
       },
       "physical": {
         "density": {
+          "value": 1025,
+          "units": "kg/m3",
           "value_kg_m3": 1025,
           "value_lb_ft3": 63.99,
           "source": "epd"
@@ -33830,7 +33990,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 582,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -33884,8 +34044,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.463,
-          "value_lb_ft3": 0.09,
+          "value": 1.463,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -34020,7 +34180,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 583,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34200,7 +34360,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 608,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34258,8 +34418,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.804,
-          "value_lb_ft3": 1.11,
+          "value": 17.804,
+          "units": "kg/m2 at RSI1",
           "source": "epd"
         },
         "additional_factor": {
@@ -34295,7 +34455,6 @@
           "storage_retention_pct": 0.9,
           "wwf_storage_factor_kgco2e_per_kgc": 21.68,
           "full_carbon_kgco2e_per_common_unit": 28.54,
-          "carbon_content_kgc_per_unit": 138.46,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -34407,7 +34566,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 620,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34465,8 +34624,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.804,
-          "value_lb_ft3": 1.11,
+          "value": 17.804,
+          "units": "kg/m2 at RSI1",
           "source": "epd"
         },
         "additional_factor": {
@@ -34501,7 +34660,6 @@
           "biogenic_factor": 0.925,
           "storage_retention_pct": 0.9,
           "wwf_storage_factor_kgco2e_per_kgc": 21.68,
-          "carbon_content_kgc_per_unit": 138.46,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -34613,7 +34771,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 621,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34671,8 +34829,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.804,
-          "value_lb_ft3": 1.11,
+          "value": 17.804,
+          "units": "kg/m2 at RSI1",
           "source": "epd"
         },
         "additional_factor": {
@@ -34707,7 +34865,6 @@
           "biogenic_factor": 0.925,
           "storage_retention_pct": 0.9,
           "wwf_storage_factor_kgco2e_per_kgc": 21.68,
-          "carbon_content_kgc_per_unit": 138.46,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -34819,7 +34976,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 622,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -34877,8 +35034,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.804,
-          "value_lb_ft3": 1.11,
+          "value": 17.804,
+          "units": "kg/m2 at RSI1",
           "source": "epd"
         },
         "additional_factor": {
@@ -34913,7 +35070,6 @@
           "biogenic_factor": 0.925,
           "storage_retention_pct": 0.9,
           "wwf_storage_factor_kgco2e_per_kgc": 21.68,
-          "carbon_content_kgc_per_unit": 138.46,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -35025,7 +35181,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 623,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35083,8 +35239,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.804,
-          "value_lb_ft3": 1.11,
+          "value": 17.804,
+          "units": "kg/m2 at RSI1",
           "source": "epd"
         },
         "additional_factor": {
@@ -35119,7 +35275,6 @@
           "biogenic_factor": 0.925,
           "storage_retention_pct": 0.9,
           "wwf_storage_factor_kgco2e_per_kgc": 21.68,
-          "carbon_content_kgc_per_unit": 138.46,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -35231,7 +35386,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 624,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35289,6 +35444,8 @@
       },
       "physical": {
         "density": {
+          "value": 31.2,
+          "units": "kg/m3",
           "value_kg_m3": 31.2,
           "value_lb_ft3": 1.95,
           "source": "epd"
@@ -35420,7 +35577,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 625,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35478,6 +35635,8 @@
       },
       "physical": {
         "density": {
+          "value": 38.4,
+          "units": "kg/m3",
           "value_kg_m3": 38.4,
           "value_lb_ft3": 2.4,
           "source": "epd"
@@ -35618,7 +35777,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 626,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35677,6 +35836,8 @@
       },
       "physical": {
         "density": {
+          "value": 31.2,
+          "units": "kg/m3",
           "value_kg_m3": 31.2,
           "value_lb_ft3": 1.95,
           "source": "epd"
@@ -35819,7 +35980,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 627,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -35878,6 +36039,8 @@
       },
       "physical": {
         "density": {
+          "value": 32,
+          "units": "kg/m3",
           "value_kg_m3": 32,
           "value_lb_ft3": 2,
           "source": "epd"
@@ -36024,7 +36187,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 628,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36083,6 +36246,8 @@
       },
       "physical": {
         "density": {
+          "value": 32,
+          "units": "kg/m3",
           "value_kg_m3": 32,
           "value_lb_ft3": 2,
           "source": "epd"
@@ -36229,7 +36394,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 629,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36287,6 +36452,8 @@
       },
       "physical": {
         "density": {
+          "value": 52,
+          "units": "kg/m3",
           "value_kg_m3": 52,
           "value_lb_ft3": 3.25,
           "source": "epd"
@@ -36418,7 +36585,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 630,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36477,6 +36644,8 @@
       },
       "physical": {
         "density": {
+          "value": 52,
+          "units": "kg/m3",
           "value_kg_m3": 52,
           "value_lb_ft3": 3.25,
           "source": "epd"
@@ -36619,7 +36788,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 631,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36678,6 +36847,8 @@
       },
       "physical": {
         "density": {
+          "value": 48,
+          "units": "kg/m3",
           "value_kg_m3": 48,
           "value_lb_ft3": 3,
           "source": "epd"
@@ -36824,7 +36995,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 632,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -36883,6 +37054,8 @@
       },
       "physical": {
         "density": {
+          "value": 48,
+          "units": "kg/m3",
           "value_kg_m3": 48,
           "value_lb_ft3": 3,
           "source": "epd"
@@ -37029,7 +37202,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 633,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37088,6 +37261,8 @@
       },
       "physical": {
         "density": {
+          "value": 9.6,
+          "units": "kg/m3",
           "value_kg_m3": 9.6,
           "value_lb_ft3": 0.6,
           "source": "epd"
@@ -37230,7 +37405,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 634,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37289,6 +37464,8 @@
       },
       "physical": {
         "density": {
+          "value": 48,
+          "units": "kg/m3",
           "value_kg_m3": 48,
           "value_lb_ft3": 3,
           "source": "epd"
@@ -37435,7 +37612,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 635,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37492,8 +37669,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.62,
-          "value_lb_ft3": 0.1,
+          "value": 1.62,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -37633,7 +37810,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 707,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37691,8 +37868,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.15,
-          "value_lb_ft3": 0.07,
+          "value": 1.15,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -37830,7 +38007,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 708,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -37888,8 +38065,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1.48,
-          "value_lb_ft3": 0.09,
+          "value": 1.48,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -38027,7 +38204,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 709,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38084,6 +38261,8 @@
       },
       "physical": {
         "density": {
+          "value": 181,
+          "units": "kg/m3",
           "value_kg_m3": 181,
           "value_lb_ft3": 11.3,
           "source": "epd"
@@ -38214,7 +38393,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 712,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38265,6 +38444,8 @@
       },
       "physical": {
         "density": {
+          "value": 1430,
+          "units": "kg/m3",
           "value_kg_m3": 1430,
           "value_lb_ft3": 89.27,
           "source": "epd"
@@ -38396,7 +38577,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 714,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38454,8 +38635,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 32.6,
-          "value_lb_ft3": 2.04,
+          "value": 32.6,
+          "units": "kg/m2",
           "source": "epd"
         },
         "thermal": {
@@ -38598,7 +38779,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 716,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38766,7 +38947,7 @@
         "markets_of_applicability": [],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 717,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -38824,8 +39005,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.625,
-          "value_lb_ft3": 0.04,
+          "value": 0.625,
+          "units": "kg/m li.",
           "source": "epd"
         },
         "dimensions": {
@@ -38867,7 +39048,6 @@
           "storage_retention_pct": 0.9,
           "stored_kgco2e_per_common_unit": 40.16,
           "full_carbon_kgco2e_per_common_unit": 44.62,
-          "carbon_content_kgc_per_unit": 64.65,
           "co2_to_c_molar_ratio": 3.67,
           "method": "wwf_storage_factor",
           "notes": "full_C = density × thickness × biogenic_factor × carbon_content × 3.67; stored = full_C × storage_retention"
@@ -38981,7 +39161,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 806,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -39037,6 +39217,8 @@
       },
       "physical": {
         "density": {
+          "value": 18.1,
+          "units": "kg/m3",
           "value_kg_m3": 18.1,
           "value_lb_ft3": 1.13,
           "source": "epd"
@@ -39188,7 +39370,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 811,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -39357,7 +39539,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 812,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -39413,6 +39595,8 @@
       },
       "physical": {
         "density": {
+          "value": 24.98,
+          "units": "kg/m3",
           "value_kg_m3": 24.98,
           "value_lb_ft3": 1.56,
           "source": "epd"
@@ -39564,7 +39748,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 813,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -39621,6 +39805,8 @@
       },
       "physical": {
         "density": {
+          "value": 21,
+          "units": "kg/m3",
           "value_kg_m3": 21,
           "value_lb_ft3": 1.31,
           "source": "epd"
@@ -39765,7 +39951,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 814,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -39822,6 +40008,8 @@
       },
       "physical": {
         "density": {
+          "value": 18,
+          "units": "kg/m3",
           "value_kg_m3": 18,
           "value_lb_ft3": 1.12,
           "source": "epd"
@@ -39966,7 +40154,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 815,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -40023,6 +40211,8 @@
       },
       "physical": {
         "density": {
+          "value": 18,
+          "units": "kg/m3",
           "value_kg_m3": 18,
           "value_lb_ft3": 1.12,
           "source": "epd"
@@ -40168,7 +40358,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 816,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -40225,6 +40415,8 @@
       },
       "physical": {
         "density": {
+          "value": 31,
+          "units": "kg/m3",
           "value_kg_m3": 31,
           "value_lb_ft3": 1.94,
           "source": "epd"
@@ -40369,7 +40561,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 817,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -40429,6 +40621,8 @@
       },
       "physical": {
         "density": {
+          "value": 24.8,
+          "units": "kg/m3",
           "value_kg_m3": 24.8,
           "value_lb_ft3": 1.55,
           "source": "epd"
@@ -40561,7 +40755,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 818,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -40745,7 +40939,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 819,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -40929,7 +41123,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 820,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -41104,7 +41298,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 821,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -41163,6 +41357,8 @@
       },
       "physical": {
         "density": {
+          "value": 24.8,
+          "units": "kg/m3",
           "value_kg_m3": 24.8,
           "value_lb_ft3": 1.55,
           "source": "epd"
@@ -41304,7 +41500,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 822,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -41488,7 +41684,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 823,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -41548,6 +41744,8 @@
       },
       "physical": {
         "density": {
+          "value": 32.8,
+          "units": "kg/m3",
           "value_kg_m3": 32.8,
           "value_lb_ft3": 2.05,
           "source": "epd"
@@ -41698,7 +41896,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 824,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -41757,6 +41955,8 @@
       },
       "physical": {
         "density": {
+          "value": 25.63,
+          "units": "kg/m3",
           "value_kg_m3": 25.63,
           "value_lb_ft3": 1.6,
           "source": "epd"
@@ -41901,7 +42101,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 825,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -41960,6 +42160,8 @@
       },
       "physical": {
         "density": {
+          "value": 24.8,
+          "units": "kg/m3",
           "value_kg_m3": 24.8,
           "value_lb_ft3": 1.55,
           "source": "epd"
@@ -42101,7 +42303,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 826,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/materials/08-openings.json
+++ b/schema/materials/08-openings.json
@@ -153,7 +153,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 720,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -312,7 +312,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 721,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -506,7 +506,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 724,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -692,7 +692,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 725,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -883,7 +883,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 726,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1074,7 +1074,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 727,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1264,7 +1264,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 728,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1456,7 +1456,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 729,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1648,7 +1648,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 730,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1839,7 +1839,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 731,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2031,7 +2031,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 732,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2222,7 +2222,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 733,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2413,7 +2413,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 734,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2603,7 +2603,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 735,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2762,7 +2762,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 736,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2921,7 +2921,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 737,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/materials/09-finishes.json
+++ b/schema/materials/09-finishes.json
@@ -154,7 +154,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 3,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -343,7 +343,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 4,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -532,7 +532,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 5,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -721,7 +721,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 6,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -910,7 +910,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 7,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1099,7 +1099,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 8,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1288,7 +1288,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 9,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1345,8 +1345,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.058,
-          "value_lb_ft3": 0,
+          "value": 0.058,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -1482,7 +1482,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 31,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1534,8 +1534,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.8,
-          "value_lb_ft3": 0.17,
+          "value": 2.8,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -1663,7 +1663,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 107,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1722,8 +1722,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.28,
-          "value_lb_ft3": 0.14,
+          "value": 2.28,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -1863,7 +1863,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 108,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -1916,8 +1916,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3.16,
-          "value_lb_ft3": 0.2,
+          "value": 3.16,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -2056,7 +2056,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 109,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2109,8 +2109,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.38,
-          "value_lb_ft3": 0.15,
+          "value": 2.38,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -2249,7 +2249,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 110,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2306,8 +2306,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.71,
-          "value_lb_ft3": 0.17,
+          "value": 2.71,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -2446,7 +2446,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 111,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2503,8 +2503,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.71,
-          "value_lb_ft3": 0.17,
+          "value": 2.71,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -2641,7 +2641,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 112,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2698,8 +2698,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3.765,
-          "value_lb_ft3": 0.24,
+          "value": 3.765,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -2839,7 +2839,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 113,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -2897,8 +2897,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4.44,
-          "value_lb_ft3": 0.28,
+          "value": 4.44,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -3038,7 +3038,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 115,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3095,8 +3095,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3.77,
-          "value_lb_ft3": 0.24,
+          "value": 3.77,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -3236,7 +3236,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 116,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3288,8 +3288,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 24.41,
-          "value_lb_ft3": 1.52,
+          "value": 24.41,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -3414,7 +3414,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 131,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3474,8 +3474,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 18.8,
-          "value_lb_ft3": 1.17,
+          "value": 18.8,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -3617,7 +3617,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 132,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3676,8 +3676,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 20.105,
-          "value_lb_ft3": 1.26,
+          "value": 20.105,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -3817,7 +3817,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 133,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -3877,8 +3877,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.58,
-          "value_lb_ft3": 1.1,
+          "value": 17.58,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -4018,7 +4018,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 134,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4078,8 +4078,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 14.75,
-          "value_lb_ft3": 0.92,
+          "value": 14.75,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -4210,7 +4210,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 144,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4268,8 +4268,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.79,
-          "value_lb_ft3": 0.55,
+          "value": 8.79,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -4416,7 +4416,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 146,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4474,8 +4474,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.79,
-          "value_lb_ft3": 0.55,
+          "value": 8.79,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -4623,7 +4623,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 147,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4675,8 +4675,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.4,
-          "value_lb_ft3": 0.52,
+          "value": 8.4,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -4813,7 +4813,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 321,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -4865,8 +4865,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2,
-          "value_lb_ft3": 0.12,
+          "value": 2,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -5001,7 +5001,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 322,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5057,6 +5057,8 @@
       },
       "physical": {
         "density": {
+          "value": 483.4,
+          "units": "kg/m3",
           "value_kg_m3": 483.4,
           "value_lb_ft3": 30.18,
           "source": "epd"
@@ -5200,7 +5202,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 333,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5357,7 +5359,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 336,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5410,8 +5412,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7.3,
-          "value_lb_ft3": 0.46,
+          "value": 7.3,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -5536,7 +5538,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 337,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5588,8 +5590,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.3,
-          "value_lb_ft3": 0.64,
+          "value": 10.3,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -5714,7 +5716,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 338,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5773,8 +5775,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 859,
-          "value_lb_ft3": 53.63,
+          "value": 859,
+          "units": "kg/92.9m2",
           "source": "epd"
         },
         "mass_per_unit_kg": 859,
@@ -5920,7 +5922,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 339,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -5979,8 +5981,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 6.7,
-          "value_lb_ft3": 0.42,
+          "value": 6.7,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -6120,7 +6122,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 340,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6179,8 +6181,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 6.5,
-          "value_lb_ft3": 0.41,
+          "value": 6.5,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -6320,7 +6322,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 341,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6375,8 +6377,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 774,
-          "value_lb_ft3": 48.32,
+          "value": 774,
+          "units": "kg/92.9m2",
           "source": "epd"
         },
         "dimensions": {
@@ -6520,7 +6522,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 342,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6573,8 +6575,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.128,
-          "value_lb_ft3": 0.51,
+          "value": 8.128,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -6699,7 +6701,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 343,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6752,8 +6754,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.67,
-          "value_lb_ft3": 0.67,
+          "value": 10.67,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -6879,7 +6881,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 344,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -6932,8 +6934,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.67,
-          "value_lb_ft3": 0.67,
+          "value": 10.67,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -7058,7 +7060,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 345,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7250,7 +7252,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 346,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7310,8 +7312,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1195,
-          "value_lb_ft3": 74.6,
+          "value": 1195,
+          "units": "kg/92.9m2",
           "source": "epd"
         },
         "mass_per_unit_kg": 1195,
@@ -7457,7 +7459,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 347,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7517,8 +7519,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.8,
-          "value_lb_ft3": 0.55,
+          "value": 8.8,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -7657,7 +7659,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 348,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -7835,7 +7837,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 407,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8014,7 +8016,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 408,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8191,7 +8193,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 409,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8368,7 +8370,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 410,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8547,7 +8549,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 411,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8606,8 +8608,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 1165,
-          "value_lb_ft3": 72.73,
+          "value": 1165,
+          "units": "kg/92.9m2",
           "source": "epd"
         },
         "dimensions": {
@@ -8744,7 +8746,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 412,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -8804,8 +8806,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.96,
-          "value_lb_ft3": 0.62,
+          "value": 9.96,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -8944,7 +8946,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 413,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9004,8 +9006,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 12.68,
-          "value_lb_ft3": 0.79,
+          "value": 12.68,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -9144,7 +9146,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 414,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9202,8 +9204,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 9.2,
-          "value_lb_ft3": 0.57,
+          "value": 9.2,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -9340,7 +9342,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 448,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9399,8 +9401,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.9,
-          "value_lb_ft3": 0.37,
+          "value": 5.9,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -9537,7 +9539,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 449,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9594,8 +9596,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 8.09,
-          "value_lb_ft3": 0.51,
+          "value": 8.09,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -9724,7 +9726,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 450,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9783,8 +9785,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.81,
-          "value_lb_ft3": 0.05,
+          "value": 0.81,
+          "units": "g/cm2",
           "source": "epd"
         }
       },
@@ -9923,7 +9925,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 451,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -9982,8 +9984,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 10.3,
-          "value_lb_ft3": 0.64,
+          "value": 10.3,
+          "units": "kg/m2",
           "source": "epd"
         },
         "mass_per_unit_kg": 10.1,
@@ -10124,7 +10126,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 452,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10181,8 +10183,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.44,
-          "value_lb_ft3": 0.34,
+          "value": 5.44,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -10311,7 +10313,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 453,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10368,8 +10370,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.45,
-          "value_lb_ft3": 0.34,
+          "value": 5.45,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -10498,7 +10500,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 454,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10558,8 +10560,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.00576,
-          "value_lb_ft3": 0,
+          "value": 0.00576,
+          "units": "g/mm2",
           "source": "epd"
         },
         "mass_per_unit_kg": 5.76
@@ -10698,7 +10700,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 455,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10757,8 +10759,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 4363,
-          "value_lb_ft3": 272.38,
+          "value": 4363,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -10897,7 +10899,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 456,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -10955,8 +10957,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 6.71,
-          "value_lb_ft3": 0.42,
+          "value": 6.71,
+          "units": "kg/m2",
           "source": "epd"
         },
         "mass_per_unit_kg": 6.54,
@@ -11099,7 +11101,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 457,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11157,8 +11159,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.79,
-          "value_lb_ft3": 0.17,
+          "value": 2.79,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -11297,7 +11299,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 458,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11356,8 +11358,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7094.7,
-          "value_lb_ft3": 442.92,
+          "value": 7094.7,
+          "units": "g/m2",
           "source": "epd"
         }
       },
@@ -11497,7 +11499,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 459,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11555,8 +11557,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5103,
-          "value_lb_ft3": 318.58,
+          "value": 5103,
+          "units": "g/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -11693,7 +11695,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 460,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11753,8 +11755,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.1,
-          "value_lb_ft3": 0.13,
+          "value": 2.1,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -11891,7 +11893,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 461,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -11949,6 +11951,8 @@
       },
       "physical": {
         "density": {
+          "value": 1600,
+          "units": "kg/m3",
           "value_kg_m3": 1600,
           "value_lb_ft3": 99.89,
           "source": "epd"
@@ -12088,7 +12092,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 475,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12250,7 +12254,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 488,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12308,8 +12312,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3,
-          "value_lb_ft3": 0.19,
+          "value": 3,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -12447,7 +12451,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 489,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12504,8 +12508,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.94,
-          "value_lb_ft3": 0.18,
+          "value": 2.94,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -12649,7 +12653,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 490,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12708,8 +12712,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3.18,
-          "value_lb_ft3": 0.2,
+          "value": 3.18,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -12854,7 +12858,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 491,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -12911,8 +12915,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.4,
-          "value_lb_ft3": 0.15,
+          "value": 2.4,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -13052,7 +13056,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 492,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13214,7 +13218,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 493,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13272,8 +13276,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 3.5,
-          "value_lb_ft3": 0.22,
+          "value": 3.5,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -13417,7 +13421,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 494,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13476,6 +13480,8 @@
       },
       "physical": {
         "density": {
+          "value": 3.66,
+          "units": "kg/m3",
           "value_kg_m3": 3.66,
           "value_lb_ft3": 0.23,
           "source": "epd"
@@ -13622,7 +13628,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 495,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13681,6 +13687,8 @@
       },
       "physical": {
         "density": {
+          "value": 4.88,
+          "units": "kg/m3",
           "value_kg_m3": 4.88,
           "value_lb_ft3": 0.3,
           "source": "epd"
@@ -13827,7 +13835,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 496,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -13886,8 +13894,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 0.9,
-          "value_lb_ft3": 0.06,
+          "value": 0.9,
+          "units": "kg/dm3",
           "source": "epd"
         },
         "dimensions": {
@@ -14037,7 +14045,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 497,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14201,7 +14209,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 509,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14261,6 +14269,8 @@
       },
       "physical": {
         "density": {
+          "value": 1000,
+          "units": "kg/m3",
           "value_kg_m3": 1000,
           "value_lb_ft3": 62.43,
           "source": "epd"
@@ -14387,7 +14397,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 510,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14446,6 +14456,8 @@
       },
       "physical": {
         "density": {
+          "value": 1000,
+          "units": "kg/m3",
           "value_kg_m3": 1000,
           "value_lb_ft3": 62.43,
           "source": "epd"
@@ -14587,7 +14599,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 511,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14638,8 +14650,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 7.476,
-          "value_lb_ft3": 0.47,
+          "value": 7.476,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -14767,7 +14779,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 609,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -14818,8 +14830,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.6,
-          "value_lb_ft3": 0.35,
+          "value": 5.6,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -14948,7 +14960,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 610,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15005,8 +15017,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 94.7,
-          "value_lb_ft3": 5.91,
+          "value": 94.7,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -15145,7 +15157,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 617,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15202,8 +15214,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 102.3,
-          "value_lb_ft3": 6.39,
+          "value": 102.3,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -15342,7 +15354,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 618,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15399,8 +15411,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 127.3,
-          "value_lb_ft3": 7.95,
+          "value": 127.3,
+          "units": "kg/m2",
           "source": "epd"
         }
       },
@@ -15539,7 +15551,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 619,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15591,8 +15603,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 6.5,
-          "value_lb_ft3": 0.41,
+          "value": 6.5,
+          "units": "kg/m2",
           "source": "epd"
         },
         "dimensions": {
@@ -15721,7 +15733,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 713,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -15780,8 +15792,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 2.53,
-          "value_lb_ft3": 0.16,
+          "value": 2.53,
+          "units": "kg/m2",
           "source": "epd"
         },
         "thermal": {
@@ -15925,7 +15937,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 715,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/materials/31-earthwork.json
+++ b/schema/materials/31-earthwork.json
@@ -51,6 +51,8 @@
       },
       "physical": {
         "density": {
+          "value": 1682,
+          "units": "kg/m3",
           "value_kg_m3": 1682,
           "value_lb_ft3": 105.01,
           "source": "epd"
@@ -181,7 +183,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 13,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -237,8 +239,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 11.93,
-          "value_lb_ft3": 0.74,
+          "value": 11.93,
+          "units": "kg/1600 mm",
           "source": "epd"
         }
       },
@@ -379,7 +381,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 425,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -435,8 +437,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 17.81,
-          "value_lb_ft3": 1.11,
+          "value": 17.81,
+          "units": "kg/1600 mm",
           "source": "epd"
         }
       },
@@ -577,7 +579,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 426,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -633,8 +635,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.5,
-          "value_lb_ft3": 0.34,
+          "value": 5.5,
+          "units": "kg/m",
           "source": "epd"
         }
       },
@@ -772,7 +774,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 427,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }
@@ -828,8 +830,8 @@
       },
       "physical": {
         "density": {
-          "value_kg_m3": 5.5,
-          "value_lb_ft3": 0.34,
+          "value": 5.5,
+          "units": "kg/m",
           "source": "epd"
         }
       },
@@ -967,7 +969,7 @@
         ],
         "import_metadata": {
           "imported_from": "BEAM Database-DUMP.csv",
-          "import_date": "2026-04-20",
+          "import_date": "2026-05-19",
           "beam_csv_row_index": 428,
           "beam_csv_sha256": "dfa1b965aeec4f004eeeecfae8121abc1c635de52d773a3f028d1c997b16ce6f"
         }

--- a/schema/scripts/beam-csv-to-json.mjs
+++ b/schema/scripts/beam-csv-to-json.mjs
@@ -334,6 +334,27 @@ function buildRecord({ row, rowIndex, lookups, warnings, csvSha256 }) {
   const wwfFactorEval = wwfFactorRaw.startsWith("=") ? evalArithmeticFormula(wwfFactorRaw, row) : (wwfFactorRaw ? Number(wwfFactorRaw) : null);
   const wwfStorageFactor = wwfFactorEval !== null && Number.isFinite(wwfFactorEval) ? Math.round(wwfFactorEval * 100) / 100 : null;
   const density = readNum(row, "AG");
+  // 2026-05-19: read the Density Units column (AH) alongside the value. The
+  // BEAM source CSV stores density correctly with units like "kg/m3", "kg/m2",
+  // "kg/m", "g/cm3", "g/m2" — the prior importer dropped this column and
+  // stamped every value as kg/m³, corrupting ~170 of 673 density-bearing
+  // records (per the parity-matcher audit). The fix preserves both the raw
+  // value and its source unit; only known-convertible units populate the
+  // derived `value_kg_m3` slot, leaving null for the rest so downstream
+  // consumers can't misread per-area or per-linear values as volumetric.
+  const densityUnits = readStr(row, "AH") || null;
+  // Convert to volumetric kg/m³ where the source unit is unambiguous.
+  // Anything else returns null — preserving the raw value but refusing to
+  // pretend it's a volumetric density.
+  function _densityToKgM3(value, units) {
+    if (value === null || value === undefined) return null;
+    if (!units) return value; // legacy fallback: no units string means trust as kg/m³
+    const u = String(units).toLowerCase().trim();
+    if (u === "kg/m3" || u === "kg/m^3" || u === "kg/m³") return value;
+    if (u === "g/cm3" || u === "g/cm^3" || u === "g/cm³") return Math.round(value * 1000 * 100) / 100;
+    return null; // kg/m2, g/m2, kg/m (linear), kg/m2 at RSI 1, etc. — not directly convertible without geometry
+  }
+  const densityKgM3 = _densityToKgM3(density, densityUnits);
   const addnFactor = readNum(row, "AI");
   const biogenicFactor = readNum(row, "X");
   const carbonContent = readNum(row, "Y");
@@ -342,10 +363,13 @@ function buildRecord({ row, rowIndex, lookups, warnings, csvSha256 }) {
   if (biogenicFull === null && biogenicStored !== null && storageRetention !== null && storageRetention > 0) {
     biogenicFull = Math.round((biogenicStored / storageRetention) * 100) / 100;
   }
-  // carbon_content_kgc_per_unit = density × thickness × biogenicFactor × carbonContent (no CO2/C ratio)
+  // carbon_content_kgc_per_unit = density × thickness × biogenicFactor × carbonContent
+  // CRITICAL: this calc only makes sense when density is genuinely in kg/m³.
+  // Gate on densityKgM3 (not raw density) so per-area or per-linear values
+  // don't corrupt the biogenic carbon-content computation.
   let carbonContentKgcPerUnit = null;
-  if (density !== null && addnFactor !== null && biogenicFactor !== null && carbonContent !== null) {
-    carbonContentKgcPerUnit = Math.round(density * addnFactor * biogenicFactor * carbonContent * 100) / 100;
+  if (densityKgM3 !== null && addnFactor !== null && biogenicFactor !== null && carbonContent !== null) {
+    carbonContentKgcPerUnit = Math.round(densityKgM3 * addnFactor * biogenicFactor * carbonContent * 100) / 100;
   }
   const biogenicMethod = (biogenicFactor !== null && carbonContent !== null) ? "wwf_storage_factor" : "none";
 
@@ -435,8 +459,20 @@ function buildRecord({ row, rowIndex, lookups, warnings, csvSha256 }) {
 
     "physical": {
       "density": {
-        "value_kg_m3": density,
-        "value_lb_ft3": density !== null ? Math.round(density * 0.06243 * 100) / 100 : null,
+        // Raw value + units from the BEAM source spreadsheet — verbatim,
+        // no conversion. Units string preserves the source intent so that
+        // BEAMweb / CCLIMB assembly math can interpret per-area, per-linear,
+        // or per-volume values appropriately at consumption time.
+        "value": density,
+        "units": densityUnits,
+        // Derived volumetric kg/m³ — populated only when the source unit
+        // is unambiguous (kg/m3 or g/cm3). For per-area (kg/m2), per-linear
+        // (kg/m), and other formats, value_kg_m3 is null and consumers must
+        // use {value, units} with their own geometry to derive volumetric
+        // density. This prevents per-area grammage from being silently
+        // misread as volumetric density (the 2026-05-19 import bug).
+        "value_kg_m3": densityKgM3,
+        "value_lb_ft3": densityKgM3 !== null ? Math.round(densityKgM3 * 0.06243 * 100) / 100 : null,
         "source": density !== null ? "epd" : null
       },
       "thermal": {

--- a/schema/scripts/test-epd-extract.mjs
+++ b/schema/scripts/test-epd-extract.mjs
@@ -32,6 +32,7 @@ const SAMPLES_ROOT = join(REPO_ROOT, "docs", "PDF References", "EPD SAMPLES");
 const EXPECTED_ROOT = join(SAMPLES_ROOT, "expected");
 const EXTRACT_MJS = join(REPO_ROOT, "js", "epd", "extract.mjs");
 const LOOKUPS_DIR = join(REPO_ROOT, "schema", "lookups");
+const MATERIALS_DIR = join(REPO_ROOT, "schema", "materials");
 const COVERAGE_HISTORY_DIR = join(REPO_ROOT, "docs", "workplans", "EPD-coverage-history");
 
 // Numeric tolerance for ground-truth extraction-fidelity check
@@ -71,6 +72,195 @@ const IMPACT_KEYS = [
   "primary_energy_nonrenewable_mj",
   "primary_energy_renewable_mj"
 ];
+
+/* ── Catalogue parity check ─────────────────────────────────────────── */
+//
+// Match each extracted candidate against the 821 records in
+// schema/materials/*.json and report:
+//   - Match category (strong / multi / medium / weak / unmatched)
+//   - Field-by-field diff on safely-comparable fields
+//
+// Why some fields are unsafe to diff today: the catalogue's
+// `impacts.<key>.total.value` is BEAM-normalized (per-common-unit,
+// `source: "beam_derived"`), while the parser writes per-declared-unit
+// values into the same path with `source: "epd_direct"`. Direct
+// comparison would produce false-positive divergences. Once Tier-10
+// (C-fb6) normalizes parser output via methodology.beam_calc, the
+// impact comparisons can be added.
+//
+// Today's safe fields: density (unit-independent), manufacturer,
+// display_name (string proximity), classification (group + material
+// type), epd.id (substring match for heterogeneous formats).
+
+const STOP_TOKENS = new Set([
+  "the", "and", "for", "with", "epd", "epd's", "product", "products",
+  "declaration", "environmental", "to", "of", "in", "on", "by", "an", "a",
+  "is", "are", "as", "or", "from", "no"
+]);
+
+function _normalize(s) {
+  return String(s == null ? "" : s).toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function _tokens(s) {
+  return _normalize(s)
+    .split(/\s+/)
+    .filter((t) => t.length > 2 && !STOP_TOKENS.has(t));
+}
+
+async function loadCatalogue() {
+  const out = [];
+  const files = await readdir(MATERIALS_DIR);
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    if (f === "index.json" || f === "import-report.json") continue;
+    const raw = await readFile(join(MATERIALS_DIR, f), "utf8");
+    const data = JSON.parse(raw);
+    const records = data.records || data;
+    for (const r of records) out.push(r);
+  }
+  return out;
+}
+
+// Score-based ranker. The thresholds (80 / 50 / 30) are empirical —
+// tunable from the snapshot's distribution.
+function matchCandidate(candidate, catalogue) {
+  const cd = {
+    displayTokens: _tokens(candidate.naming && candidate.naming.display_name),
+    group: candidate.classification && candidate.classification.group_prefix,
+    material: _normalize(candidate.classification && candidate.classification.material_type),
+    manufacturer: _normalize(candidate.manufacturer && candidate.manufacturer.name),
+    epdId: _normalize(candidate.epd && candidate.epd.id)
+  };
+
+  const ranked = [];
+  for (const rec of catalogue) {
+    const rd = {
+      displayTokens: _tokens(rec.naming && rec.naming.display_name),
+      group: rec.classification && rec.classification.group_prefix,
+      material: _normalize(rec.classification && rec.classification.material_type),
+      manufacturer: _normalize(rec.manufacturer && rec.manufacturer.name),
+      epdId: _normalize(rec.epd && rec.epd.id),
+      isIndustryAvg: rec.status && rec.status.is_industry_average === true
+    };
+
+    let score = 0;
+    const reasons = [];
+
+    // STRONG signals — manufacturer + epd.id substring overlap.
+    // epd.id requires 5+ chars on both sides so we don't false-match
+    // single-digit citation snippets like "2011".
+    if (cd.epdId && rd.epdId && cd.epdId.length > 5 && rd.epdId.length > 5) {
+      if (rd.epdId.includes(cd.epdId) || cd.epdId.includes(rd.epdId)) {
+        score += 80;
+        reasons.push("epd.id");
+      }
+    }
+    if (cd.manufacturer && rd.manufacturer && cd.manufacturer.length > 3) {
+      if (rd.manufacturer.includes(cd.manufacturer) || cd.manufacturer.includes(rd.manufacturer)) {
+        score += 40;
+        reasons.push("mfr");
+      }
+    }
+
+    // MEDIUM — display_name token overlap (Jaccard-ish, asymmetric).
+    if (cd.displayTokens.length && rd.displayTokens.length) {
+      let shared = 0;
+      for (const t of cd.displayTokens) if (rd.displayTokens.includes(t)) shared++;
+      const overlap = shared / cd.displayTokens.length;
+      if (overlap >= 0.5) {
+        score += Math.round(40 * overlap);
+        reasons.push(`disp(${shared}/${cd.displayTokens.length})`);
+      }
+    }
+
+    // WEAK — classification anchors. Same-group bonus, cross-group small penalty.
+    if (cd.group && cd.group === rd.group) {
+      score += 10;
+      reasons.push("group");
+    } else if (cd.group && rd.group && cd.group !== rd.group) {
+      score -= 5;
+    }
+    if (cd.material && cd.material === rd.material) {
+      score += 10;
+      reasons.push("mat");
+    }
+
+    if (score > 0) {
+      ranked.push({
+        id: rec.id,
+        score,
+        reasons,
+        isIndustryAvg: rd.isIndustryAvg,
+        displayName: (rec.naming && rec.naming.display_name) || "—"
+      });
+    }
+  }
+
+  ranked.sort((a, b) => b.score - a.score);
+  return ranked;
+}
+
+function classifyMatch(ranked) {
+  if (ranked.length === 0) return { category: "unmatched", topScore: 0, matches: [] };
+  const top = ranked[0];
+  // 1:N detection — cluster matches within 10 points of the top score.
+  // Same EPD producing multiple catalogue rows (e.g. bamboo plywood
+  // 1/2" + 3/4" both reference the same SmartEPD id) lands here.
+  const cluster = ranked.filter((m) => m.score >= top.score - 10);
+  if (top.score >= 80) {
+    return { category: cluster.length > 1 ? "strong-multi" : "strong", topScore: top.score, matches: cluster };
+  }
+  if (top.score >= 50) {
+    return { category: cluster.length > 1 ? "medium-multi" : "medium", topScore: top.score, matches: cluster };
+  }
+  if (top.score >= 30) {
+    return { category: "weak", topScore: top.score, matches: [top] };
+  }
+  return { category: "unmatched", topScore: top.score, matches: [] };
+}
+
+// Field-by-field diff between a candidate and ONE catalogue record.
+// Returns an array of { path, status: "match"|"differ"|"one-null"|"both-null", candidate, catalogue }.
+function fieldDiff(candidate, rec) {
+  const out = [];
+  const compare = (path, comparator) => {
+    const cVal = getPath(candidate, path);
+    const rVal = getPath(rec, path);
+    if (cVal == null && rVal == null) {
+      out.push({ path, status: "both-null", candidate: null, catalogue: null });
+      return;
+    }
+    if (cVal == null || rVal == null) {
+      out.push({ path, status: "one-null", candidate: cVal == null ? null : cVal, catalogue: rVal == null ? null : rVal });
+      return;
+    }
+    out.push({ path, status: comparator(cVal, rVal) ? "match" : "differ", candidate: cVal, catalogue: rVal });
+  };
+
+  const strEq = (a, b) => _normalize(a) === _normalize(b);
+  const strContains = (a, b) => {
+    const na = _normalize(a);
+    const nb = _normalize(b);
+    if (!na || !nb) return false;
+    return na.includes(nb) || nb.includes(na);
+  };
+  const numWithin5pct = (a, b) => {
+    if (typeof a !== "number" || typeof b !== "number") return false;
+    if (b === 0 && a === 0) return true;
+    const denom = Math.max(Math.abs(b), 1e-12);
+    return Math.abs(a - b) / denom <= 0.05;
+  };
+
+  compare("classification.group_prefix", strEq);
+  compare("classification.material_type", strEq);
+  compare("manufacturer.name", strContains);
+  compare("physical.density.value_kg_m3", numWithin5pct);
+  compare("epd.id", strContains);
+  // NOT comparing impacts.* — see header comment.
+
+  return out;
+}
 
 function parseArgs(argv) {
   const args = { json: null, md: null, only: null, root: null };
@@ -401,6 +591,12 @@ async function main() {
   const byStageLabelHits = new Array(Extract._BYSTAGE_LABELS.length).fill(0);
   const ciscHits = new Array(Extract._CISC_LABEL_PATTERNS.length).fill(0);
 
+  // Catalogue parity (§11.10 follow-up — verifies extracted records
+  // against the 821-record schema/materials/ catalogue). Loaded once
+  // per harness run; matcher runs per-sample after extraction.
+  const catalogue = await loadCatalogue();
+  console.log(`Loaded ${catalogue.length} catalogue records for parity check.`);
+
   const results = [];
   for (const pdfPath of pdfs) {
     const rel = relative(REPO_ROOT, pdfPath);
@@ -437,6 +633,23 @@ async function main() {
     const summary = summarizeRecord(result.record);
     const expected = await loadExpected(file);
     const gt = evaluateGroundTruth(result.record, expected);
+
+    // Catalogue parity — match candidate against the 821-record catalogue
+    // and field-diff against the top match (if any). For unmatched
+    // samples, parity = null and the snapshot tags them as candidates
+    // for new entries.
+    const ranked = matchCandidate(result.record, catalogue);
+    const classification = classifyMatch(ranked);
+    const parity =
+      classification.matches.length > 0
+        ? {
+            category: classification.category,
+            topScore: classification.topScore,
+            matches: classification.matches.slice(0, 5),
+            diff: fieldDiff(result.record, catalogue.find((r) => r.id === classification.matches[0].id))
+          }
+        : { category: "unmatched", topScore: classification.topScore, matches: [], diff: [] };
+
     results.push({
       group,
       file,
@@ -452,15 +665,20 @@ async function main() {
       byStagePerIndicator: summary.byStagePerIndicator,
       record: result.record,
       expected,
-      groundTruth: gt
+      groundTruth: gt,
+      parity
     });
     const gtTag = expected
       ? gt.extractionFailures.length === 0 && gt.silentOverrides.length === 0 && gt.defaultsAppliedFailures.length === 0
         ? "  GT=✓"
         : `  GT=✗ ext:${gt.extractionFailures.length} silent:${gt.silentOverrides.length} dflt:${gt.defaultsAppliedFailures.length}`
       : "";
+    const parityTag =
+      parity.category === "unmatched"
+        ? "  cat=—"
+        : `  cat=${parity.category}(${parity.topScore})`;
     console.log(
-      `✓ ${group}/${file.padEnd(60)}  fmt=${result.format.padEnd(20)}  meta=${fmtPct(summary.metaHit, summary.metaTotal)}  impacts=${fmtPct(summary.impactHit, summary.impactTotal)}  by_stage=${fmtPct(summary.byStageHit, summary.byStageTotal)}  pages=${extracted.pageCount}${gtTag}`
+      `✓ ${group}/${file.padEnd(60)}  fmt=${result.format.padEnd(20)}  meta=${fmtPct(summary.metaHit, summary.metaTotal)}  impacts=${fmtPct(summary.impactHit, summary.impactTotal)}  by_stage=${fmtPct(summary.byStageHit, summary.byStageTotal)}  pages=${extracted.pageCount}${gtTag}${parityTag}`
     );
   }
 
@@ -586,6 +804,53 @@ async function main() {
     (e) => e.rx,
     (e) => e.key
   );
+
+  // ── Catalogue parity (§11.10 follow-up) ──────────────
+  // Distribution of match category + field-diff aggregate. Unmatched
+  // samples are candidates for new catalogue entries; matched ones
+  // give us extraction-fidelity signal against authoritative values
+  // (limited to safely-comparable fields today — impact values still
+  // pending Tier-10 unit normalization).
+  const parityCounts = {};
+  const parityFieldStats = {};
+  const PARITY_FIELDS = [
+    "classification.group_prefix",
+    "classification.material_type",
+    "manufacturer.name",
+    "physical.density.value_kg_m3",
+    "epd.id"
+  ];
+  for (const p of PARITY_FIELDS) parityFieldStats[p] = { match: 0, differ: 0, oneNull: 0, bothNull: 0 };
+  for (const r of ok) {
+    const cat = r.parity.category;
+    parityCounts[cat] = (parityCounts[cat] || 0) + 1;
+    if (r.parity.category !== "unmatched") {
+      for (const d of r.parity.diff) {
+        const stat = parityFieldStats[d.path];
+        if (!stat) continue;
+        if (d.status === "match") stat.match++;
+        else if (d.status === "differ") stat.differ++;
+        else if (d.status === "one-null") stat.oneNull++;
+        else if (d.status === "both-null") stat.bothNull++;
+      }
+    }
+  }
+  console.log("");
+  console.log(`Catalogue parity check (${ok.length} candidates × ${catalogue.length} catalogue records):`);
+  const CAT_ORDER = ["strong", "strong-multi", "medium", "medium-multi", "weak", "unmatched"];
+  for (const cat of CAT_ORDER) {
+    const n = parityCounts[cat] || 0;
+    const pct = ok.length ? ((100 * n) / ok.length).toFixed(0) : "0";
+    console.log(`  ${cat.padEnd(14)} ${String(n).padStart(4)}/${ok.length}  (${pct}%)`);
+  }
+  console.log("");
+  console.log(`Field-diff on matched samples (excluding unmatched):`);
+  for (const p of PARITY_FIELDS) {
+    const s = parityFieldStats[p];
+    const totalNonNull = s.match + s.differ + s.oneNull;
+    const matchPct = totalNonNull ? ((100 * s.match) / totalNonNull).toFixed(0) : "—";
+    console.log(`  ${p.padEnd(50)} match=${s.match}  differ=${s.differ}  one-null=${s.oneNull}  both-null=${s.bothNull}  (${matchPct}%)`);
+  }
 
   // ── Ground-truth aggregate (workplan §10.3) ─────────
   const annotated = ok.filter((r) => r.expected);
@@ -713,6 +978,70 @@ async function main() {
       (e) => e.rx,
       (e) => (e.key ? `\`${e.key}\`` : null)
     );
+
+    // Catalogue parity (§11.10 follow-up) — aggregate distribution
+    // + per-field diff + per-sample top-match listing. Sample listing
+    // helps Andy/Mélanie spot-check that the matcher is making sensible
+    // assignments before we trust the divergence signal at scale.
+    lines.push("");
+    lines.push("## Catalogue parity check");
+    lines.push("");
+    lines.push(`${ok.length} candidates × ${catalogue.length} catalogue records.`);
+    lines.push("");
+    lines.push("| Category | Count | % |");
+    lines.push("|---|---:|---:|");
+    for (const cat of CAT_ORDER) {
+      const n = parityCounts[cat] || 0;
+      const pct = ok.length ? ((100 * n) / ok.length).toFixed(0) : "0";
+      lines.push(`| ${cat} | ${n}/${ok.length} | ${pct}% |`);
+    }
+    lines.push("");
+    lines.push("### Field diff on matched samples");
+    lines.push("");
+    lines.push("Impact values (`impacts.*`) deliberately excluded — catalogue stores BEAM-normalized values; parser stores per-declared-unit values. Comparison would false-positive until Tier-10 (C-fb6) normalizes parser output.");
+    lines.push("");
+    lines.push("| Field | Match | Differ | One-null | Both-null | Match% (excl. both-null) |");
+    lines.push("|---|---:|---:|---:|---:|---:|");
+    for (const p of PARITY_FIELDS) {
+      const s = parityFieldStats[p];
+      const totalNonNull = s.match + s.differ + s.oneNull;
+      const matchPct = totalNonNull ? ((100 * s.match) / totalNonNull).toFixed(0) + "%" : "—";
+      lines.push(`| \`${p}\` | ${s.match} | ${s.differ} | ${s.oneNull} | ${s.bothNull} | ${matchPct} |`);
+    }
+    lines.push("");
+    lines.push("### Per-sample top match");
+    lines.push("");
+    lines.push("| Sample | Category | Score | Catalogue id | Catalogue display_name | Reasons |");
+    lines.push("|---|---|---:|---|---|---|");
+    for (const r of results) {
+      if (r.error || !r.parity) continue;
+      const p = r.parity;
+      if (p.category === "unmatched") {
+        lines.push(`| ${r.group}/${r.file} | unmatched | ${p.topScore || 0} | — | — | — |`);
+      } else {
+        const top = p.matches[0];
+        const reasons = top.reasons.join(", ");
+        const multi = p.matches.length > 1 ? ` (+${p.matches.length - 1} more)` : "";
+        const dispEsc = String(top.displayName).replace(/\|/g, "\\|");
+        lines.push(`| ${r.group}/${r.file} | ${p.category} | ${top.score} | \`${top.id}\`${multi} | ${dispEsc} | ${reasons} |`);
+      }
+    }
+    // Per-sample divergence detail — only for samples with at least one "differ".
+    const divergent = results.filter((r) => !r.error && r.parity && r.parity.diff.some((d) => d.status === "differ"));
+    if (divergent.length) {
+      lines.push("");
+      lines.push("### Divergence detail (matched samples with at least one differing field)");
+      lines.push("");
+      for (const r of divergent) {
+        const diffs = r.parity.diff.filter((d) => d.status === "differ");
+        if (!diffs.length) continue;
+        lines.push(`**${r.group}/${r.file}** (top: \`${r.parity.matches[0].id}\` — ${r.parity.matches[0].displayName}):`);
+        for (const d of diffs) {
+          lines.push(`- \`${d.path}\` — candidate \`${JSON.stringify(d.candidate)}\` vs catalogue \`${JSON.stringify(d.catalogue)}\``);
+        }
+        lines.push("");
+      }
+    }
 
     // Ground-truth section appended only when at least one sample is
     // annotated. Empty expected/ dir = no section, no clutter.

--- a/schema/scripts/test-epd-extract.mjs
+++ b/schema/scripts/test-epd-extract.mjs
@@ -309,6 +309,55 @@ function fmtPct(n, d) {
   return `${n}/${d}`;
 }
 
+// Synthesise a short human-readable label from a regex source so the
+// per-pattern audit table is readable. Strips escape backslashes /
+// whitespace tokens, truncates with ellipsis.
+function shortRxLabel(rx, maxLen) {
+  if (!rx || !rx.source) return "?";
+  let s = rx.source
+    .replace(/\\s\+/g, " ")
+    .replace(/\\s\*/g, "")
+    .replace(/\\s/g, " ")
+    .replace(/\\b/g, "")
+    .replace(/\\\./g, ".")
+    .replace(/\(\?:/g, "(")
+    .replace(/\\n|\\r/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (s.length > maxLen) s = s.substring(0, maxLen - 1) + "…";
+  return s;
+}
+
+// Per-pattern hit tally (workplan §12.5 item 1). Mirrors production
+// semantics: IMPACT_INDICATORS are matched against the whole joined
+// text (same as _extractIndicatorTotals); _BYSTAGE_LABELS and
+// _CISC_LABEL_PATTERNS are tested per-line (same as _extractByStage /
+// _findCISCDataRowKey). A pattern with 0 hits across the full sample
+// set is a deprecation candidate.
+function tallyWholeText(allText, patternArr, getRx, hits) {
+  for (let i = 0; i < patternArr.length; i++) {
+    const rx = getRx(patternArr[i]);
+    if (!rx) continue;
+    if (rx.test(allText)) hits[i]++;
+  }
+}
+
+function tallyPerLine(allText, patternArr, getRx, hits) {
+  const lines = allText.split("\n");
+  for (let i = 0; i < patternArr.length; i++) {
+    const rx = getRx(patternArr[i]);
+    if (!rx) continue;
+    let matched = false;
+    for (let l = 0; l < lines.length; l++) {
+      if (rx.test(lines[l])) {
+        matched = true;
+        break;
+      }
+    }
+    if (matched) hits[i]++;
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const pdfjs = await loadPdfjs();
@@ -343,6 +392,15 @@ async function main() {
     console.log(`Using --root ${sampleRoot} (${pdfs.length} PDFs)`);
   }
 
+  // Per-pattern hit-count audit (workplan §12.5 item 1). Counters
+  // sized to each pattern array; bumped once per sample where the
+  // regex fires (mirrors production semantics — see tallyWholeText /
+  // tallyPerLine). Patterns with 0 hits across the full set surface
+  // as deprecation candidates in the snapshot.
+  const impactHits = new Array(Extract.IMPACT_INDICATORS.length).fill(0);
+  const byStageLabelHits = new Array(Extract._BYSTAGE_LABELS.length).fill(0);
+  const ciscHits = new Array(Extract._CISC_LABEL_PATTERNS.length).fill(0);
+
   const results = [];
   for (const pdfPath of pdfs) {
     const rel = relative(REPO_ROOT, pdfPath);
@@ -367,6 +425,14 @@ async function main() {
       console.error(`✗ ${file}  extract failed: ${err.message}`);
       continue;
     }
+
+    // Per-pattern audit: re-join page texts the same way extract()
+    // does (page-pair separator "\n\n") so the regexes see identical
+    // input to production.
+    const allText = (extracted.pageTexts || []).join("\n\n");
+    tallyWholeText(allText, Extract.IMPACT_INDICATORS, (e) => e.regex, impactHits);
+    tallyPerLine(allText, Extract._BYSTAGE_LABELS, (e) => e.rx, byStageLabelHits);
+    tallyPerLine(allText, Extract._CISC_LABEL_PATTERNS, (e) => e.rx, ciscHits);
 
     const summary = summarizeRecord(result.record);
     const expected = await loadExpected(file);
@@ -480,6 +546,47 @@ async function main() {
     console.log(`  ${path.padEnd(50)} ${hits.toString().padStart(3)}/${ok.length}  (${pct}%)`);
   }
 
+  // ── Per-pattern hit count (workplan §12.5 item 1) ───
+  // For each entry in IMPACT_INDICATORS / _BYSTAGE_LABELS /
+  // _CISC_LABEL_PATTERNS, report how many samples the regex fires on.
+  // Patterns with 0 hits are deprecation candidates; patterns with 1
+  // hit are also candidates if the matched sample's coverage is
+  // already strong from another regex. This is the data input to the
+  // §12.3 architecture decision — geometric/declarative/HITL choice
+  // becomes cheaper to evaluate when we can name the dead weight.
+  function printPatternAudit(title, patternArr, hits, getRx, getLabel) {
+    console.log("");
+    console.log(`Per-pattern hit count — ${title} (${patternArr.length} patterns × ${ok.length} samples):`);
+    for (let i = 0; i < patternArr.length; i++) {
+      const hit = hits[i];
+      const pct = ok.length ? ((100 * hit) / ok.length).toFixed(0) : "0";
+      const tag = hit === 0 ? "  DEAD" : "";
+      const label = getLabel(patternArr[i], i) || shortRxLabel(getRx(patternArr[i]), 56);
+      console.log(`  [${String(i).padStart(2, "0")}] ${label.padEnd(58)} hits=${String(hit).padStart(3)}/${ok.length}  (${pct}%)${tag}`);
+    }
+  }
+  printPatternAudit(
+    "IMPACT_INDICATORS",
+    Extract.IMPACT_INDICATORS,
+    impactHits,
+    (e) => e.regex,
+    (e) => (e.schemaKey ? `${e.schemaKey} — ${e.label || ""}`.trim() : null)
+  );
+  printPatternAudit(
+    "_BYSTAGE_LABELS",
+    Extract._BYSTAGE_LABELS,
+    byStageLabelHits,
+    (e) => e.rx,
+    (e) => e.key
+  );
+  printPatternAudit(
+    "_CISC_LABEL_PATTERNS",
+    Extract._CISC_LABEL_PATTERNS,
+    ciscHits,
+    (e) => e.rx,
+    (e) => e.key
+  );
+
   // ── Ground-truth aggregate (workplan §10.3) ─────────
   const annotated = ok.filter((r) => r.expected);
   const totalExtractFailures = annotated.reduce((a, r) => a + r.groundTruth.extractionFailures.length, 0);
@@ -564,6 +671,49 @@ async function main() {
         `| ${r.group}/${r.file} | ${bsCell(bs.gwp_kgco2e)} | ${bsCell(bs.gwp_bio_kgco2e)} | ${bsCell(bs.ozone_depletion_kgcfc11eq)} | ${bsCell(bs.acidification_kgso2eq)} | ${bsCell(bs.eutrophication_kgneq)} | ${bsCell(bs.smog_kgo3eq)} | ${bsCell(bs.abiotic_depletion_fossil_mj)} | ${bsCell(bs.water_consumption_m3)} | ${bsCell(bs.primary_energy_nonrenewable_mj)} | ${bsCell(bs.primary_energy_renewable_mj)} |`
       );
     }
+    // Per-pattern hit count (workplan §12.5 item 1). Identifies dead-
+    // weight regexes that are candidates for deprecation in the §12.3
+    // architecture review. A pattern matching 0 samples earned nothing
+    // for its maintenance cost; 1 sample is also a candidate when the
+    // matched sample's coverage is already strong from another regex.
+    function mdPatternAudit(title, patternArr, hits, getRx, getLabel) {
+      lines.push("");
+      lines.push(`## Per-pattern hit count — ${title}`);
+      lines.push("");
+      lines.push(`${patternArr.length} patterns × ${ok.length} samples. \`DEAD\` = 0 hits, deprecation candidate.`);
+      lines.push("");
+      lines.push("| # | Key / label | Hits | % | Status |");
+      lines.push("|---:|---|---:|---:|---|");
+      for (let i = 0; i < patternArr.length; i++) {
+        const hit = hits[i];
+        const pct = ok.length ? ((100 * hit) / ok.length).toFixed(0) : "0";
+        const tag = hit === 0 ? "DEAD" : hit === 1 ? "thin" : "";
+        const label = getLabel(patternArr[i], i) || shortRxLabel(getRx(patternArr[i]), 56);
+        lines.push(`| ${i} | ${label.replace(/\|/g, "\\|")} | ${hit}/${ok.length} | ${pct}% | ${tag} |`);
+      }
+    }
+    mdPatternAudit(
+      "IMPACT_INDICATORS",
+      Extract.IMPACT_INDICATORS,
+      impactHits,
+      (e) => e.regex,
+      (e) => (e.schemaKey ? `\`${e.schemaKey}\` — ${e.label || ""}`.trim() : null)
+    );
+    mdPatternAudit(
+      "_BYSTAGE_LABELS",
+      Extract._BYSTAGE_LABELS,
+      byStageLabelHits,
+      (e) => e.rx,
+      (e) => (e.key ? `\`${e.key}\`` : null)
+    );
+    mdPatternAudit(
+      "_CISC_LABEL_PATTERNS",
+      Extract._CISC_LABEL_PATTERNS,
+      ciscHits,
+      (e) => e.rx,
+      (e) => (e.key ? `\`${e.key}\`` : null)
+    );
+
     // Ground-truth section appended only when at least one sample is
     // annotated. Empty expected/ dir = no section, no clutter.
     if (annotated.length) {


### PR DESCRIPTION
## Summary

Coherent EPD-Parser branch (20 commits) spanning four workstreams: a catalogue data-quality fix, EPD-extraction field-tuning, the CCLIMB 6th-module scaffold, and parity-validation planning.

**1. Catalogue data-quality — density-units import bug FOUND + FIXED** (`16d4ebd`)
- The BEAM CSV stores density with its unit in a paired column (col 32 value + col 33 unit). The importer (`beam-csv-to-json.mjs`) dropped col 33 and stamped every value as `kg/m³`, corrupting ~180 of 684 density records (per-area `kg/m2` grammage and per-linear `kg/m` values silently stored as volumetric).
- Fix: importer now reads both columns and emits `{value, units, value_kg_m3 (null unless volumetric), value_lb_ft3, source}`. Regenerated all 8 `schema/materials/*.json` group files.
- The source spreadsheet was correct; the bug was BfCA-side at JSON conversion. Catalogue-parity "differ" count dropped 102 → 36. Full CSV units audit (workplan §15.3) confirms density was the **only** affected column.

**2. EPD-extraction field-tuning** (5 passes, all canonical-30 regression-clean)
- Per-pattern hit-count audit + catalogue-parity matcher added to the harness.
- Passes lifted manufacturer + epd.id (+20–41pp recall), dates, epd.type/validation, density, material_type vocab.
- Net metadata aggregate: +3pp canonical-30, +9.7pp v1.1-candidates, +5.7pp Existing-BEAM. Impact + by_stage dimensions untouched (the §12.3 pattern-array pause stayed in force).

**3. CCLIMB — 6th BEAM module scaffold (Phase 0)** (`7a6ef51`)
- `cclimb.html` + `js/cclimb.mjs` + `js/cclimb/*.mjs` stubs + verbatim OBJECTIVE port-reference + landing card + CSS.
- Companion methodology docs in `docs/RMI Work/CCLIMB-Workplan2.md`.

**4. Parity-validation planning** (workplan §16) — Parity A (CSV↔JSON, regex-independent, do-first) vs Parity B (EPD↔catalogue, gated on multi-product extraction, deferred).

## Known follow-ups (documented in the workplan, not blocking this PR)

- **Pass 1+2 metadata patches landed in `extractNA` instead of `extractCommon`** — NSF / EPD-Intl / unknown formats (~26% of samples) skip the date/type/validation lifts. Clean one-commit fix = move 5 blocks up. (Workplan "Known issue".)
- **CCLIMB `chart-config.mjs` still defines `LCA_MODULES` as axes** — the corrected design (`TIME_HORIZONS`) per CCLIMB-Workplan2 §3.2.E lands in a follow-up commit.

## Test plan

- [x] `node schema/scripts/test-epd-extract.mjs` — canonical-30 aggregate up or equal, no individual sample regression (harness contract §7.6)
- [x] Scaling-set audits re-run on v1.1-candidates (116) + Existing-BEAM (208), snapshots committed to `docs/workplans/EPD-coverage-history/`
- [ ] `node schema/scripts/validate.mjs` — re-confirm regenerated `schema/materials/*.json` validate against `material.schema.json`
- [ ] Spot-check a few density records in the Database viewer (kg/m2 / kg/m rows now carry verbatim units, `value_kg_m3` null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
